### PR TITLE
feat: add markdown rendering for plain text emails (SHR-45)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/settings/SettingsDataStore.kt
@@ -55,6 +55,7 @@ data class AppSettings(
     val smartGroupingRecentOnly: Boolean = true,
     val organizeByThread: Boolean = true,
     val loadRemoteImages: Boolean = true,
+    val renderMarkdown: Boolean = false,
     val navScale: Float = 1f,
     val undoSendEnabled: Boolean = true,
     val undoSendWindow: UndoSendWindow = UndoSendWindow.SEC_10,
@@ -83,6 +84,7 @@ class SettingsDataStore(private val context: Context) {
         val SMART_GROUPING_RECENT_ONLY = booleanPreferencesKey("smart_grouping_recent_only")
         val ORGANIZE_BY_THREAD = booleanPreferencesKey("organize_by_thread")
         val LOAD_REMOTE_IMAGES = booleanPreferencesKey("load_remote_images")
+        val RENDER_MARKDOWN = booleanPreferencesKey("render_markdown")
         val NAV_SCALE = floatPreferencesKey("nav_scale")
         val UNDO_SEND_ENABLED = booleanPreferencesKey("undo_send_enabled")
         val UNDO_SEND_WINDOW = stringPreferencesKey("undo_send_window")
@@ -110,6 +112,7 @@ class SettingsDataStore(private val context: Context) {
             smartGroupingRecentOnly = prefs[Keys.SMART_GROUPING_RECENT_ONLY] ?: true,
             organizeByThread = prefs[Keys.ORGANIZE_BY_THREAD] ?: true,
             loadRemoteImages = prefs[Keys.LOAD_REMOTE_IMAGES] ?: true,
+            renderMarkdown = prefs[Keys.RENDER_MARKDOWN] ?: false,
             navScale = prefs[Keys.NAV_SCALE] ?: 1f,
             undoSendEnabled = prefs[Keys.UNDO_SEND_ENABLED] ?: true,
             undoSendWindow = prefs[Keys.UNDO_SEND_WINDOW]?.let { UndoSendWindow.valueOf(it) } ?: UndoSendWindow.SEC_10,
@@ -177,6 +180,9 @@ class SettingsDataStore(private val context: Context) {
     }
     suspend fun setLoadRemoteImages(enabled: Boolean) {
         context.dataStore.edit { it[Keys.LOAD_REMOTE_IMAGES] = enabled }
+    }
+    suspend fun setRenderMarkdown(enabled: Boolean) {
+        context.dataStore.edit { it[Keys.RENDER_MARKDOWN] = enabled }
     }
     suspend fun setNavScale(scale: Float) {
         context.dataStore.edit { it[Keys.NAV_SCALE] = scale }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -283,6 +283,7 @@ fun NavGraph(
                     isConversationView = appSettings.organizeByThread,
                     fontScaleMultiplier = fontScaleMultiplier,
                     loadRemoteImages = appSettings.loadRemoteImages,
+                    renderMarkdown = appSettings.renderMarkdown,
                     onReply   = { to, subject, body, tid, messageId ->
                         navController.navigate(
                             Screen.Compose.createRoute(

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -91,6 +91,7 @@ fun EmailDetailScreen(
     isConversationView: Boolean = true,
     fontScaleMultiplier: Float = 1f,
     loadRemoteImages: Boolean = true,
+    renderMarkdown: Boolean = false,
     onReply: (to: String, subject: String, body: String, threadId: String, messageId: String) -> Unit = { _, _, _, _, _ -> },
     onForward: (subject: String, body: String, threadId: String, messageId: String) -> Unit = { _, _, _, _ -> },
     onFetchAttachment: suspend (String, String) -> ByteArray? = { _, _ -> null }
@@ -206,6 +207,7 @@ fun EmailDetailScreen(
                             isConversationView = isConversationView,
                             fontScaleMultiplier = fontScaleMultiplier,
                             loadRemoteImages = loadRemoteImages,
+                            renderMarkdown = renderMarkdown,
                             onReply = { onReply(latestEmail.fromEmail, latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
                             onForward = { onForward(latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
                             onFetchAttachment = onFetchAttachment
@@ -223,6 +225,7 @@ private fun ThreadConversationContent(
     isConversationView: Boolean = true,
     fontScaleMultiplier: Float = 1f,
     loadRemoteImages: Boolean = true,
+    renderMarkdown: Boolean = false,
     onReply: () -> Unit = {},
     onForward: () -> Unit = {},
     onFetchAttachment: suspend (String, String) -> ByteArray? = { _, _ -> null }
@@ -443,6 +446,7 @@ private fun ThreadConversationContent(
                                 linkColor = linkColor,
                                 fontScaleMultiplier = fontScaleMultiplier,
                                 loadRemoteImages = loadRemoteImages,
+                                renderMarkdown = renderMarkdown,
                                 onFetchAttachment = onFetchAttachment,
                                 modifier = Modifier.fillMaxWidth()
                             )
@@ -457,6 +461,7 @@ private fun ThreadConversationContent(
                     linkColor = linkColor,
                     fontScaleMultiplier = fontScaleMultiplier,
                     loadRemoteImages = loadRemoteImages,
+                    renderMarkdown = renderMarkdown,
                     onFetchAttachment = onFetchAttachment,
                     showSender = true,
                     messageCount = emails.size
@@ -525,6 +530,7 @@ private fun MessageBody(
     linkColor: String,
     fontScaleMultiplier: Float = 1f,
     loadRemoteImages: Boolean = true,
+    renderMarkdown: Boolean = false,
     onFetchAttachment: suspend (String, String) -> ByteArray?,
     showSender: Boolean = false,
     messageCount: Int = 0,
@@ -651,13 +657,20 @@ private fun MessageBody(
 
         // Images blocked banner (shown when loadRemoteImages is off and showRemoteImages is still false)
 
-        val htmlContent = remember(email.id, email.body, bgColor, textColor, linkColor, fontScaleMultiplier, showQuotedText, loadRemoteImages, showRemoteImages) {
+        val htmlContent = remember(email.id, email.body, bgColor, textColor, linkColor, fontScaleMultiplier, showQuotedText, loadRemoteImages, showRemoteImages, renderMarkdown) {
             // Determine body: preserve or strip quoted text
             val bodyText = if (showQuotedText) email.body else stripQuotedText(email.body)
 
-            // HTML-encode plain text bodies before wrapping
+            // Convert markdown to HTML for plain text bodies if enabled
             val preparedBody = if (email.bodyIsHtml) {
                 bodyText
+            } else if (renderMarkdown) {
+                try {
+                    markdownToHtml(bodyText)
+                } catch (_: Exception) {
+                    TextUtils.htmlEncode(bodyText)
+                        .replace("\n", "<br>")
+                }
             } else {
                 TextUtils.htmlEncode(bodyText)
                     .replace("\n", "<br>")
@@ -1233,4 +1246,88 @@ private fun autolinkHtml(html: String): String {
         i = tagEnd + 1
     }
     return sb.toString()
+}
+
+/**
+ * Converts a subset of Markdown syntax to HTML for WebView rendering.
+ * Handles: headers, bold, italic, inline code, code blocks, links,
+ * unordered lists, ordered lists, blockquotes, and horizontal rules.
+ */
+private fun markdownToHtml(markdown: String): String {
+    var html = markdown
+
+    // Escape HTML entities first to prevent XSS/injection
+    html = html.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+
+    // Code block (fenced) — must be before inline code
+    html = html.replace(Regex("""```(\w*)\n([\s\S]*?)```""")) { match ->
+        val code = match.groupValues[2].trimEnd()
+        "<pre><code>${code}</code></pre>"
+    }
+
+    // Indented code blocks (4 spaces at start of line)
+    html = html.replace(Regex("""(?m)^(?:    |\t)(.+)$""")) { match ->
+        "<code>${match.groupValues[1]}</code><br>"
+    }
+
+    // Headers (atx-style)
+    html = html.replace(Regex("""(?m)^##### (.+)$""")) { "<h5>${it.groupValues[1]}</h5>" }
+    html = html.replace(Regex("""(?m)^#### (.+)$""")) { "<h4>${it.groupValues[1]}</h4>" }
+    html = html.replace(Regex("""(?m)^### (.+)$""")) { "<h3>${it.groupValues[1]}</h3>" }
+    html = html.replace(Regex("""(?m)^## (.+)$""")) { "<h2>${it.groupValues[1]}</h2>" }
+    html = html.replace(Regex("""(?m)^# (.+)$""")) { "<h1>${it.groupValues[1]}</h1>" }
+
+    // Blockquotes
+    html = html.replace(Regex("""(?m)^&gt; (.*)$""")) { "<blockquote>${it.groupValues[1]}</blockquote>" }
+
+    // Horizontal rules
+    html = html.replace(Regex("""(?m)^([-*_]){3,}\s*$"""), "<hr>")
+
+    // Unordered lists
+    html = html.replace(Regex("""(?m)^[*-] (.+)$""")) { "<li>${it.groupValues[1]}</li>" }
+
+    // Ordered lists
+    html = html.replace(Regex("""(?m)^\d+\. (.+)$""")) { "<li>${it.groupValues[1]}</li>" }
+
+    // Wrap consecutive <li> in <ul> tags
+    html = html.replace(Regex("""(?:<li>.*?</li>)+""")) {
+        val listItems = it.value.split("</li>").filter { it.isNotBlank() }
+        if (listItems.size <= 1) return@replace it.value
+        "<ul>${it.value}</ul>"
+    }
+    // Fix: wrap isolated <li> items too
+    html = html.replace(Regex("""(<li>.*?</li>)(?!</li>)""")) { "<ul>${it.value}</ul>" }
+
+    // Inline code (must be after code blocks)
+    html = html.replace(Regex("""`([^`\n]+?)`""")) { "<code>${it.groupValues[1]}</code>" }
+
+    // Images — must be before links
+    html = html.replace(Regex("""!\[([^\]]*)\]\(([^)]+)\)""")) { "<img src=\"${it.groupValues[2]}\" alt=\"${it.groupValues[1]}\">" }
+
+    // Links [text](url)
+    html = html.replace(Regex("""\[([^\]]+)\]\(([^)]+)\)""")) { "<a href=\"${it.groupValues[2]}\">${it.groupValues[1]}</a>" }
+
+    // Bold
+    html = html.replace(Regex("""\*\*(.+?)\*\*""")) { "<strong>${it.groupValues[1]}</strong>" }
+    html = html.replace(Regex("""__(.+?)__""")) { "<strong>${it.groupValues[1]}</strong>" }
+
+    // Italic
+    html = html.replace(Regex("""\*(.+?)\*""")) { "<em>${it.groupValues[1]}</em>" }
+    html = html.replace(Regex("""_(.+?)_""")) { "<em>${it.groupValues[1]}</em>" }
+
+    // Strikethrough
+    html = html.replace(Regex("""~~(.+?)~~""")) { "<del>${it.groupValues[1]}</del>" }
+
+    // Line breaks (preserve double newlines as paragraph breaks, single as <br>)
+    html = html.replace(Regex("""\n\n+"""), "</p><p>")
+    html = html.replace(Regex("""\n(?!</)"""), "<br>")
+
+    // Wrap in paragraph if not already wrapped in block-level tags
+    if (!html.startsWith("<h") && !html.startsWith("<p") && !html.startsWith("<pre") && !html.startsWith("<ul") && !html.startsWith("<blockquote")) {
+        html = "<p>$html</p>"
+    }
+
+    return html
 }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsScreen.kt
@@ -123,6 +123,14 @@ fun SettingsScreen(
                     checked = settings.loadRemoteImages,
                     onCheckedChange = { viewModel.setLoadRemoteImages(it) }
                 )
+                CardDivider()
+                SettingsToggleRow(
+                    icon = Icons.Rounded.Code,
+                    title = "Render Markdown",
+                    subtitle = "Convert markdown formatting in plain text emails",
+                    checked = settings.renderMarkdown,
+                    onCheckedChange = { viewModel.setRenderMarkdown(it) }
+                )
             }
             SettingsCard {
                 SectionHeader(icon = Icons.Rounded.TouchApp, title = "Behavior")

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsViewModel.kt
@@ -46,6 +46,7 @@ class SettingsViewModel @Inject constructor(
     fun setSmartGroupingRecentOnly(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setSmartGroupingRecentOnly(enabled) }
     fun setOrganizeByThread(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setOrganizeByThread(enabled) }
     fun setLoadRemoteImages(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setLoadRemoteImages(enabled) }
+    fun setRenderMarkdown(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setRenderMarkdown(enabled) }
     fun setNavScale(scale: Float) = viewModelScope.launch { settingsDataStore.setNavScale(scale) }
     fun setUndoSendEnabled(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setUndoSendEnabled(enabled) }
     fun setUndoSendWindow(window: UndoSendWindow) = viewModelScope.launch { settingsDataStore.setUndoSendWindow(window) }


### PR DESCRIPTION
## Summary

Adds a **Render Markdown** toggle in Settings → Appearance that converts markdown formatting in plain text email bodies to styled HTML when displayed via WebView.

## Changes

- **SettingsDataStore.kt** — Added `renderMarkdown` field, key, mapping, and setter
- **SettingsViewModel.kt** — Added `setRenderMarkdown()` method
- **SettingsScreen.kt** — Added toggle row with Code icon
- **NavGraph.kt** — Wired `renderMarkdown` to the detail screen
- **EmailDetailScreen.kt** — Added `renderMarkdown` param, conditional markdown→HTML conversion, and `markdownToHtml()` utility

## Supported syntax

- Headers (# through #####)
- Bold (**text**, __text__)
- Italic (*text*, _text_)
- Inline code (`code`)
- Fenced code blocks (```)
- Links [text](url)
- Unordered and ordered lists
- Blockquotes
- Horizontal rules
- Strikethrough (~~text~~)
- Images ![alt](url)

## Notes

- Only applies to plain text emails (not HTML emails)
- Graceful fallback to plain text if parsing fails
- Off by default; user-enabled via Settings

Closes #27