### PR TITLE
SHR-41: Milestone v1.5 — Deep security audit

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         applicationId = "com.shrivatsav.monomail"
         minSdk = 26
         targetSdk = 35
-        versionCode = 12
-        versionName = "1.4b"
+        versionCode = 13
+        versionName = "1.5b"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         
         buildConfigField("String", "GOOGLE_CLIENT_ID", "\"$googleClientId\"")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -28,8 +28,20 @@
     @com.google.gson.annotations.SerializedName <fields>;
 }
 
-# Keep data classes used with Gson in AccountManager
--keepclassmembers class com.shrivatsav.monomail.** {
+# Keep Gson-serialized data classes in AccountManager
+-keepclassmembers class com.shrivatsav.monomail.auth.UserProfile {
+    <fields>;
+}
+-keepclassmembers class com.shrivatsav.monomail.data.provider.imap.ImapAccountConfig {
+    <fields>;
+}
+-keepclassmembers class com.shrivatsav.monomail.data.local.ScheduledMessageEntity {
+    <fields>;
+}
+-keepclassmembers class com.shrivatsav.monomail.data.model.EmailAttachment {
+    <fields>;
+}
+-keepclassmembers class com.shrivatsav.monomail.data.model.EmailAttachmentInfo {
     <fields>;
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.MonoMail" >
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/shrivatsav/monomail/auth/AccountManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/auth/AccountManager.kt
@@ -115,11 +115,11 @@ class AccountManager(private val context: Context) {
     }
     suspend fun getLastKnownEmailId(accountId: String): String? {
         val prefs = context.dataStore.data.first()
-        return prefs[stringPreferencesKey("last_email_$accountId")]
+        return prefs[stringPreferencesKey("last_timestamp_$accountId")]
     }
     suspend fun setLastKnownEmailId(accountId: String, emailId: String) {
         context.dataStore.edit { prefs ->
-            prefs[stringPreferencesKey("last_email_$accountId")] = emailId
+            prefs[stringPreferencesKey("last_timestamp_$accountId")] = emailId
         }
     }
     suspend fun getLastActiveTime(): Long {

--- a/app/src/main/java/com/shrivatsav/monomail/auth/AuthManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/auth/AuthManager.kt
@@ -85,6 +85,7 @@ class AuthManager(
         } catch (e: UserRecoverableAuthException) {
             notifyReauthRequired(profile.email, profile.provider)
         } catch (e: Exception) {
+            android.util.Log.w("AuthManager", "refreshCurrentToken failed", e)
         }
     }
     suspend fun signIn(activityContext: Context): SignInResult {
@@ -146,6 +147,7 @@ class AuthManager(
             try {
                 credentialManager.clearCredentialState(ClearCredentialStateRequest())
             } catch (e: Exception) {
+                android.util.Log.w("AuthManager", "clearCredentialState failed", e)
             }
         } else if (active.provider == "outlook") {
             try {
@@ -165,10 +167,14 @@ class AuthManager(
     suspend fun signOutAll() {
         try {
             credentialManager.clearCredentialState(ClearCredentialStateRequest())
-        } catch (e: Exception) { }
+        } catch (e: Exception) {
+            android.util.Log.w("AuthManager", "signOutAll clearCredentialState failed", e)
+        }
         val accounts = accountManager.getAccounts()
         accounts.filter { it.provider == "outlook" }.forEach {
-            try { microsoftAuthManager.signOut(it.id) } catch (e: Exception) { }
+            try { microsoftAuthManager.signOut(it.id) } catch (e: Exception) {
+                android.util.Log.w("AuthManager", "Outlook signOut failed for ${it.id}", e)
+            }
         }
         accountManager.clearAll()
         _isSignedIn.value = false
@@ -201,7 +207,7 @@ class AuthManager(
                     connection.setRequestProperty("Authorization", "Bearer $accessToken")
                     connection.responseCode
                 } catch (e: Exception) {
-                    200 
+                    throw e
                 }
             }
             if (responseCode == 401 || responseCode == 403) {

--- a/app/src/main/java/com/shrivatsav/monomail/auth/MicrosoftAuthManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/auth/MicrosoftAuthManager.kt
@@ -31,7 +31,7 @@ class MicrosoftAuthManager(private val context: Context, private val accountMana
                     continuation.resume(true)
                 }
                 override fun onError(exception: MsalException) {
-                    exception.printStackTrace()
+                    android.util.Log.e("MicrosoftAuth", "MSAL init failed", exception)
                     continuation.resume(false)
                 }
             }

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/AppDatabase.kt
@@ -29,7 +29,7 @@ abstract class AppDatabase : RoomDatabase() {
                     "monomail_database"
                 )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_2_3, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
                 .fallbackToDestructiveMigration()
                 .build()
                 INSTANCE = instance
@@ -42,6 +42,12 @@ val MIGRATION_2_3 = object : androidx.room.migration.Migration(2, 3) {
     override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE threads ADD COLUMN accountId TEXT NOT NULL DEFAULT 'gmail_unknown'")
         db.execSQL("ALTER TABLE emails ADD COLUMN accountId TEXT NOT NULL DEFAULT 'gmail_unknown'")
+    }
+}
+val MIGRATION_3_4 = object : androidx.room.migration.Migration(3, 4) {
+    override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE emails ADD COLUMN ccEmail TEXT NOT NULL DEFAULT ''")
+        db.execSQL("ALTER TABLE emails ADD COLUMN bccEmail TEXT NOT NULL DEFAULT ''")
     }
 }
 val MIGRATION_4_5 = object : androidx.room.migration.Migration(4, 5) {

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
@@ -4,6 +4,7 @@ import androidx.room.PrimaryKey
 import com.shrivatsav.monomail.data.model.Email
 import com.shrivatsav.monomail.data.model.EmailAttachment
 import com.shrivatsav.monomail.data.model.EmailThread
+import com.google.gson.Gson
 @Entity(tableName = "threads")
 data class ThreadEntity(
     @PrimaryKey val threadId: String,
@@ -82,7 +83,7 @@ data class EmailEntity(
         isStarred = isStarred,
         labels = labels,
         attachments = try {
-            com.google.gson.Gson().fromJson(attachmentsJson, Array<com.shrivatsav.monomail.data.model.EmailAttachmentInfo>::class.java)?.toList() ?: emptyList()
+            gson.fromJson(attachmentsJson, Array<com.shrivatsav.monomail.data.model.EmailAttachmentInfo>::class.java)?.toList() ?: emptyList()
         } catch(e: Exception) { emptyList() }
     )
 }
@@ -132,6 +133,7 @@ data class ScheduledMessageEntity(
     val createdAt: Long = System.currentTimeMillis()
 )
 
+private val gson = Gson()
 fun Email.toEntity(accountId: String) = EmailEntity(
     id = id,
     accountId = accountId,
@@ -148,7 +150,7 @@ fun Email.toEntity(accountId: String) = EmailEntity(
     isRead = isRead,
     isStarred = isStarred,
     labels = labels,
-    attachmentsJson = com.google.gson.Gson().toJson(attachments),
+    attachmentsJson = gson.toJson(attachments),
     inInbox = labels.contains("INBOX"),
     inSent = labels.contains("SENT"),
     inArchived = !labels.contains("INBOX") && !labels.contains("TRASH") && !labels.contains("SENT") && !labels.contains("SPAM"),

--- a/app/src/main/java/com/shrivatsav/monomail/data/provider/GmailProvider.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/provider/GmailProvider.kt
@@ -40,9 +40,10 @@ class GmailProvider(
             query = finalQuery
         )
         val threadRefs = response.threads.orEmpty()
+        val limitedParallelism = Dispatchers.IO.limitedParallelism(5)
         val rawThreads = coroutineScope {
             threadRefs.map { ref ->
-                async {
+                async(limitedParallelism) {
                     try {
                         api.getThread(ref.id)
                     } catch (e: Exception) {

--- a/app/src/main/java/com/shrivatsav/monomail/data/provider/OutlookProvider.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/provider/OutlookProvider.kt
@@ -12,6 +12,9 @@ import com.shrivatsav.monomail.data.remote.OutlookRecipient
 import com.shrivatsav.monomail.data.remote.OutlookSendMailRequest
 import com.shrivatsav.monomail.data.remote.OutlookUpdateMessageRequest
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -89,7 +92,7 @@ class OutlookProvider(
     override suspend fun getThread(threadId: String, folderHints: List<String>): ProviderThread = withContext(Dispatchers.IO) {
         val response = api.listMessages(
             maxResults = 100,
-            filter = "conversationId eq '$threadId'"
+            filter = sanitizeFilter(threadId)
         )
         val providerMessages = response.value.map { msg ->
             val date = parseDate(msg.receivedDateTime)
@@ -139,28 +142,30 @@ class OutlookProvider(
             }
         }
     }
+    private fun sanitizeFilter(threadId: String): String = "conversationId eq '${threadId.replace("'", "''")}'"
+
     override suspend fun archiveThread(threadId: String) {
-        val msgs = api.listMessages(filter = "conversationId eq '$threadId'").value
+        val msgs = api.listMessages(filter = sanitizeFilter(threadId)).value
         msgs.forEach { api.moveMessage(it.id, OutlookMoveMessageRequest("archive")) }
     }
     override suspend fun unarchiveThread(threadId: String) {
-        val msgs = api.listMessages(filter = "conversationId eq '$threadId'").value
+        val msgs = api.listMessages(filter = sanitizeFilter(threadId)).value
         msgs.forEach { api.moveMessage(it.id, OutlookMoveMessageRequest("inbox")) }
     }
     override suspend fun trashThread(threadId: String) {
-        val msgs = api.listMessages(filter = "conversationId eq '$threadId'").value
+        val msgs = api.listMessages(filter = sanitizeFilter(threadId)).value
         msgs.forEach { api.moveMessage(it.id, OutlookMoveMessageRequest("deleteditems")) }
     }
     override suspend fun restoreThread(threadId: String) {
-        val msgs = api.listMessages(filter = "conversationId eq '$threadId'").value
+        val msgs = api.listMessages(filter = sanitizeFilter(threadId)).value
         msgs.forEach { api.moveMessage(it.id, OutlookMoveMessageRequest("inbox")) }
     }
     override suspend fun permanentlyDeleteThread(threadId: String) {
-        val msgs = api.listMessages(filter = "conversationId eq '$threadId'").value
+        val msgs = api.listMessages(filter = sanitizeFilter(threadId)).value
         msgs.forEach { api.deleteMessage(it.id) }
     }
     override suspend fun toggleStar(threadId: String, starred: Boolean) {
-        val msgs = api.listMessages(filter = "conversationId eq '$threadId'").value
+        val msgs = api.listMessages(filter = sanitizeFilter(threadId)).value
         msgs.forEach { msg ->
             val categories = msg.categories?.toMutableList() ?: mutableListOf()
             if (starred) {
@@ -172,15 +177,19 @@ class OutlookProvider(
         }
     }
     override suspend fun markRead(threadId: String, read: Boolean) {
-        val msgs = api.listMessages(filter = "conversationId eq '$threadId'").value
+        val msgs = api.listMessages(filter = sanitizeFilter(threadId)).value
         msgs.forEach { msg ->
             api.updateMessage(msg.id, OutlookUpdateMessageRequest(isRead = read))
         }
     }
     override suspend fun batchMarkRead(messageIds: List<String>) {
         withContext(Dispatchers.IO) {
-            messageIds.forEach { id ->
-                try { api.updateMessage(id, OutlookUpdateMessageRequest(isRead = true)) } catch (e: Exception) {}
+            coroutineScope {
+                messageIds.map { id ->
+                    async {
+                        try { api.updateMessage(id, OutlookUpdateMessageRequest(isRead = true)) } catch (_: Exception) {}
+                    }
+                }.awaitAll()
             }
         }
     }

--- a/app/src/main/java/com/shrivatsav/monomail/data/provider/imap/ImapProvider.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/provider/imap/ImapProvider.kt
@@ -122,25 +122,24 @@ class ImapProvider(
 
         imapFolder.open(Folder.READ_ONLY)
         try {
-            val messages = if (folder == EmailFolder.STARRED) {
-                imapFolder.search(FlagTerm(Flags(Flags.Flag.FLAGGED), true))
+            val toFetch: Array<jakarta.mail.Message>
+            val fetchStart: Int
+            if (folder == EmailFolder.STARRED) {
+                val allStarred = imapFolder.search(FlagTerm(Flags(Flags.Flag.FLAGGED), true))
+                if (allStarred.isEmpty()) return@withContext ProviderThreadListResult(emptyList(), null)
+                toFetch = allStarred.takeLast(maxResults).toTypedArray()
+                fetchStart = 1
             } else {
-                imapFolder.messages
-            }
+                val total = imapFolder.messageCount
+                if (total == 0) return@withContext ProviderThreadListResult(emptyList(), null)
 
-            val total = messages.size
-            if (total == 0) return@withContext ProviderThreadListResult(emptyList(), null)
+                val offset = pageToken?.toIntOrNull() ?: total
+                val start = maxOf(1, offset - maxResults + 1)
+                val end = offset
+                if (start > end) return@withContext ProviderThreadListResult(emptyList(), null)
 
-            // Very basic pagination: fetch last maxResults
-            val offset = pageToken?.toIntOrNull() ?: total
-            val start = maxOf(1, offset - maxResults + 1)
-            val end = offset
-            if (start > end) return@withContext ProviderThreadListResult(emptyList(), null)
-
-            val toFetch = if (folder == EmailFolder.STARRED) {
-                messages.takeLast(maxResults).toTypedArray()
-            } else {
-                imapFolder.getMessages(start, end)
+                toFetch = imapFolder.getMessages(start, end)
+                fetchStart = start
             }
 
             // Fetch envelope, flags, and content info for body parsing
@@ -282,7 +281,7 @@ class ImapProvider(
                 ProviderThread(threadId, msgs)
             }.sortedByDescending { t -> t.messages.maxOfOrNull { it.date } ?: 0L }
 
-            val nextToken = if (start > 1) (start - 1).toString() else null
+            val nextToken = if (fetchStart > 1) (fetchStart - 1).toString() else null
             ProviderThreadListResult(threads, nextToken)
 
         } finally {
@@ -681,8 +680,19 @@ class ImapProvider(
         if (config.smtpStartTls) {
             props["mail.$protocol.starttls.enable"] = "true"
         }
-        props["mail.$protocol.connectiontimeout"] = "10000"
-        props["mail.$protocol.timeout"] = "10000"
+        props["mail.$protocol.connectiontimeout"] = "15000"
+        props["mail.$protocol.timeout"] = "15000"
+        props["mail.$protocol.writetimeout"] = "15000"
+        val localhost = from.substringAfterLast("@").ifBlank { config.smtpHost }
+        props["mail.smtp.localhost"] = localhost
+        props["mail.smtp.quitwait"] = "false"
+        props["mail.$protocol.ssl.protocols"] = "TLSv1.2 TLSv1.3"
+        if (config.smtpSsl || config.smtpStartTls) {
+            props["mail.$protocol.checkserveridentity"] = "true"
+        }
+        if (config.smtpStartTls) {
+            props["mail.$protocol.starttls.required"] = "true"
+        }
 
         val session = Session.getInstance(props, object : jakarta.mail.Authenticator() {
             override fun getPasswordAuthentication() = jakarta.mail.PasswordAuthentication(config.username, password)

--- a/app/src/main/java/com/shrivatsav/monomail/data/remote/RetrofitClient.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/remote/RetrofitClient.kt
@@ -9,16 +9,18 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicReference
 class RetrofitClient(
-    private val tokenProvider: () -> String?,
+    tokenProvider: () -> String?,
     private val tokenRefresher: () -> String?,
     private val onRefreshFailed: () -> Unit = {},
 ) {
+    private val cachedToken = AtomicReference(tokenProvider())
     class AuthFailedException(message: String) : IOException(message)
 
     private fun createAuthInterceptor() = Interceptor { chain ->
         val request = chain.request()
-        val token = tokenProvider()
+        val token = cachedToken.get()
         val newRequest = if (token != null) {
             request.newBuilder()
                 .header("Authorization", "Bearer $token")
@@ -30,6 +32,7 @@ class RetrofitClient(
         if (response.code == 401) {
             val newToken = tokenRefresher()
             if (newToken != null) {
+                cachedToken.set(newToken)
                 response.close()
                 val retryRequest = request.newBuilder()
                     .header("Authorization", "Bearer $newToken")
@@ -43,25 +46,22 @@ class RetrofitClient(
         response
     }
     private val loggingInterceptor = HttpLoggingInterceptor().apply {
-        level = HttpLoggingInterceptor.Level.HEADERS
+        level = HttpLoggingInterceptor.Level.BASIC
     }
-    private val gmailHttpClient = OkHttpClient.Builder()
+    private val baseHttpClient = OkHttpClient.Builder()
         .addInterceptor(createAuthInterceptor())
         .addInterceptor(loggingInterceptor)
         .build()
-    private val outlookHttpClient = OkHttpClient.Builder()
-        .addInterceptor(createAuthInterceptor())
-        .addInterceptor(loggingInterceptor)
-        .build()
+    private val gsonConverter = GsonConverterFactory.create()
     private val gmailRetrofit = Retrofit.Builder()
         .baseUrl("https://gmail.googleapis.com/gmail/v1/")
-        .client(gmailHttpClient)
-        .addConverterFactory(GsonConverterFactory.create())
+        .client(baseHttpClient)
+        .addConverterFactory(gsonConverter)
         .build()
     private val outlookRetrofit = Retrofit.Builder()
         .baseUrl("https://graph.microsoft.com/v1.0/")
-        .client(outlookHttpClient)
-        .addConverterFactory(GsonConverterFactory.create())
+        .client(baseHttpClient)
+        .addConverterFactory(gsonConverter)
         .build()
     val gmailApi: GmailApi = gmailRetrofit.create(GmailApi::class.java)
     val outlookApi: OutlookApi = outlookRetrofit.create(OutlookApi::class.java)

--- a/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
@@ -401,9 +401,6 @@ class EmailRepository(
         attachments: List<EmailAttachment> = emptyList()
     ) {
         val id = UUID.randomUUID().toString()
-        val attachmentsJson = if (attachments.isNotEmpty()) {
-            gson.toJson(attachments.map { it.copy(uri = Uri.fromFile(File(it.uri.toString())).toString().let { Uri.parse(it) }) })
-        } else "[]"
         val entity = ScheduledMessageEntity(
             id = id,
             accountId = accountId,

--- a/app/src/main/java/com/shrivatsav/monomail/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/settings/SettingsDataStore.kt
@@ -54,6 +54,7 @@ data class AppSettings(
     val dockConfig: DockConfig = DockConfig.defaults()
 )
 class SettingsDataStore(private val context: Context) {
+    private val gson = Gson()
     private object Keys {
         val THEME_MODE = stringPreferencesKey("theme_mode")
         val FONT_SCALE = stringPreferencesKey("font_scale")
@@ -100,7 +101,7 @@ class SettingsDataStore(private val context: Context) {
             undoSendEnabled = prefs[Keys.UNDO_SEND_ENABLED] ?: true,
             undoSendWindow = prefs[Keys.UNDO_SEND_WINDOW]?.let { UndoSendWindow.valueOf(it) } ?: UndoSendWindow.SEC_10,
             dockConfig = dockConfigJson?.let { json ->
-                try { Gson().fromJson(json, DockConfig::class.java) } catch (e: Exception) { DockConfig.defaults() }
+                try { gson.fromJson(json, DockConfig::class.java) } catch (e: Exception) { DockConfig.defaults() }
             } ?: DockConfig.defaults()
         )
     }
@@ -162,26 +163,26 @@ class SettingsDataStore(private val context: Context) {
         context.dataStore.edit { it[Keys.UNDO_SEND_WINDOW] = window.name }
     }
     suspend fun setDockConfig(config: DockConfig) {
-        context.dataStore.edit { it[Keys.DOCK_CONFIG] = Gson().toJson(config) }
+        context.dataStore.edit { it[Keys.DOCK_CONFIG] = gson.toJson(config) }
     }
     suspend fun getTemplates(): List<EmailTemplate> {
         val prefs = context.dataStore.data.first()
         val json = prefs[Keys.TEMPLATES] ?: return emptyList()
         return try {
             val type = object : TypeToken<Array<EmailTemplate>>() {}.type
-            Gson().fromJson<Array<EmailTemplate>>(json, type).toList()
+            gson.fromJson<Array<EmailTemplate>>(json, type).toList()
         } catch (e: Exception) { emptyList() }
     }
     suspend fun saveTemplates(templates: List<EmailTemplate>) {
         context.dataStore.edit { prefs ->
-            prefs[Keys.TEMPLATES] = Gson().toJson(templates)
+            prefs[Keys.TEMPLATES] = gson.toJson(templates)
         }
     }
     val templatesFlow: Flow<List<EmailTemplate>> = context.dataStore.data.map { prefs ->
         val json = prefs[Keys.TEMPLATES] ?: return@map emptyList()
         try {
             val type = object : TypeToken<Array<EmailTemplate>>() {}.type
-            Gson().fromJson<Array<EmailTemplate>>(json, type).toList()
+            gson.fromJson<Array<EmailTemplate>>(json, type).toList()
         } catch (e: Exception) { emptyList() }
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/security/SecurityUtil.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/security/SecurityUtil.kt
@@ -33,18 +33,19 @@ object SecurityUtil {
     }
     fun getDatabasePassphrase(context: Context): CharArray {
         val prefs = getSecurePrefs(context)
-        var passphrase = prefs.getString(DB_PASSPHRASE_KEY, null)
-        if (passphrase == null) {
-            passphrase = generateRandomPassphrase()
-            prefs.edit().putString(DB_PASSPHRASE_KEY, passphrase).apply()
+        val stored = prefs.getString(DB_PASSPHRASE_KEY, null)
+        if (stored != null) {
+            val chars = stored.toCharArray()
+            return chars
         }
-        return passphrase.toCharArray()
-    }
-    private fun generateRandomPassphrase(): String {
         val random = SecureRandom()
         val bytes = ByteArray(32)
         random.nextBytes(bytes)
-        return Base64.encodeToString(bytes, Base64.NO_WRAP)
+        val passphrase = Base64.encodeToString(bytes, Base64.NO_WRAP)
+        bytes.fill(0)
+        prefs.edit().putString(DB_PASSPHRASE_KEY, passphrase).apply()
+        val chars = passphrase.toCharArray()
+        return chars
     }
     private fun getSecretKey(): SecretKey {
         val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
@@ -75,7 +76,10 @@ object SecurityUtil {
     fun decryptString(encryptedBase64: String): String? {
         return try {
             val combined = Base64.decode(encryptedBase64, Base64.NO_WRAP)
-            if (combined.size < IV_LENGTH) return null
+            if (combined.size < IV_LENGTH) {
+                android.util.Log.e("SecurityUtil", "decryptString: combined size < IV_LENGTH")
+                return null
+            }
             val iv = ByteArray(IV_LENGTH)
             System.arraycopy(combined, 0, iv, 0, iv.size)
             val spec = GCMParameterSpec(128, iv)
@@ -86,7 +90,7 @@ object SecurityUtil {
             val decryptedData = cipher.doFinal(encryptedData)
             String(decryptedData, Charsets.UTF_8)
         } catch (e: Exception) {
-            e.printStackTrace()
+            android.util.Log.e("SecurityUtil", "decryptString failed", e)
             null
         }
     }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -150,19 +150,6 @@ fun EmailDetailScreen(
         }
     ) { padding ->
         when (val s = state) {
-            is EmailDetailState.Loading -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(padding),
-                    contentAlignment = Alignment.Center
-                ) {
-                    LoadingIndicator(
-                        modifier = Modifier.size(48.dp),
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                }
-            }
             is EmailDetailState.Error -> {
                 Box(
                     modifier = Modifier
@@ -180,7 +167,6 @@ fun EmailDetailScreen(
             }
             is EmailDetailState.Success -> {
                 val emails = s.emails
-                val latestEmail = emails.lastOrNull() ?: return@Scaffold
                 androidx.compose.foundation.layout.Column(modifier = Modifier.fillMaxSize().padding(padding)) {
                     if (s.isRefreshing) {
                         LinearProgressIndicator(
@@ -196,15 +182,26 @@ fun EmailDetailScreen(
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                         )
                     }
-                    ThreadConversationContent(
-                        emails = emails,
-                        contactPhotoUris = contactPhotoUris,
-                        modifier = Modifier.weight(1f),
-                        isConversationView = isConversationView,
-                        onReply = { onReply(latestEmail.fromEmail, latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
-                        onForward = { onForward(latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
-                        onFetchAttachment = onFetchAttachment
-                    )
+                    if (emails.isEmpty()) {
+                        Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                            Text(
+                                "Loading...",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                            )
+                        }
+                    } else {
+                        val latestEmail = emails.last()
+                        ThreadConversationContent(
+                            emails = emails,
+                            contactPhotoUris = contactPhotoUris,
+                            modifier = Modifier.weight(1f),
+                            isConversationView = isConversationView,
+                            onReply = { onReply(latestEmail.fromEmail, latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
+                            onForward = { onForward(latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
+                            onFetchAttachment = onFetchAttachment
+                        )
+                    }
                 }
             }
         }
@@ -568,6 +565,7 @@ private fun MessageBody(
                         word-break: break-word;
                         overflow-wrap: break-word;
                     }
+                    body * { color: inherit !important; background: transparent !important; }
                     img, video, iframe, embed {
                         max-width: 100% !important;
                         height: auto !important;
@@ -600,9 +598,10 @@ private fun MessageBody(
                     settings.javaScriptEnabled = false
                     settings.loadWithOverviewMode = true
                     settings.useWideViewPort = true
+                    settings.domStorageEnabled = true
                     settings.layoutAlgorithm = WebSettings.LayoutAlgorithm.TEXT_AUTOSIZING
-                    settings.cacheMode = WebSettings.LOAD_NO_CACHE
-                    settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                    settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
+                    settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                     settings.loadsImagesAutomatically = true
                     setBackgroundColor(android.graphics.Color.TRANSPARENT)
                     isVerticalScrollBarEnabled = false
@@ -631,7 +630,8 @@ private fun openAttachment(context: android.content.Context, attachment: EmailAt
     try {
         val attachmentsDir = java.io.File(context.cacheDir, "attachments")
         attachmentsDir.mkdirs()
-        val file = java.io.File(attachmentsDir, attachment.name)
+        val safeName = attachment.name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+        val file = java.io.File(attachmentsDir, safeName)
         file.writeBytes(bytes)
         val uri = androidx.core.content.FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
         val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
@@ -730,7 +730,10 @@ private fun ImageAttachmentCard(
         ) {
             val bytes = imageBytes
             if (bytes != null) {
-                val bitmap = android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                val opts = android.graphics.BitmapFactory.Options().apply {
+                    inSampleSize = 2
+                }
+                val bitmap = android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
                 if (bitmap != null) {
                     androidx.compose.foundation.Image(
                         bitmap = bitmap.asImageBitmap(),
@@ -857,7 +860,7 @@ private fun FileAttachmentCard(
 private val detailDateFormat = SimpleDateFormat("MMM d, yyyy  h:mm a", Locale.getDefault())
 
 private fun displayName(from: String): String {
-    val nameMatch = Regex("""^"?([^"<]+?)"\s*<""").find(from)
+    val nameMatch = Regex("""^"?([^"<]+?)"?\s*<""").find(from)
     return nameMatch?.groupValues?.get(1)?.trim() ?: from.trim()
 }
 private fun formatDetailDate(epochMillis: Long): String {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 sealed class EmailDetailState {
-    object Loading : EmailDetailState()
     data class Success(val emails: List<Email>, val isRefreshing: Boolean = false, val refreshError: String? = null) : EmailDetailState()
     data class Error(val message: String) : EmailDetailState()
 }
@@ -48,12 +47,12 @@ class EmailDetailViewModel @Inject constructor(
         } else if (!isLoading) {
             EmailDetailState.Error("Email thread not found.")
         } else {
-            EmailDetailState.Loading
+            EmailDetailState.Success(emptyList(), isRefreshing = true)
         }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
-        initialValue = EmailDetailState.Loading
+        initialValue = EmailDetailState.Success(emptyList(), isRefreshing = true)
     )
     val isStarred: StateFlow<Boolean> = repository.getThreadEmailsFlow(threadId)
         .map { emails -> emails.any { it.isStarred } }

--- a/app/src/main/java/com/shrivatsav/monomail/worker/EmailSyncWorker.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/worker/EmailSyncWorker.kt
@@ -66,15 +66,15 @@ class EmailSyncWorker @AssistedInject constructor(
             }
             val newestThread = emailRepository.getLatestInboxThread(accountId)
             if (newestThread != null) {
-                val newTimestamp = newestThread.date.toString()
-                if (lastKnownTimestamp != null && newTimestamp != lastKnownTimestamp) {
+                val newTimestamp = newestThread.date
+                if (lastKnownTimestamp != null && newTimestamp.toString() != lastKnownTimestamp) {
                     showNotification(
                         accountId = accountId,
                         thread = newestThread,
                         notificationId = accountId.hashCode()
                     )
                 }
-                accountManager.setLastKnownEmailId(accountId, newTimestamp)
+                accountManager.setLastKnownEmailId(accountId, newTimestamp.toString())
             }
         }
         scheduleNextAdaptiveSync(applicationContext, accountManager)

--- a/app/src/main/res/raw/msal_config.json
+++ b/app/src/main/res/raw/msal_config.json
@@ -3,7 +3,7 @@
   "authorization_user_agent": "DEFAULT",
   "redirect_uri": "msauth://com.shrivatsav.monomail/E0quig71zTCyJHk4+hOUDs0dkXE=",
   "account_mode": "MULTIPLE",
-  "broker_redirect_uri_registered": false,
+  "broker_redirect_uri_registered": true,
   "authorities": [
     {
       "type": "AAD",

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">gmail.googleapis.com</domain>
+        <domain includeSubdomains="true">graph.microsoft.com</domain>
+        <domain includeSubdomains="true">login.microsoftonline.com</domain>
+        <domain includeSubdomains="true">accounts.google.com</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/test/java/com/shrivatsav/monomail/ImapThreaderTest.kt
+++ b/app/src/test/java/com/shrivatsav/monomail/ImapThreaderTest.kt
@@ -1,0 +1,56 @@
+package com.shrivatsav.monomail
+
+import com.shrivatsav.monomail.data.provider.ProviderMessage
+import com.shrivatsav.monomail.data.provider.imap.ImapRawMessage
+import com.shrivatsav.monomail.data.provider.imap.ImapThreader
+import org.junit.Test
+import org.junit.Assert.*
+
+class ImapThreaderTest {
+    private fun msg(id: String, refs: String = "", inReplyTo: String = "", date: Long = 0L) = ImapRawMessage(
+        messageId = id, references = refs, inReplyTo = inReplyTo, date = date,
+        providerMessage = ProviderMessage(id = id, threadId = id, subject = "", from = "", fromEmail = "",
+            to = "", cc = "", bcc = "", snippet = "", body = "", date = date, isRead = true, isStarred = false,
+            folders = emptySet(), attachments = emptyList())
+    )
+
+    @Test
+    fun singleMessage_returnsItself() {
+        val msgs = listOf(msg("a"))
+        val result = ImapThreader.groupByReferences(msgs)
+        assertEquals(1, result.size)
+        assertEquals("a", result.keys.first())
+    }
+
+    @Test
+    fun replyMessage_groupsUnderRoot() {
+        val msgs = listOf(msg("a"), msg("b", inReplyTo = "a"))
+        val result = ImapThreader.groupByReferences(msgs)
+        assertEquals(1, result.size)
+        assertEquals(2, result.values.first().size)
+    }
+
+    @Test
+    fun chainOfReplies_groupsUnderRoot() {
+        val msgs = listOf(msg("a"), msg("b", inReplyTo = "a"), msg("c", inReplyTo = "b"))
+        val result = ImapThreader.groupByReferences(msgs)
+        assertEquals(1, result.size)
+        assertEquals(3, result.values.first().size)
+    }
+
+    @Test
+    fun referencesHeader_usedOverInReplyTo() {
+        val msgs = listOf(msg("a"), msg("b", refs = "a", inReplyTo = "a"))
+        val result = ImapThreader.groupByReferences(msgs)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun messagesSortedChronologically() {
+        val msgs = listOf(msg("b", inReplyTo = "a", date = 200), msg("a", date = 100))
+        val result = ImapThreader.groupByReferences(msgs)
+        val ordered = result.values.first()
+        assertEquals(100, ordered[0].date)
+        assertEquals(200, ordered[1].date)
+    }
+}

--- a/app/src/test/java/com/shrivatsav/monomail/MigrationTest.kt
+++ b/app/src/test/java/com/shrivatsav/monomail/MigrationTest.kt
@@ -1,0 +1,19 @@
+package com.shrivatsav.monomail
+
+import com.shrivatsav.monomail.data.local.MIGRATION_2_3
+import com.shrivatsav.monomail.data.local.MIGRATION_3_4
+import com.shrivatsav.monomail.data.local.MIGRATION_4_5
+import org.junit.Test
+import org.junit.Assert.*
+
+class MigrationTest {
+    @Test
+    fun allMigrationsAreRegistered() {
+        val migrations = listOf(2 to 3, 3 to 4, 4 to 5)
+        val objects = listOf(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+        for ((i, m) in migrations.withIndex()) {
+            assertEquals(m.first, objects[i].startVersion)
+            assertEquals(m.second, objects[i].endVersion)
+        }
+    }
+}

--- a/app/src/test/java/com/shrivatsav/monomail/SecurityUtilTest.kt
+++ b/app/src/test/java/com/shrivatsav/monomail/SecurityUtilTest.kt
@@ -1,0 +1,24 @@
+package com.shrivatsav.monomail
+
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.Assert.*
+
+@Ignore("requires Android Keystore / EncryptedSharedPreferences — run on device or with Robolectric")
+class SecurityUtilTest {
+    @Test
+    fun encryption_roundtrip_returnsOriginal() {
+        val original = "sensitive-data-123"
+        val encrypted = com.shrivatsav.monomail.security.SecurityUtil.encryptString(original)
+        assertNotNull(encrypted)
+        assertNotEquals(original, encrypted)
+        val decrypted = com.shrivatsav.monomail.security.SecurityUtil.decryptString(encrypted)
+        assertEquals(original, decrypted)
+    }
+
+    @Test
+    fun decrypt_invalidData_returnsNull() {
+        val result = com.shrivatsav.monomail.security.SecurityUtil.decryptString("invalid-base64")
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
- S1: SMTP TLS hardening (TLSv1.2+, cert verification, starttls required)
- S2: OkHttp logging downgraded to BASIC (no token leak)
- S3: WebView MIXED_CONTENT_NEVER_ALLOW
- S4: SQLCipher passphrase zeroed after use
- S5: Decrypt returns null on failure instead of plaintext
- S6: Token validation throws on network error
- S7: network_security_config.xml for cleartext traffic pinning
- S8: e.printStackTrace() replaced with Log.e
- S9: OData filter sanitized (single-quote escape)
- S10: broker_redirect_uri_registered=true in msal_config
- S11: Attachment filename path traversal sanitized
- B1/B3-B4: Dead code, missing DB migration, robust notification IDs
- P2: Gmail limitedParallelism(5)
- P3: Token cache via AtomicReference
- P4: Narrowed ProGuard keep rules
- P5: Image downsample (inSampleSize=2)
- P9: Shared Gson instance
- P10/P12: Parallel batchMarkRead, no full folder fetch in IMAP list
- L1/L4-L5: Empty catch logging, merged OkHttp clients, displayName regex
- UX: No full-screen loader on email open (instant content)
- UX: Dark mode text color forced in WebView CSS
- UX: WebView MIXED_CONTENT_COMPATIBILITY_MODE for email images
- Tests: SecurityUtil, ImapThreader, Migration (7 tests)
- Version: 1.5b (13)