### PR TITLE
Remove compose strong skipping mode, add printVersionName task to build.gradle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,9 +63,6 @@ android {
         buildConfig = true
     }
 
-    composeCompiler {
-        enableStrongSkippingMode = true
-    }
 
     packaging {
         jniLibs {
@@ -162,4 +159,8 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.junit)
+}
+
+tasks.register("printVersionName") {
+    doLast { println(android.defaultConfig.versionName) }
 }


### PR DESCRIPTION
- Remove composeCompiler { enableStrongSkippingMode = true } (moved to libs.versions.toml or causing issues)\n- Add printVersionName Gradle task for CI/release workflows