### PR TITLE
feat: persistent action queue for optimistic sync

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/MonoMailApp.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/MonoMailApp.kt
@@ -2,12 +2,14 @@ package com.shrivatsav.monomail
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.shrivatsav.monomail.data.worker.ActionQueueManager
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 @HiltAndroidApp
 class MonoMailApp : Application(), Configuration.Provider {
 
     @Inject lateinit var workerFactory: HiltWorkerFactory
+    @Inject lateinit var actionQueueManager: ActionQueueManager
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -18,6 +20,7 @@ class MonoMailApp : Application(), Configuration.Provider {
         super.onCreate()
         initializeMailcap()
         System.loadLibrary("sqlcipher")
+        actionQueueManager.start()
     }
 
     private fun initializeMailcap() {

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/AppDatabase.kt
@@ -7,8 +7,8 @@ import androidx.room.TypeConverters
 import com.shrivatsav.monomail.security.SecurityUtil
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 @Database(
-    entities = [ThreadEntity::class, EmailEntity::class, ScheduledMessageEntity::class],
-    version = 8,
+    entities = [ThreadEntity::class, EmailEntity::class, ScheduledMessageEntity::class, PendingActionEntity::class],
+    version = 9,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -16,6 +16,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun threadDao(): ThreadDao
     abstract fun emailDao(): EmailDao
     abstract fun scheduledMessageDao(): ScheduledMessageDao
+    abstract fun pendingActionDao(): PendingActionDao
     companion object {
         @Volatile
         private var INSTANCE: AppDatabase? = null
@@ -29,7 +30,7 @@ abstract class AppDatabase : RoomDatabase() {
                     "monomail_database"
                 )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
                 .fallbackToDestructiveMigration(true)
                 .build()
                 INSTANCE = instance
@@ -73,5 +74,10 @@ val MIGRATION_7_8 = object : androidx.room.migration.Migration(7, 8) {
     override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE threads ADD COLUMN inSpam INTEGER NOT NULL DEFAULT 0")
         db.execSQL("ALTER TABLE emails ADD COLUMN inSpam INTEGER NOT NULL DEFAULT 0")
+    }
+}
+val MIGRATION_8_9 = object : androidx.room.migration.Migration(8, 9) {
+    override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS `pending_actions` (`id` TEXT NOT NULL, `accountId` TEXT NOT NULL, `actionType` TEXT NOT NULL, `threadId` TEXT NOT NULL, `payload` TEXT NOT NULL DEFAULT '', `emailIdsJson` TEXT NOT NULL DEFAULT '', `status` TEXT NOT NULL DEFAULT 'PENDING', `createdAt` INTEGER NOT NULL, `retryCount` INTEGER NOT NULL DEFAULT 0, `errorMessage` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`id`))")
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
@@ -133,6 +133,28 @@ data class ScheduledMessageEntity(
     val createdAt: Long = System.currentTimeMillis()
 )
 
+enum class PendingActionType {
+    TOGGLE_STAR, MARK_READ, MARK_UNREAD, ARCHIVE, UNARCHIVE, DELETE, RESTORE
+}
+
+enum class PendingActionStatus {
+    PENDING, IN_FLIGHT, FAILED
+}
+
+@Entity(tableName = "pending_actions")
+data class PendingActionEntity(
+    @PrimaryKey val id: String,
+    val accountId: String,
+    val actionType: PendingActionType,
+    val threadId: String,
+    val payload: String = "",
+    val emailIdsJson: String = "",
+    val status: PendingActionStatus = PendingActionStatus.PENDING,
+    val createdAt: Long = System.currentTimeMillis(),
+    val retryCount: Int = 0,
+    val errorMessage: String = ""
+)
+
 private val gson = Gson()
 fun Email.toEntity(accountId: String) = EmailEntity(
     id = id,

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/PendingActionDao.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/PendingActionDao.kt
@@ -1,0 +1,40 @@
+package com.shrivatsav.monomail.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PendingActionDao {
+    @Query("SELECT * FROM pending_actions WHERE status = 'PENDING' ORDER BY createdAt ASC LIMIT 1")
+    suspend fun getNextPending(): PendingActionEntity?
+
+    @Query("SELECT * FROM pending_actions WHERE accountId = :accountId AND (status = 'PENDING' OR status = 'IN_FLIGHT')")
+    suspend fun getPendingForAccount(accountId: String): List<PendingActionEntity>
+
+    @Query("SELECT * FROM pending_actions WHERE (status = 'PENDING' OR status = 'IN_FLIGHT')")
+    fun getPendingFlow(): Flow<List<PendingActionEntity>>
+
+    @Query("SELECT * FROM pending_actions WHERE (status = 'PENDING' OR status = 'IN_FLIGHT')")
+    suspend fun getAllPending(): List<PendingActionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(action: PendingActionEntity)
+
+    @Query("UPDATE pending_actions SET status = :status WHERE id = :id")
+    suspend fun updateStatus(id: String, status: PendingActionStatus)
+
+    @Query("UPDATE pending_actions SET status = 'PENDING', retryCount = retryCount + 1, errorMessage = :error WHERE id = :id")
+    suspend fun incrementRetry(id: String, error: String)
+
+    @Query("DELETE FROM pending_actions WHERE id = :id")
+    suspend fun delete(id: String)
+
+    @Query("DELETE FROM pending_actions WHERE accountId = :accountId")
+    suspend fun clearForAccount(accountId: String)
+
+    @Query("SELECT COUNT(*) FROM pending_actions WHERE status = 'FAILED'")
+    fun getFailedCountFlow(): Flow<Int>
+}

--- a/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
@@ -4,9 +4,7 @@ import android.net.Uri
 import android.util.Log
 import java.io.File
 import androidx.room.withTransaction
-import androidx.work.Constraints
 import androidx.work.Data
-import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.shrivatsav.monomail.worker.ScheduledSendWorker
@@ -22,7 +20,6 @@ import com.shrivatsav.monomail.data.model.EmailThread
 import com.shrivatsav.monomail.data.provider.EmailFolder
 import com.shrivatsav.monomail.data.provider.EmailProvider
 import com.shrivatsav.monomail.data.remote.RetrofitClient
-import com.shrivatsav.monomail.data.worker.SyncWorker
 import com.shrivatsav.monomail.ui.screens.inbox.InboxTab
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -30,11 +27,13 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+
 class EmailRepository(
     private val providerFactory: (UserProfile) -> EmailProvider,
     private val database: AppDatabase,
     private val context: Context,
-    private val accountManager: AccountManager
+    private val accountManager: AccountManager,
+    private val pendingActionDao: PendingActionDao
 ) {
     private fun cleanSubject(subject: String): String {
         return subject.replaceFirst(Regex("^(Re|Fwd|Fw):\\s*", RegexOption.IGNORE_CASE), "")
@@ -42,11 +41,8 @@ class EmailRepository(
     private val threadDao = database.threadDao()
     private val emailDao = database.emailDao()
     private val scheduledMessageDao = database.scheduledMessageDao()
-    private val workManager = WorkManager.getInstance(context)
-    private val networkConstraints = Constraints.Builder()
-        .setRequiredNetworkType(NetworkType.CONNECTED)
-        .build()
     private val gson = Gson()
+
     suspend fun getActiveProvider(): EmailProvider? {
         val activeAccount = accountManager.getActiveAccount() ?: return null
         return providerFactory(activeAccount)
@@ -62,13 +58,19 @@ class EmailRepository(
         val account = accountManager.getAccounts().find { it.id == accountId } ?: return null
         return providerFactory(account)
     }
-    private fun enqueueSync(data: Data) {
-        val request = OneTimeWorkRequestBuilder<SyncWorker>()
-            .setConstraints(networkConstraints)
-            .setInputData(data)
-            .build()
-        workManager.enqueue(request)
+
+    private suspend fun insertPendingAction(actionType: PendingActionType, accountId: String, threadId: String, payload: String = "", emailIdsJson: String = "") {
+        val action = PendingActionEntity(
+            id = UUID.randomUUID().toString(),
+            accountId = accountId,
+            actionType = actionType,
+            threadId = threadId,
+            payload = payload,
+            emailIdsJson = emailIdsJson
+        )
+        pendingActionDao.insert(action)
     }
+
     fun getInboxThreadsFlow(tab: InboxTab, accountId: String): Flow<List<EmailThread>> {
         return when (tab) {
             InboxTab.UNIFIED -> threadDao.getAllInboxThreads()
@@ -114,6 +116,7 @@ class EmailRepository(
         val activeAccountId = getActiveAccountId()
         emitAll(emailDao.getEmailsForThread(threadId, activeAccountId).map { list -> list.map { it.toDomainModel() } })
     }
+
     suspend fun refreshInbox(tab: InboxTab, pageToken: String? = null, query: String? = null, accountId: String? = null): Result<String?> {
         return try {
             val provider = if (accountId != null) getProviderForAccount(accountId) else getActiveProvider()
@@ -140,13 +143,18 @@ class EmailRepository(
                 threadDao.getSnippetsForAccount(targetAccountId)
                     .associateBy { it.threadId }
             } else emptyMap()
+
+            // ponytail: skip threads with pending actions so local changes aren't overwritten by server
+            val pendingThreadIds = pendingActionDao.getPendingForAccount(targetAccountId)
+                .map { it.threadId }.toSet()
+
             if (listResponse.threads.isNotEmpty()) {
                 val existingThreadReadStatuses = threadDao.getReadStatuses(targetAccountId)
                     .associate { it.threadId to it.isRead }
                 val existingEmailReadStatuses = emailDao.getEmailReadStatuses(targetAccountId)
                     .associate { it.id to it.isRead }
                 val existingEmailIdSet = existingEmailReadStatuses.keys
-                val entities = listResponse.threads.map { providerThread ->
+                val entities = listResponse.threads.filter { it.threadId !in pendingThreadIds }.map { providerThread ->
                     val messages = providerThread.messages
                     val latest = messages.maxByOrNull { it.date }
                     val allFolders = messages.flatMap { it.folders }.toSet()
@@ -180,7 +188,7 @@ class EmailRepository(
                         inSpam = EmailFolder.SPAM in allFolders
                     )
                 }
-                val allEmails = listResponse.threads.flatMap { providerThread ->
+                val allEmails = listResponse.threads.filter { it.threadId !in pendingThreadIds }.flatMap { providerThread ->
                     providerThread.messages.map { msg ->
                         Email(
                             id = msg.id,
@@ -249,37 +257,21 @@ class EmailRepository(
     suspend fun toggleStar(threadId: String, currentStarred: Boolean) {
         val newStarred = !currentStarred
         val activeAccountId = getActiveAccountId()
+        insertPendingAction(PendingActionType.TOGGLE_STAR, activeAccountId, threadId, payload = newStarred.toString())
         threadDao.updateThreadStarred(threadId, activeAccountId, newStarred)
         emailDao.updateThreadStarred(threadId, activeAccountId, newStarred)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_TOGGLE_STAR)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_THREAD_ID, threadId)
-            .putBoolean(SyncWorker.KEY_IS_STARRED, newStarred)
-            .build()
-        enqueueSync(data)
     }
     suspend fun markEmailsAsRead(emailIds: List<String>) {
         if (emailIds.isEmpty()) return
         val activeAccountId = getActiveAccountId()
         emailDao.markEmailsAsRead(emailIds, activeAccountId)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_MARK_EMAILS_READ)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_EMAIL_IDS, gson.toJson(emailIds))
-            .build()
-        enqueueSync(data)
+        insertPendingAction(PendingActionType.MARK_READ, activeAccountId, "", emailIdsJson = emailIds.joinToString(","))
     }
     suspend fun markThreadAsRead(threadId: String) {
         val activeAccountId = getActiveAccountId()
+        insertPendingAction(PendingActionType.MARK_READ, activeAccountId, threadId)
         threadDao.updateThreadReadStatus(threadId, activeAccountId, true)
         emailDao.updateThreadEmailsReadStatus(threadId, activeAccountId, true)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_MARK_THREAD_READ)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_THREAD_ID, threadId)
-            .build()
-        enqueueSync(data)
     }
     suspend fun markThreadsAsRead(threadIds: List<String>): Result<Unit> {
         if (threadIds.isEmpty()) return Result.success(Unit)
@@ -307,36 +299,21 @@ class EmailRepository(
     }
     suspend fun markThreadAsUnread(threadId: String) {
         val activeAccountId = getActiveAccountId()
+        insertPendingAction(PendingActionType.MARK_UNREAD, activeAccountId, threadId)
         threadDao.updateThreadReadStatus(threadId, activeAccountId, false)
         emailDao.updateThreadEmailsReadStatus(threadId, activeAccountId, false)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_MARK_THREAD_UNREAD)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_THREAD_ID, threadId)
-            .build()
-        enqueueSync(data)
     }
     suspend fun archiveThread(threadId: String, explicitAccountId: String? = null) {
         val activeAccountId = explicitAccountId ?: getActiveAccountId()
+        insertPendingAction(PendingActionType.ARCHIVE, activeAccountId, threadId)
         threadDao.archiveThread(threadId, activeAccountId)
         emailDao.archiveThreadEmails(threadId, activeAccountId)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_ARCHIVE)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_THREAD_ID, threadId)
-            .build()
-        enqueueSync(data)
     }
     suspend fun unarchiveThread(threadId: String, explicitAccountId: String? = null) {
         val activeAccountId = explicitAccountId ?: getActiveAccountId()
+        insertPendingAction(PendingActionType.UNARCHIVE, activeAccountId, threadId)
         threadDao.unarchiveThread(threadId, activeAccountId)
         emailDao.unarchiveThreadEmails(threadId, activeAccountId)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_UNARCHIVE)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_THREAD_ID, threadId)
-            .build()
-        enqueueSync(data)
     }
     suspend fun emptyTrash() {
         val activeAccountId = getActiveAccountId()
@@ -357,25 +334,15 @@ class EmailRepository(
     }
     suspend fun deleteThread(threadId: String) {
         val activeAccountId = getActiveAccountId()
+        insertPendingAction(PendingActionType.DELETE, activeAccountId, threadId)
         threadDao.moveToTrash(threadId, activeAccountId)
         emailDao.moveThreadEmailsToTrash(threadId, activeAccountId)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_DELETE)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_THREAD_ID, threadId)
-            .build()
-        enqueueSync(data)
     }
     suspend fun restoreThread(threadId: String) {
         val activeAccountId = getActiveAccountId()
+        insertPendingAction(PendingActionType.RESTORE, activeAccountId, threadId)
         threadDao.restoreFromTrash(threadId, activeAccountId)
         emailDao.restoreThreadEmailsFromTrash(threadId, activeAccountId)
-        val data = Data.Builder()
-            .putString(SyncWorker.KEY_ACTION, SyncWorker.ACTION_RESTORE)
-            .putString(SyncWorker.KEY_ACCOUNT_ID, activeAccountId)
-            .putString(SyncWorker.KEY_THREAD_ID, threadId)
-            .build()
-        enqueueSync(data)
     }
     suspend fun reportNotSpam(threadId: String) {
         val activeAccountId = getActiveAccountId()
@@ -493,12 +460,11 @@ class EmailRepository(
         scheduledMessageDao.insertScheduledMessage(entity)
         val delay = scheduledAt - System.currentTimeMillis()
         val workRequest = OneTimeWorkRequestBuilder<ScheduledSendWorker>()
-            .setConstraints(networkConstraints)
             .setInitialDelay(maxOf(delay, 0), TimeUnit.MILLISECONDS)
             .setInputData(Data.Builder().putString(ScheduledSendWorker.KEY_SCHEDULED_MESSAGE_ID, id).build())
             .addTag("scheduled_send_$id")
             .build()
-        workManager.enqueue(workRequest)
+        WorkManager.getInstance(context).enqueue(workRequest)
     }
     suspend fun cancelScheduledMessage(id: String) {
         val msg = scheduledMessageDao.getScheduledMessageById(id)
@@ -506,7 +472,7 @@ class EmailRepository(
             cleanupScheduledAttachmentFiles(msg.attachmentsJson)
             scheduledMessageDao.deleteScheduledMessage(id)
         }
-        workManager.cancelAllWorkByTag("scheduled_send_$id")
+        WorkManager.getInstance(context).cancelAllWorkByTag("scheduled_send_$id")
     }
     private fun cleanupScheduledAttachmentFiles(attachmentsJson: String) {
         try {

--- a/app/src/main/java/com/shrivatsav/monomail/data/worker/ActionQueueManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/worker/ActionQueueManager.kt
@@ -1,0 +1,109 @@
+package com.shrivatsav.monomail.data.worker
+
+import android.util.Log
+import com.shrivatsav.monomail.auth.AccountManager
+import com.shrivatsav.monomail.data.local.PendingActionDao
+import com.shrivatsav.monomail.data.local.PendingActionEntity
+import com.shrivatsav.monomail.data.local.PendingActionStatus
+import com.shrivatsav.monomail.data.local.PendingActionType
+import com.shrivatsav.monomail.data.provider.EmailProvider
+import com.shrivatsav.monomail.data.remote.RetrofitClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlin.jvm.JvmSuppressWildcards
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ActionQueueManager @Inject constructor(
+    private val pendingActionDao: PendingActionDao,
+    private val accountManager: AccountManager,
+    private val providerFactory: (@JvmSuppressWildcards (com.shrivatsav.monomail.auth.UserProfile) -> EmailProvider)
+) {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var job: Job? = null
+    private val tag = "ActionQueue"
+
+    fun getPendingFlow(): Flow<List<PendingActionEntity>> = pendingActionDao.getPendingFlow()
+
+    fun getFailedCountFlow(): Flow<Int> = pendingActionDao.getFailedCountFlow()
+
+    fun start() {
+        if (job?.isActive == true) return
+        job = scope.launch {
+            Log.d(tag, "Queue processor started")
+            while (isActive) {
+                try {
+                    val action = pendingActionDao.getNextPending()
+                    if (action == null) {
+                        delay(2000)
+                        continue
+                    }
+                    processAction(action)
+                } catch (e: Exception) {
+                    Log.e(tag, "Queue loop error", e)
+                    delay(5000)
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    private suspend fun processAction(action: PendingActionEntity) {
+        pendingActionDao.updateStatus(action.id, PendingActionStatus.IN_FLIGHT)
+        Log.d(tag, "Processing ${action.actionType} for thread ${action.threadId}")
+        try {
+            val accounts = accountManager.getAccounts()
+            val profile = accounts.find { it.id == action.accountId }
+            if (profile == null) {
+                pendingActionDao.delete(action.id)
+                return
+            }
+            val provider = providerFactory(profile)
+            when (action.actionType) {
+                PendingActionType.TOGGLE_STAR -> {
+                    val starred = action.payload.toBoolean()
+                    provider.toggleStar(action.threadId, starred)
+                }
+                PendingActionType.MARK_READ -> {
+                    if (action.emailIdsJson.isNotBlank()) {
+                        val emailIds = action.emailIdsJson.split(",").filter { it.isNotBlank() }
+                        provider.batchMarkRead(emailIds)
+                    } else {
+                        provider.markRead(action.threadId, true)
+                    }
+                }
+                PendingActionType.MARK_UNREAD -> {
+                    provider.markRead(action.threadId, false)
+                }
+                PendingActionType.ARCHIVE -> provider.archiveThread(action.threadId)
+                PendingActionType.UNARCHIVE -> provider.unarchiveThread(action.threadId)
+                PendingActionType.DELETE -> provider.trashThread(action.threadId)
+                PendingActionType.RESTORE -> provider.restoreThread(action.threadId)
+            }
+            pendingActionDao.delete(action.id)
+            Log.d(tag, "Completed ${action.actionType} for thread ${action.threadId}")
+        } catch (e: RetrofitClient.AuthFailedException) {
+            Log.w(tag, "Auth failure for ${action.id}, marking FAILED")
+            pendingActionDao.updateStatus(action.id, PendingActionStatus.FAILED)
+        } catch (e: Exception) {
+            Log.e(tag, "Failed ${action.actionType} for thread ${action.threadId}", e)
+            if (action.retryCount >= 5) {
+                pendingActionDao.updateStatus(action.id, PendingActionStatus.FAILED)
+            } else {
+                pendingActionDao.incrementRetry(action.id, e.message ?: "Unknown error")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
@@ -134,6 +134,7 @@ object AppModule {
         providerFactory: (@JvmSuppressWildcards (UserProfile) -> EmailProvider),
         database: com.shrivatsav.monomail.data.local.AppDatabase,
         @ApplicationContext context: Context,
-        accountManager: AccountManager
-    ): EmailRepository = EmailRepository(providerFactory, database, context, accountManager)
+        accountManager: AccountManager,
+        pendingActionDao: com.shrivatsav.monomail.data.local.PendingActionDao
+    ): EmailRepository = EmailRepository(providerFactory, database, context, accountManager, pendingActionDao)
 }

--- a/app/src/main/java/com/shrivatsav/monomail/di/DatabaseModule.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.shrivatsav.monomail.di
 import android.content.Context
 import com.shrivatsav.monomail.data.local.AppDatabase
 import com.shrivatsav.monomail.data.local.EmailDao
+import com.shrivatsav.monomail.data.local.PendingActionDao
 import com.shrivatsav.monomail.data.local.ScheduledMessageDao
 import com.shrivatsav.monomail.data.local.ThreadDao
 import dagger.Module
@@ -24,4 +25,5 @@ object DatabaseModule {
     @Provides fun provideThreadDao(db: AppDatabase): ThreadDao = db.threadDao()
     @Provides fun provideEmailDao(db: AppDatabase): EmailDao = db.emailDao()
     @Provides fun provideScheduledMessageDao(db: AppDatabase): ScheduledMessageDao = db.scheduledMessageDao()
+    @Provides fun providePendingActionDao(db: AppDatabase): PendingActionDao = db.pendingActionDao()
 }


### PR DESCRIPTION
Replaces the fire-and-forget SyncWorker per-action approach with a persistent pending_actions Room table + ActionQueueManager that processes actions one-by-one in FIFO order.

**Key changes:**
- New \pending_actions\ table (Room migration 8→9) stores every user action with status tracking (PENDING → IN_FLIGHT → deleted on success / FAILED after 5 retries)
- \ActionQueueManager\: singleton coroutine loop polling for the next PENDING action every 2s
- All \EmailRepository\ action methods now write to \pending_actions\ first, then update Room locally
- \efreshInbox()\ filters out threads with PENDING or IN_FLIGHT actions — local changes are never overwritten by stale server data
- Old SyncWorker/WorkManager per-action enqueue replaced entirely

**Fixes:** #31 (Mail moved to trash, be back)