### PR TITLE
SHR-38 Implement contact avatar cache from device contacts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
 
     <application
         android:name=".MonoMailApp"

--- a/app/src/main/java/com/shrivatsav/monomail/MainActivity.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/MainActivity.kt
@@ -55,6 +55,10 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private val requestContactsPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _: Boolean -> }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -86,6 +90,15 @@ class MainActivity : ComponentActivity() {
             }
         }
         requestNotificationPermissionAndScheduleSync()
+        requestContactsPermission()
+    }
+
+    private fun requestContactsPermission() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CONTACTS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestContactsPermissionLauncher.launch(Manifest.permission.READ_CONTACTS)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/shrivatsav/monomail/data/repository/ContactPhotoProvider.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/repository/ContactPhotoProvider.kt
@@ -1,0 +1,66 @@
+package com.shrivatsav.monomail.data.repository
+
+import android.Manifest
+import android.content.ContentUris
+import android.content.Context
+import android.content.pm.PackageManager
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.provider.ContactsContract
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ContactPhotoProvider @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+    private val cache = mutableMapOf<String, Uri?>()
+
+    private val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+        override fun onChange(selfChange: Boolean) {
+            cache.clear()
+        }
+    }
+
+    init {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CONTACTS)
+            == PackageManager.PERMISSION_GRANTED
+        ) {
+            context.contentResolver.registerContentObserver(
+                ContactsContract.Contacts.CONTENT_URI,
+                true,
+                observer
+            )
+        }
+    }
+
+    fun getPhotoUri(email: String): Uri? {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CONTACTS)
+            != PackageManager.PERMISSION_GRANTED
+        ) return null
+
+        return cache.getOrPut(email) { queryContactPhoto(email) }
+    }
+
+    private fun queryContactPhoto(email: String): Uri? {
+        val cr = context.contentResolver
+        val projection = arrayOf(ContactsContract.Data.CONTACT_ID)
+        val selection = "${ContactsContract.CommonDataKinds.Email.ADDRESS} = ? AND ${ContactsContract.Data.MIMETYPE} = ?"
+        val args = arrayOf(email, ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE)
+
+        cr.query(ContactsContract.Data.CONTENT_URI, projection, selection, args, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val contactId = cursor.getLong(0)
+                return Uri.withAppendedPath(
+                    ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, contactId),
+                    ContactsContract.Contacts.Photo.CONTENT_DIRECTORY
+                )
+            }
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
@@ -14,6 +14,7 @@ import com.shrivatsav.monomail.data.provider.OutlookProvider
 import com.shrivatsav.monomail.data.provider.imap.ImapAccountConfig
 import com.shrivatsav.monomail.data.provider.imap.ImapProvider
 import com.shrivatsav.monomail.data.remote.RetrofitClient
+import com.shrivatsav.monomail.data.repository.ContactPhotoProvider
 import com.shrivatsav.monomail.data.repository.ContactSuggestionProvider
 import com.shrivatsav.monomail.data.repository.EmailRepository
 import com.shrivatsav.monomail.data.settings.SettingsDataStore
@@ -50,6 +51,10 @@ object AppModule {
     @Provides @Singleton
     fun provideContactSuggestionProvider(): ContactSuggestionProvider =
         ContactSuggestionProvider()
+
+    @Provides @Singleton
+    fun provideContactPhotoProvider(@ApplicationContext context: Context): ContactPhotoProvider =
+        ContactPhotoProvider(context)
 
     @Provides @Singleton
     fun provideSentEmailEvents(): MutableSharedFlow<SentEmailEvent> =

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -1,4 +1,5 @@
 package com.shrivatsav.monomail.ui.screens.detail
+import android.net.Uri
 import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.compose.animation.AnimatedVisibility
@@ -18,6 +19,8 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.layout.ContentScale
+import coil.compose.AsyncImage
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -85,6 +88,7 @@ fun EmailDetailScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val isStarred by viewModel.isStarred.collectAsState()
+    val contactPhotoUris by viewModel.contactPhotoUris.collectAsState()
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         contentWindowInsets = WindowInsets(
@@ -194,11 +198,12 @@ fun EmailDetailScreen(
                     }
                     ThreadConversationContent(
                         emails = emails,
+                        contactPhotoUris = contactPhotoUris,
                         modifier = Modifier.weight(1f),
                         isConversationView = isConversationView,
                         onReply = { onReply(latestEmail.fromEmail, latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
                         onForward = { onForward(latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
-                        onFetchAttachment = { msgId, attId -> viewModel.fetchAttachmentBytes(msgId, attId) }
+                        onFetchAttachment = onFetchAttachment
                     )
                 }
             }
@@ -208,6 +213,7 @@ fun EmailDetailScreen(
 @Composable
 private fun ThreadConversationContent(
     emails: List<Email>,
+    contactPhotoUris: Map<String, Uri?> = emptyMap(),
     modifier: Modifier = Modifier,
     isConversationView: Boolean = true,
     onReply: () -> Unit = {},
@@ -263,6 +269,7 @@ private fun ThreadConversationContent(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     val initial = email.from.firstOrNull()?.uppercase() ?: "?"
+                    val photoUri = contactPhotoUris[email.fromEmail]
                     Box(
                         modifier = Modifier
                             .size(36.dp)
@@ -270,11 +277,20 @@ private fun ThreadConversationContent(
                             .background(MaterialTheme.colorScheme.surfaceContainerHigh),
                         contentAlignment = Alignment.Center
                     ) {
-                        Text(
-                            text = initial,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
+                        if (photoUri != null) {
+                            coil.compose.AsyncImage(
+                                model = photoUri,
+                                contentDescription = "Contact photo",
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = androidx.compose.ui.layout.ContentScale.Crop
+                            )
+                        } else {
+                            Text(
+                                text = initial,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
                     }
                     Spacer(modifier = Modifier.width(12.dp))
                     Column(modifier = Modifier.weight(1f)) {
@@ -283,6 +299,13 @@ private fun ThreadConversationContent(
                             style = MaterialTheme.typography.titleSmall,
                             fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = email.fromEmail,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -330,6 +353,7 @@ private fun ThreadConversationContent(
                 ) {
                     MessageBody(
                         email = email,
+                        contactPhotoUri = contactPhotoUris[email.fromEmail],
                         bgColor = bgColor,
                         textColor = textColor,
                         linkColor = linkColor,
@@ -339,6 +363,7 @@ private fun ThreadConversationContent(
             } else {
                 MessageBody(
                     email = email,
+                    contactPhotoUri = contactPhotoUris[email.fromEmail],
                     bgColor = bgColor,
                     textColor = textColor,
                     linkColor = linkColor,
@@ -405,6 +430,7 @@ private fun ThreadConversationContent(
 @Composable
 private fun MessageBody(
     email: Email,
+    contactPhotoUri: Uri? = null,
     bgColor: String,
     textColor: String,
     linkColor: String,
@@ -430,11 +456,20 @@ private fun MessageBody(
                             .background(MaterialTheme.colorScheme.surfaceContainerHigh),
                         contentAlignment = Alignment.Center
                     ) {
-                        Text(
-                            text = initial,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
+                        if (contactPhotoUri != null) {
+                            AsyncImage(
+                                model = contactPhotoUri,
+                                contentDescription = "Contact photo",
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop
+                            )
+                        } else {
+                            Text(
+                                text = initial,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
                     }
                     if (isMsgUnread) {
                         Box(
@@ -474,6 +509,13 @@ private fun MessageBody(
                             )
                         }
                     }
+                    Text(
+                        text = email.fromEmail,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         if (isMsgUnread) {
                             Text(

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
@@ -2,14 +2,20 @@ package com.shrivatsav.monomail.ui.screens.detail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.net.Uri
 import com.shrivatsav.monomail.data.model.Email
+import com.shrivatsav.monomail.data.repository.ContactPhotoProvider
 import com.shrivatsav.monomail.data.repository.EmailRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 sealed class EmailDetailState {
     object Loading : EmailDetailState()
@@ -19,6 +25,7 @@ sealed class EmailDetailState {
 @HiltViewModel
 class EmailDetailViewModel @Inject constructor(
     private val repository: EmailRepository,
+    private val contactPhotoProvider: ContactPhotoProvider,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     private val threadId: String = savedStateHandle.get<String>("threadId") ?: ""
@@ -55,6 +62,8 @@ class EmailDetailViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = false
         )
+    private val _contactPhotoUris = MutableStateFlow<Map<String, Uri?>>(emptyMap())
+    val contactPhotoUris: StateFlow<Map<String, Uri?>> = _contactPhotoUris.asStateFlow()
     init {
         viewModelScope.launch {
             repository.markThreadAsRead(threadId)
@@ -63,6 +72,16 @@ class EmailDetailViewModel @Inject constructor(
             _isLoading.value = false
             result.onFailure {
                 _error.value = it.message ?: "Failed to refresh thread"
+            }
+        }
+        viewModelScope.launch {
+            state.collect { s ->
+                if (s is EmailDetailState.Success) {
+                    val uris = withContext(Dispatchers.IO) {
+                        s.emails.associate { it.fromEmail to contactPhotoProvider.getPhotoUri(it.fromEmail) }
+                    }
+                    _contactPhotoUris.value = uris
+                }
             }
         }
     }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/EmailItem.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/EmailItem.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import android.net.Uri
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
@@ -54,6 +55,7 @@ private val domainRegex = Regex("@(.+)$")
 @Composable
 fun EmailItem(
     thread: EmailThread,
+    contactPhotoUri: Uri? = null,
     onClick: () -> Unit,
     onLongClick: () -> Unit = {},
     showSnippet: Boolean = true,
@@ -103,6 +105,7 @@ fun EmailItem(
             SenderAvatar(
                 domain = domain,
                 senderInitial = senderInitial,
+                contactPhotoUri = contactPhotoUri,
                 isSelected = isSelected,
                 isBulkMode = isBulkMode,
                 onClick = avatarClickAction,
@@ -196,6 +199,7 @@ fun EmailItem(
 private fun SenderAvatar(
     domain: String?,
     senderInitial: String,
+    contactPhotoUri: Uri? = null,
     isSelected: Boolean = false,
     isBulkMode: Boolean = false,
     onClick: () -> Unit = {},
@@ -206,10 +210,15 @@ private fun SenderAvatar(
         .size(40.dp)
         .clip(CircleShape)
     val context = LocalContext.current
-    val painter = if (domain != null) {
+    val imageUrl = when {
+        contactPhotoUri != null -> contactPhotoUri.toString()
+        domain != null -> "https://www.google.com/s2/favicons?domain=$domain&sz=128"
+        else -> null
+    }
+    val painter = if (imageUrl != null) {
         rememberAsyncImagePainter(
             model = ImageRequest.Builder(context)
-                .data("https://www.google.com/s2/favicons?domain=$domain&sz=128")
+                .data(imageUrl)
                 .crossfade(true)
                 .build(),
             placeholder = null

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -53,6 +53,7 @@ fun InboxScreen(
     val showWelcomePrompt by viewModel.showWelcomePrompt.collectAsState()
     val scheduledCount by viewModel.scheduledCount.collectAsState()
     val immediateTab by viewModel.currentTab.collectAsState()
+    val contactPhotoUris by viewModel.contactPhotoUris.collectAsState()
 
     val context = androidx.compose.ui.platform.LocalContext.current
     var threadToDelete by remember { mutableStateOf<String?>(null) }
@@ -352,6 +353,7 @@ fun InboxScreen(
                                                     SwipeableEmailItem(
                                                         modifier = Modifier.animateItem(),
                                                         thread = displayItem.thread,
+                                                        contactPhotoUri = contactPhotoUris[displayItem.thread.fromEmail],
                                                         tabForSwipe = currentTab,
                                                         appSettings = appSettings,
                                                         viewModel = viewModel,
@@ -378,6 +380,7 @@ fun InboxScreen(
                                                     SwipeableEmailItem(
                                                         modifier = Modifier.animateItem(),
                                                         thread = displayItem.thread,
+                                                        contactPhotoUri = contactPhotoUris[displayItem.thread.fromEmail],
                                                         tabForSwipe = currentTab,
                                                         appSettings = appSettings,
                                                         viewModel = viewModel,

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxViewModel.kt
@@ -7,8 +7,10 @@ import com.shrivatsav.monomail.auth.AuthManager
 import com.shrivatsav.monomail.auth.UserProfile
 import com.shrivatsav.monomail.data.model.Email
 import com.shrivatsav.monomail.data.model.EmailThread
+import com.shrivatsav.monomail.data.repository.ContactPhotoProvider
 import com.shrivatsav.monomail.data.repository.ContactSuggestionProvider
 import com.shrivatsav.monomail.data.repository.EmailRepository
+import android.net.Uri
 import com.shrivatsav.monomail.data.settings.AppSettings
 import com.shrivatsav.monomail.data.settings.SettingsDataStore
 import androidx.compose.runtime.mutableStateMapOf
@@ -31,8 +33,10 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 enum class InboxTab { INBOX, SENT, ARCHIVED, STARRED, TRASH, UNIFIED, SNOOZED, SPAM }
 sealed class InboxState {
@@ -51,6 +55,7 @@ sealed class InboxState {
 class InboxViewModel @Inject constructor(
     private val repository: EmailRepository,
     private val contactProvider: ContactSuggestionProvider,
+    private val contactPhotoProvider: ContactPhotoProvider,
     private val authManager: AuthManager,
     private val settingsDataStore: SettingsDataStore,
     private val sentEmailEvents: MutableSharedFlow<SentEmailEvent>,
@@ -99,6 +104,8 @@ class InboxViewModel @Inject constructor(
     val settingsFlow = settingsDataStore.settingsFlow
     private val _state = MutableStateFlow<InboxState>(InboxState.Loading)
     val state: StateFlow<InboxState> = _state.asStateFlow()
+    private val _contactPhotoUris = MutableStateFlow<Map<String, Uri?>>(emptyMap())
+    val contactPhotoUris: StateFlow<Map<String, Uri?>> = _contactPhotoUris.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -190,6 +197,16 @@ class InboxViewModel @Inject constructor(
             InboxTab.values().forEach { tab ->
                 if (tab != _currentTab.value && tab != InboxTab.UNIFIED) {
                     repository.refreshInbox(tab)
+                }
+            }
+        }
+        viewModelScope.launch {
+            state.collect { s ->
+                if (s is InboxState.Success) {
+                    val uris = withContext(Dispatchers.IO) {
+                        s.threads.associate { it.fromEmail to contactPhotoProvider.getPhotoUri(it.fromEmail) }
+                    }
+                    _contactPhotoUris.value = uris
                 }
             }
         }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import android.net.Uri
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,6 +22,7 @@ import kotlinx.coroutines.launch
 internal fun SwipeableEmailItem(
     modifier: Modifier = Modifier,
     thread: EmailThread,
+    contactPhotoUri: Uri? = null,
     tabForSwipe: InboxTab,
     appSettings: com.shrivatsav.monomail.data.settings.AppSettings,
     viewModel: InboxViewModel,
@@ -79,6 +81,7 @@ internal fun SwipeableEmailItem(
         if (isBulkMode) {
             EmailItem(
                 thread = thread.copy(isRead = optIsRead, isStarred = optIsStarred),
+                contactPhotoUri = contactPhotoUri,
                 onClick = onEmailClick,
                 onLongClick = onLongClick,
                 showSnippet = appSettings.showSnippet,
@@ -157,6 +160,7 @@ internal fun SwipeableEmailItem(
         ) {
             EmailItem(
                 thread = thread.copy(isRead = optIsRead, isStarred = optIsStarred),
+                contactPhotoUri = contactPhotoUri,
                 onClick = onEmailClick,
                 onLongClick = onLongClick,
                 showSnippet = appSettings.showSnippet,


### PR DESCRIPTION
Pull sender photos from device contacts database. Falls back to Google favicon API for unknown senders. Handles READ_CONTACTS permission gracefully (silent fallback).