### PR TITLE
fix: PGP decryption bugs and raw-blob flash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,6 +175,9 @@ dependencies {
     implementation(libs.sqlcipher)
     implementation(libs.androidx.sqlite.ktx)
 
+    // PGP — PGPainless (OpenPGP encryption)
+    implementation(libs.pgpainless.core)
+
     // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
@@ -1,0 +1,154 @@
+package com.shrivatsav.monomail.data.pgp
+
+import org.pgpainless.PGPainless
+import org.pgpainless.algorithm.KeyFlag
+import org.pgpainless.algorithm.PublicKeyAlgorithm
+import org.pgpainless.key.OpenPgpFingerprint
+import org.pgpainless.key.generation.KeySpec
+import org.pgpainless.key.generation.type.ecc.Ed25519
+import org.pgpainless.key.protection.SecretKeyRingProtector
+import org.pgpainless.util.Passphrase
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PgpKeyManager @Inject constructor(
+    private val storage: PgpKeyStorage
+) {
+    fun generateKeyPair(userId: String, passphrase: String? = null): PgpKeyInfo {
+        val keySpec = KeySpec.getBuilder(Ed25519(), KeyFlag.SIGN_DATA, KeyFlag.CERTIFY_OTHER)
+            .build()
+        val subkeySpec = KeySpec.getBuilder(Ed25519(), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE)
+            .build()
+
+        val builder = PGPainless.buildKeyRing()
+            .setPrimaryKey(keySpec)
+            .addSubkey(subkeySpec)
+            .addUserId(userId)
+
+        if (passphrase != null) {
+            builder.setPassphrase(Passphrase.fromPassword(passphrase))
+        }
+
+        val openPgpKey = builder.build()
+        val secretKeyRing = openPgpKey.pgpSecretKeyRing
+        val publicKeyRing = PGPainless.extractCertificate(secretKeyRing)
+
+        val info = keyRingToInfo(secretKeyRing, isPrivate = true)
+
+        val armoredSecret = PGPainless.asciiArmor(secretKeyRing)
+        storage.savePrivateKey(info.fingerprint, armoredSecret)
+
+        val armoredPublic = PGPainless.asciiArmor(publicKeyRing)
+        storage.savePublicKey(info.fingerprint, armoredPublic)
+
+        storage.saveKeyMetadata(info.fingerprint, info)
+        return info
+    }
+
+    fun importKey(armoredKey: String, passphrase: String? = null): PgpKeyInfo {
+        val isPrivate = armoredKey.contains("BEGIN PGP PRIVATE KEY BLOCK")
+
+        if (isPrivate) {
+            val secretKeyRing = PGPainless.readKeyRing().secretKeyRing(armoredKey)
+            val info = keyRingToInfo(secretKeyRing!!, isPrivate = true)
+
+            storage.savePrivateKey(info.fingerprint, armoredKey)
+            val publicKeyRing = PGPainless.extractCertificate(secretKeyRing!!)
+            val armoredPublic = PGPainless.asciiArmor(publicKeyRing)
+            storage.savePublicKey(info.fingerprint, armoredPublic)
+            storage.saveKeyMetadata(info.fingerprint, info)
+            return info
+        } else {
+            val publicKeyRing = PGPainless.readKeyRing().publicKeyRing(armoredKey)
+            val info = keyRingToInfo(publicKeyRing!!, isPrivate = false)
+
+            storage.savePublicKey(info.fingerprint, armoredKey)
+            storage.saveKeyMetadata(info.fingerprint, info)
+            return info
+        }
+    }
+
+    fun exportPublicKey(fingerprint: String): String? {
+        return storage.loadPublicKey(fingerprint)
+    }
+
+    fun listKeys(): List<PgpKeyInfo> {
+        return storage.loadAllMetadata().values.toList()
+    }
+
+    fun deleteKey(fingerprint: String) {
+        storage.deletePrivateKey(fingerprint)
+        storage.deletePublicKey(fingerprint)
+        storage.deleteKeyMetadata(fingerprint)
+    }
+
+    fun getPublicKeyForRecipient(email: String): ByteArray? {
+        val allKeys = listKeys().filter { it.userId.contains(email, ignoreCase = true) }
+        for (info in allKeys) {
+            val armored = storage.loadPublicKey(info.fingerprint) ?: continue
+            try {
+                val publicKeyRing = PGPainless.readKeyRing().publicKeyRing(armored)
+                return publicKeyRing!!.encoded
+            } catch (_: Exception) { continue }
+        }
+        return null
+    }
+
+    fun getPublicKeyForRecipientAsFingerprint(email: String): String? {
+        val allKeys = listKeys().filter { it.userId.contains(email, ignoreCase = true) }
+        for (info in allKeys) {
+            val armored = storage.loadPublicKey(info.fingerprint) ?: continue
+            try {
+                PGPainless.readKeyRing().publicKeyRing(armored)
+                return info.fingerprint
+            } catch (_: Exception) { continue }
+        }
+        return null
+    }
+
+    fun loadSecretKeyRing(fingerprint: String): org.bouncycastle.openpgp.PGPSecretKeyRing? {
+        val armored = storage.loadPrivateKey(fingerprint) ?: return null
+        return try {
+            PGPainless.readKeyRing().secretKeyRing(armored)
+        } catch (_: Exception) { null }
+    }
+
+    fun loadPublicKeyRing(fingerprint: String): org.bouncycastle.openpgp.PGPPublicKeyRing? {
+        val armored = storage.loadPublicKey(fingerprint) ?: return null
+        return try {
+            PGPainless.readKeyRing().publicKeyRing(armored)
+        } catch (_: Exception) { null }
+    }
+
+    private fun keyRingToInfo(
+        ring: org.bouncycastle.openpgp.PGPSecretKeyRing,
+        isPrivate: Boolean
+    ): PgpKeyInfo {
+        val info = PGPainless.inspectKeyRing(ring)
+        return PgpKeyInfo(
+            fingerprint = info.fingerprint.toString(),
+            userId = info.primaryUserId ?: "Unknown",
+            algorithm = info.algorithm.name,
+            creationDate = info.creationDate.time,
+            isPrivate = isPrivate,
+            isExpired = info.primaryKeyExpirationDate?.let { it.before(Date()) } ?: false
+        )
+    }
+
+    private fun keyRingToInfo(
+        ring: org.bouncycastle.openpgp.PGPPublicKeyRing,
+        isPrivate: Boolean
+    ): PgpKeyInfo {
+        val info = PGPainless.inspectKeyRing(ring)
+        return PgpKeyInfo(
+            fingerprint = info.fingerprint.toString(),
+            userId = info.primaryUserId ?: "Unknown",
+            algorithm = info.algorithm.name,
+            creationDate = info.creationDate.time,
+            isPrivate = isPrivate,
+            isExpired = info.primaryKeyExpirationDate?.let { it.before(Date()) } ?: false
+        )
+    }
+}

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
@@ -6,6 +6,7 @@ import org.pgpainless.algorithm.PublicKeyAlgorithm
 import org.pgpainless.key.OpenPgpFingerprint
 import org.pgpainless.key.generation.KeySpec
 import org.pgpainless.key.generation.type.ecc.Ed25519
+import org.pgpainless.key.generation.type.ecc.X25519
 import org.pgpainless.key.protection.SecretKeyRingProtector
 import org.pgpainless.util.Passphrase
 import java.util.Date
@@ -19,7 +20,7 @@ class PgpKeyManager @Inject constructor(
     fun generateKeyPair(userId: String, passphrase: String? = null): PgpKeyInfo {
         val keySpec = KeySpec.getBuilder(Ed25519(), KeyFlag.SIGN_DATA, KeyFlag.CERTIFY_OTHER)
             .build()
-        val subkeySpec = KeySpec.getBuilder(Ed25519(), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE)
+        val subkeySpec = KeySpec.getBuilder(X25519(), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE)
             .build()
 
         val builder = PGPainless.buildKeyRing()

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
@@ -1,0 +1,108 @@
+package com.shrivatsav.monomail.data.pgp
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.shrivatsav.monomail.security.SecurityUtil
+import org.pgpainless.key.protection.SecretKeyRingProtector
+import org.pgpainless.util.Passphrase
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PgpKeyStorage @Inject constructor(
+    private val context: Context
+) {
+    // Encrypted metadata storage (fingerprint → PgpKeyInfo)
+    private val gson = Gson()
+
+    private val prefs: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            "pgp_key_metadata",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    private val keysDir: File by lazy {
+        File(context.filesDir, "pgp/keys").also { it.mkdirs() }
+    }
+
+    private val publicKeysDir: File by lazy {
+        File(context.filesDir, "pgp/public").also { it.mkdirs() }
+    }
+
+    fun savePrivateKey(fingerprint: String, armoredKey: String) {
+        val encrypted = SecurityUtil.encryptString(armoredKey)
+        File(keysDir, "$fingerprint.asc").writeText(encrypted)
+    }
+
+    fun loadPrivateKey(fingerprint: String): String? {
+        val file = File(keysDir, "$fingerprint.asc")
+        if (!file.exists()) return null
+        val encrypted = file.readText()
+        return SecurityUtil.decryptString(encrypted)
+    }
+
+    fun deletePrivateKey(fingerprint: String) {
+        File(keysDir, "$fingerprint.asc").delete()
+    }
+
+    fun savePublicKey(fingerprint: String, armoredKey: String) {
+        File(publicKeysDir, "$fingerprint.asc").writeText(armoredKey)
+    }
+
+    fun loadPublicKey(fingerprint: String): String? {
+        val file = File(publicKeysDir, "$fingerprint.asc")
+        if (!file.exists()) return null
+        return file.readText()
+    }
+
+    fun deletePublicKey(fingerprint: String) {
+        File(publicKeysDir, "$fingerprint.asc").delete()
+    }
+
+    fun saveKeyMetadata(fingerprint: String, info: PgpKeyInfo) {
+        val all = loadAllMetadata().toMutableMap()
+        all[info.userId] = info
+        prefs.edit().putString(PREF_KEYS, gson.toJson(all)).apply()
+    }
+
+    fun loadKeyMetadata(fingerprint: String): PgpKeyInfo? {
+        return loadAllMetadata().values.find { it.fingerprint == fingerprint }
+    }
+
+    fun loadAllMetadata(): Map<String, PgpKeyInfo> {
+        val json = prefs.getString(PREF_KEYS, null) ?: return emptyMap()
+        return try {
+            val type = object : TypeToken<Map<String, PgpKeyInfo>>() {}.type
+            gson.fromJson(json, type) ?: emptyMap()
+        } catch (e: Exception) {
+            emptyMap()
+        }
+    }
+
+    fun deleteKeyMetadata(fingerprint: String) {
+        val all = loadAllMetadata().toMutableMap()
+        all.entries.removeIf { it.value.fingerprint == fingerprint }
+        prefs.edit().putString(PREF_KEYS, gson.toJson(all)).apply()
+    }
+
+    fun keyFileExists(fingerprint: String): Boolean {
+        return File(keysDir, "$fingerprint.asc").exists() ||
+                File(publicKeysDir, "$fingerprint.asc").exists()
+    }
+
+    companion object {
+        private const val PREF_KEYS = "pgp_keys_metadata"
+    }
+}

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
@@ -73,7 +73,7 @@ class PgpKeyStorage @Inject constructor(
 
     fun saveKeyMetadata(fingerprint: String, info: PgpKeyInfo) {
         val all = loadAllMetadata().toMutableMap()
-        all[info.userId] = info
+        all[fingerprint] = info
         prefs.edit().putString(PREF_KEYS, gson.toJson(all)).apply()
     }
 
@@ -100,6 +100,14 @@ class PgpKeyStorage @Inject constructor(
     fun keyFileExists(fingerprint: String): Boolean {
         return File(keysDir, "$fingerprint.asc").exists() ||
                 File(publicKeysDir, "$fingerprint.asc").exists()
+    }
+
+    fun publicKeyExists(fingerprint: String): Boolean {
+        return File(publicKeysDir, "$fingerprint.asc").exists()
+    }
+
+    fun privateKeyExists(fingerprint: String): Boolean {
+        return File(keysDir, "$fingerprint.asc").exists()
     }
 
     companion object {

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
@@ -1,0 +1,155 @@
+package com.shrivatsav.monomail.data.pgp
+
+import org.bouncycastle.openpgp.PGPException
+import org.pgpainless.PGPainless
+import org.pgpainless.decryption_verification.ConsumerOptions
+import org.pgpainless.encryption_signing.EncryptionOptions
+import org.pgpainless.encryption_signing.ProducerOptions
+import org.pgpainless.encryption_signing.SigningOptions
+import org.pgpainless.key.protection.SecretKeyRingProtector
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PgpManager @Inject constructor(
+    private val keyManager: PgpKeyManager,
+    private val storage: PgpKeyStorage
+) {
+    fun isPgpMessage(body: String): Boolean {
+        return body.contains("-----BEGIN PGP MESSAGE-----") ||
+                body.contains("multipart/encrypted") ||
+                body.contains("application/pgp-encrypted") ||
+                body.contains("-----BEGIN PGP SIGNED MESSAGE-----")
+    }
+
+    fun decryptBody(emailBody: String, fingerprintHint: String? = null): PgpDecryptionResult? {
+        if (!isPgpMessage(emailBody)) return null
+
+        val fingerprints = if (fingerprintHint != null) {
+            listOf(fingerprintHint)
+        } else {
+            keyManager.listKeys()
+                .filter { it.isPrivate }
+                .map { it.fingerprint }
+        }
+
+        for (fp in fingerprints) {
+            try {
+                val armoredSecret = storage.loadPrivateKey(fp) ?: continue
+                val secretKeyRing = try {
+                    PGPainless.readKeyRing().secretKeyRing(armoredSecret)!!
+                } catch (_: Exception) { continue }
+
+                val protector = SecretKeyRingProtector.unprotectedKeys()
+
+                val consumerOptions = ConsumerOptions.get()
+                    .addDecryptionKey(secretKeyRing, protector)
+
+                val decryptionStream = PGPainless.decryptAndOrVerify()
+                    .onInputStream(ByteArrayInputStream(emailBody.toByteArray()))
+                    .withOptions(consumerOptions)
+
+                val decryptedBytes = decryptionStream.readBytes()
+                decryptionStream.close()
+
+                val decrypted = decryptedBytes.toString(Charsets.UTF_8)
+
+                val metadata = decryptionStream.metadata
+                val signatures = mutableListOf<PgpSignature>()
+
+                for (sig in metadata.verifiedSignatures) {
+                    signatures.add(
+                        PgpSignature(
+                            isValid = true,
+                            signer = sig.signingKey?.toString() ?: "Unknown"
+                        )
+                    )
+                }
+
+                return PgpDecryptionResult(
+                    decryptedBody = decrypted,
+                    signatures = signatures.ifEmpty { null }
+                )
+            } catch (_: Exception) {
+                continue
+            }
+        }
+
+        return null
+    }
+
+    fun encryptBody(
+        plaintext: String,
+        toAddresses: List<String>
+    ): PgpEncryptionResult? {
+        val recipientRings = toAddresses.mapNotNull { address ->
+            val fp = keyManager.getPublicKeyForRecipientAsFingerprint(address) ?: return@mapNotNull null
+            val armored = storage.loadPublicKey(fp) ?: return@mapNotNull null
+            try {
+                PGPainless.readKeyRing().publicKeyRing(armored)
+            } catch (_: Exception) { null }
+        }
+
+        if (recipientRings.isEmpty()) return null
+
+        try {
+            val encryptionOptions = EncryptionOptions.get()
+            for (ring in recipientRings) {
+                encryptionOptions.addRecipient(ring)
+            }
+
+            val producerOptions = ProducerOptions.encrypt(encryptionOptions)
+            val outputStream = ByteArrayOutputStream()
+
+            val encryptionStream = PGPainless.encryptAndOrSign()
+                .onOutputStream(outputStream)
+                .withOptions(producerOptions)
+
+            encryptionStream.write(plaintext.toByteArray())
+            encryptionStream.close()
+
+            val encrypted = outputStream.toString(Charsets.UTF_8.name())
+            return PgpEncryptionResult(encryptedBody = encrypted)
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    fun signBody(body: String, fingerprint: String): String? {
+        val armoredSecret = storage.loadPrivateKey(fingerprint) ?: return null
+        val secretKeyRing = try {
+            PGPainless.readKeyRing().secretKeyRing(armoredSecret)!!
+        } catch (_: Exception) { return null }
+
+        try {
+            val protector = SecretKeyRingProtector.unprotectedKeys()
+
+            val signingOptions = SigningOptions.get()
+                .addInlineSignature(protector, secretKeyRing)
+
+            val producerOptions = ProducerOptions.sign(signingOptions)
+            val outputStream = ByteArrayOutputStream()
+
+            val signingStream = PGPainless.encryptAndOrSign()
+                .onOutputStream(outputStream)
+                .withOptions(producerOptions)
+
+            signingStream.write(body.toByteArray())
+            signingStream.close()
+
+            return outputStream.toString(Charsets.UTF_8.name())
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    fun getAvailableEncryptionKeys(): List<PgpKeyInfo> {
+        return keyManager.listKeys().filter { !it.isPrivate }
+    }
+
+    fun getAvailableSigningKeys(): List<PgpKeyInfo> {
+        return keyManager.listKeys().filter { it.isPrivate }
+    }
+}

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
@@ -145,6 +145,57 @@ class PgpManager @Inject constructor(
         }
     }
 
+    fun encryptAndSignBody(
+        plaintext: String,
+        toAddresses: List<String>,
+        signingFingerprint: String? = null
+    ): PgpEncryptionResult? {
+        val recipientRings = toAddresses.mapNotNull { address ->
+            val fp = keyManager.getPublicKeyForRecipientAsFingerprint(address) ?: return@mapNotNull null
+            val armored = storage.loadPublicKey(fp) ?: return@mapNotNull null
+            try {
+                PGPainless.readKeyRing().publicKeyRing(armored)
+            } catch (_: Exception) { null }
+        }
+
+        if (recipientRings.isEmpty()) return null
+
+        try {
+            val encryptionOptions = EncryptionOptions.get()
+            for (ring in recipientRings) {
+                encryptionOptions.addRecipient(ring)
+            }
+
+            val producerOptions: ProducerOptions = if (signingFingerprint != null) {
+                val armoredSecret = storage.loadPrivateKey(signingFingerprint) ?: return null
+                val secretKeyRing = try {
+                    PGPainless.readKeyRing().secretKeyRing(armoredSecret)!!
+                } catch (_: Exception) { return null }
+
+                val protector = SecretKeyRingProtector.unprotectedKeys()
+                val signingOptions = SigningOptions.get()
+                    .addInlineSignature(protector, secretKeyRing)
+
+                ProducerOptions.signAndEncrypt(encryptionOptions, signingOptions)
+            } else {
+                ProducerOptions.encrypt(encryptionOptions)
+            }
+
+            val outputStream = ByteArrayOutputStream()
+            val encryptionStream = PGPainless.encryptAndOrSign()
+                .onOutputStream(outputStream)
+                .withOptions(producerOptions)
+
+            encryptionStream.write(plaintext.toByteArray())
+            encryptionStream.close()
+
+            val encrypted = outputStream.toString(Charsets.UTF_8.name())
+            return PgpEncryptionResult(encryptedBody = encrypted)
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
     fun getAvailableEncryptionKeys(): List<PgpKeyInfo> {
         return keyManager.listKeys().filter { !it.isPrivate }
     }

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
@@ -1,5 +1,6 @@
 package com.shrivatsav.monomail.data.pgp
 
+import android.util.Log
 import org.bouncycastle.openpgp.PGPException
 import org.pgpainless.PGPainless
 import org.pgpainless.decryption_verification.ConsumerOptions
@@ -20,8 +21,7 @@ class PgpManager @Inject constructor(
     fun isPgpMessage(body: String): Boolean {
         return body.contains("-----BEGIN PGP MESSAGE-----") ||
                 body.contains("multipart/encrypted") ||
-                body.contains("application/pgp-encrypted") ||
-                body.contains("-----BEGIN PGP SIGNED MESSAGE-----")
+                body.contains("application/pgp-encrypted")
     }
 
     fun decryptBody(emailBody: String, fingerprintHint: String? = null): PgpDecryptionResult? {
@@ -31,16 +31,24 @@ class PgpManager @Inject constructor(
             listOf(fingerprintHint)
         } else {
             keyManager.listKeys()
-                .filter { it.isPrivate }
+                .filter { storage.privateKeyExists(it.fingerprint) }
                 .map { it.fingerprint }
         }
 
         for (fp in fingerprints) {
             try {
-                val armoredSecret = storage.loadPrivateKey(fp) ?: continue
+                val armoredSecret = storage.loadPrivateKey(fp)
+                if (armoredSecret == null) {
+                    Log.d("PgpManager", "No private key file for $fp, checking storage...")
+                    continue
+                }
                 val secretKeyRing = try {
-                    PGPainless.readKeyRing().secretKeyRing(armoredSecret)!!
-                } catch (_: Exception) { continue }
+                    PGPainless.readKeyRing().secretKeyRing(armoredSecret)
+                        ?: throw NullPointerException("readKeyRing returned null")
+                } catch (e: Exception) {
+                    Log.e("PgpManager", "Failed to parse private key ring for $fp", e)
+                    continue
+                }
 
                 val protector = SecretKeyRingProtector.unprotectedKeys()
 
@@ -72,7 +80,8 @@ class PgpManager @Inject constructor(
                     decryptedBody = decrypted,
                     signatures = signatures.ifEmpty { null }
                 )
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.e("PgpManager", "Decryption failed for $fp", e)
                 continue
             }
         }
@@ -197,10 +206,10 @@ class PgpManager @Inject constructor(
     }
 
     fun getAvailableEncryptionKeys(): List<PgpKeyInfo> {
-        return keyManager.listKeys().filter { !it.isPrivate }
+        return keyManager.listKeys().filter { storage.publicKeyExists(it.fingerprint) }
     }
 
     fun getAvailableSigningKeys(): List<PgpKeyInfo> {
-        return keyManager.listKeys().filter { it.isPrivate }
+        return keyManager.listKeys().filter { storage.privateKeyExists(it.fingerprint) }
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpModels.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpModels.kt
@@ -1,0 +1,25 @@
+package com.shrivatsav.monomail.data.pgp
+
+data class PgpKeyInfo(
+    val fingerprint: String,
+    val userId: String,
+    val algorithm: String,
+    val creationDate: Long,
+    val isPrivate: Boolean,
+    val isExpired: Boolean
+)
+
+data class PgpSignature(
+    val isValid: Boolean,
+    val signer: String
+)
+
+data class PgpDecryptionResult(
+    val decryptedBody: String,
+    val signatures: List<PgpSignature>? = null
+)
+
+data class PgpEncryptionResult(
+    val encryptedBody: String,
+    val contentType: String = "multipart/encrypted; protocol=\"application/pgp-encrypted\""
+)

--- a/app/src/main/java/com/shrivatsav/monomail/di/PgpModule.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/di/PgpModule.kt
@@ -1,0 +1,33 @@
+package com.shrivatsav.monomail.di
+
+import android.content.Context
+import com.shrivatsav.monomail.data.pgp.PgpKeyManager
+import com.shrivatsav.monomail.data.pgp.PgpKeyStorage
+import com.shrivatsav.monomail.data.pgp.PgpManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PgpModule {
+
+    @Provides @Singleton
+    fun providePgpKeyStorage(
+        @ApplicationContext context: Context
+    ): PgpKeyStorage = PgpKeyStorage(context)
+
+    @Provides @Singleton
+    fun providePgpKeyManager(
+        storage: PgpKeyStorage
+    ): PgpKeyManager = PgpKeyManager(storage)
+
+    @Provides @Singleton
+    fun providePgpManager(
+        keyManager: PgpKeyManager,
+        storage: PgpKeyStorage
+    ): PgpManager = PgpManager(keyManager, storage)
+}

--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -46,6 +46,7 @@ import com.shrivatsav.monomail.ui.screens.inbox.InboxScreen
 import com.shrivatsav.monomail.ui.screens.inbox.InboxViewModel
 import com.shrivatsav.monomail.ui.screens.scheduled.ScheduledMessagesScreen
 import com.shrivatsav.monomail.ui.screens.scheduled.ScheduledMessagesViewModel
+import com.shrivatsav.monomail.ui.screens.pgp.PgpKeyManagementScreen
 import com.shrivatsav.monomail.ui.screens.settings.SettingsScreen
 import com.shrivatsav.monomail.ui.screens.settings.SettingsViewModel
 import java.net.URLDecoder
@@ -76,6 +77,7 @@ sealed class Screen(val route: String) {
     object Legal : Screen("legal/{type}") {
         fun createRoute(type: String) = "legal/$type"
     }
+    object PgpKeys : Screen("pgp_keys")
 }
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -252,7 +254,15 @@ fun NavGraph(
                     onNavigateToLegal = { type ->
                         navController.navigate(Screen.Legal.createRoute(type)) { launchSingleTop = true }
                     },
+                    onNavigateToPgpKeys = {
+                        navController.navigate(Screen.PgpKeys.route) { launchSingleTop = true }
+                    },
                     accountCount = accounts.size
+                )
+            }
+            composable(Screen.PgpKeys.route) {
+                PgpKeyManagementScreen(
+                    onNavigateBack = { navController.popBackStack() }
                 )
             }
             composable(

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/compose/ComposeScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/compose/ComposeScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.material.icons.rounded.AttachFile
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.FormatBold
 import androidx.compose.material.icons.rounded.FormatItalic
 import androidx.compose.material.icons.rounded.FormatUnderlined
@@ -272,6 +274,31 @@ fun ComposeScreen(
                                     }
                                 }
                             }
+                        }
+                    }
+                    // PGP encrypt/sign toggles
+                    if (state.hasEncryptionKeys || state.hasSigningKeys) {
+                        IconButton(
+                            onClick = { viewModel.toggleEncrypt() },
+                            enabled = state.hasEncryptionKeys
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Lock,
+                                contentDescription = "Encrypt",
+                                tint = if (state.encryptEnabled) MaterialTheme.colorScheme.primary
+                                       else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                            )
+                        }
+                        IconButton(
+                            onClick = { viewModel.toggleSign() },
+                            enabled = state.hasSigningKeys
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Edit,
+                                contentDescription = "Sign",
+                                tint = if (state.signEnabled) MaterialTheme.colorScheme.primary
+                                       else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                            )
                         }
                     }
                     if (state.isSending) {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/compose/ComposeViewModel.kt
@@ -7,6 +7,8 @@ import com.shrivatsav.monomail.ScheduledEmailEvent
 import com.shrivatsav.monomail.SentEmailEvent
 import com.shrivatsav.monomail.auth.AuthManager
 import com.shrivatsav.monomail.data.model.EmailAttachment
+import com.shrivatsav.monomail.data.pgp.PgpManager
+import com.shrivatsav.monomail.data.pgp.PgpKeyInfo
 import com.shrivatsav.monomail.data.provider.SendAsAlias
 import com.shrivatsav.monomail.data.repository.ContactSuggestionProvider
 import com.shrivatsav.monomail.data.repository.EmailRepository
@@ -45,7 +47,11 @@ data class ComposeUiState(
     val attachments: List<EmailAttachment> = emptyList(),
     val showConfirmSendDialog: Boolean = false,
     val showSchedulePicker: Boolean = false,
-    val scheduledAt: Long? = null
+    val scheduledAt: Long? = null,
+    val encryptEnabled: Boolean = false,
+    val signEnabled: Boolean = false,
+    val hasEncryptionKeys: Boolean = false,
+    val hasSigningKeys: Boolean = false
 )
 
 @HiltViewModel
@@ -56,6 +62,8 @@ class ComposeViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val sentEmailEvents: MutableSharedFlow<SentEmailEvent>,
     private val scheduledEmailEvents: MutableSharedFlow<ScheduledEmailEvent>,
+    private val pgpManager: PgpManager,
+    private val pgpKeyManager: com.shrivatsav.monomail.data.pgp.PgpKeyManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -96,6 +104,15 @@ class ComposeViewModel @Inject constructor(
     private var confirmBeforeSending = false
 
     init {
+        // Load PGP key availability
+        viewModelScope.launch {
+            val encKeys = pgpManager.getAvailableEncryptionKeys()
+            val sigKeys = pgpManager.getAvailableSigningKeys()
+            _state.value = _state.value.copy(
+                hasEncryptionKeys = encKeys.isNotEmpty(),
+                hasSigningKeys = sigKeys.isNotEmpty()
+            )
+        }
         viewModelScope.launch {
             settingsDataStore.settingsFlow.collect { settings ->
                 confirmBeforeSending = settings.confirmBeforeSending
@@ -161,6 +178,14 @@ class ComposeViewModel @Inject constructor(
 
     fun dismissFromDropdown() {
         _state.value = _state.value.copy(showFromDropdown = false)
+    }
+
+    fun toggleEncrypt() {
+        _state.value = _state.value.copy(encryptEnabled = !_state.value.encryptEnabled)
+    }
+
+    fun toggleSign() {
+        _state.value = _state.value.copy(signEnabled = !_state.value.signEnabled)
     }
 
     fun updateTo(value: String) {
@@ -248,13 +273,16 @@ class ComposeViewModel @Inject constructor(
                     append("</blockquote>")
                 }
             }
+            val finalBody = if (current.encryptEnabled || current.signEnabled) {
+                applyPgp(current, fullBody) ?: return@launch
+            } else fullBody
             val result = repository.sendEmail(
                 from = current.from,
                 to = current.to,
                 cc = current.cc,
                 bcc = current.bcc,
                 subject = current.subject,
-                body = fullBody,
+                body = finalBody,
                 threadId = current.threadId,
                 inReplyToMessageId = current.inReplyToMessageId,
                 references = current.references,
@@ -290,6 +318,11 @@ class ComposeViewModel @Inject constructor(
         viewModelScope.launch {
             val sId = scheduledMessageId
             if (!sId.isNullOrEmpty()) repository.cancelScheduledMessage(sId)
+
+            val finalBody = if (current.encryptEnabled || current.signEnabled) {
+                applyPgp(current, current.body) ?: return@launch
+            } else current.body
+
             val cachedAttachments = repository.copyAttachmentsToCache(
                 "schedule_${System.currentTimeMillis()}",
                 current.attachments
@@ -300,7 +333,7 @@ class ComposeViewModel @Inject constructor(
                 fromEmail = current.from,
                 to = current.to,
                 subject = current.subject,
-                body = current.body,
+                body = finalBody,
                 scheduledAt = scheduledAt,
                 cc = current.cc,
                 bcc = current.bcc,
@@ -316,6 +349,61 @@ class ComposeViewModel @Inject constructor(
             )
             _state.value = _state.value.copy(isSent = true)
         }
+    }
+
+    /** Apply PGP encryption and/or signing. Returns the transformed body or null on failure (sets error). */
+    private suspend fun applyPgp(current: ComposeUiState, bodyText: String): String? {
+        return if (current.encryptEnabled) {
+            val recipients = parseRecipients(current.to, current.cc, current.bcc)
+            if (recipients.isEmpty()) {
+                _state.value = current.copy(isSending = false, error = "No valid recipient addresses for encryption")
+                return null
+            }
+            val signingFp = if (current.signEnabled) getBestSigningKey() else null
+            val result = if (signingFp != null) {
+                pgpManager.encryptAndSignBody(bodyText, recipients, signingFp)
+            } else {
+                pgpManager.encryptBody(bodyText, recipients)
+            }
+            if (result == null) {
+                _state.value = current.copy(
+                    isSending = false,
+                    error = "Missing PGP key for one or more recipients. Import their public key first."
+                )
+                return null
+            }
+            result.encryptedBody
+        } else if (current.signEnabled) {
+            val signingFp = getBestSigningKey()
+            if (signingFp == null) {
+                _state.value = current.copy(
+                    isSending = false,
+                    error = "No private key available for signing. Generate or import one in Settings > PGP Keys."
+                )
+                return null
+            }
+            pgpManager.signBody(bodyText, signingFp) ?: run {
+                _state.value = current.copy(isSending = false, error = "Failed to sign message")
+                return null
+            }
+        } else bodyText
+    }
+
+    private fun getBestSigningKey(): String? {
+        val keys = pgpManager.getAvailableSigningKeys()
+        if (keys.isEmpty()) return null
+        val currentEmail = authManager.currentUser?.email ?: ""
+        val matching = keys.find { it.userId.contains(currentEmail, ignoreCase = true) }
+        return matching?.fingerprint ?: keys.first().fingerprint
+    }
+
+    private fun parseRecipients(vararg fields: String): List<String> {
+        val emailRegex = Regex("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
+        return fields.flatMap { field ->
+            field.split(",").mapNotNull { part ->
+                emailRegex.find(part.trim())?.value?.lowercase()
+            }
+        }.distinct()
     }
 
     fun cancelSchedule() {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -45,8 +45,11 @@ import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Image
 import androidx.compose.material.icons.rounded.ImageNotSupported
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.LinearProgressIndicator
@@ -78,6 +81,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.shrivatsav.monomail.data.model.EmailAttachmentInfo
 import com.shrivatsav.monomail.data.model.Email
+import com.shrivatsav.monomail.data.pgp.PgpDecryptionResult
 import com.shrivatsav.monomail.util.HtmlSanitizer
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -99,6 +103,7 @@ fun EmailDetailScreen(
     val renderMarkdown by viewModel.renderMarkdown.collectAsState()
     val state by viewModel.state.collectAsState()
     val isStarred by viewModel.isStarred.collectAsState()
+    val decryptedBodies by viewModel.decryptedBodies.collectAsState()
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         contentWindowInsets = WindowInsets(
@@ -202,15 +207,17 @@ fun EmailDetailScreen(
                         }
                     } else {
                         val latestEmail = emails.last()
+                        val latestBody = decryptedBodies[latestEmail.id]?.decryptedBody ?: latestEmail.body
                         ThreadConversationContent(
                             emails = emails,
+                            decryptedBodies = decryptedBodies,
                             modifier = Modifier.weight(1f),
                             isConversationView = isConversationView,
                             fontScaleMultiplier = fontScaleMultiplier,
                             loadRemoteImages = loadRemoteImages,
                             renderMarkdown = renderMarkdown,
-                            onReply = { onReply(latestEmail.fromEmail, latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
-                            onForward = { onForward(latestEmail.subject, latestEmail.body, latestEmail.threadId, latestEmail.id) },
+                            onReply = { onReply(latestEmail.fromEmail, latestEmail.subject, latestBody, latestEmail.threadId, latestEmail.id) },
+                            onForward = { onForward(latestEmail.subject, latestBody, latestEmail.threadId, latestEmail.id) },
                             onFetchAttachment = onFetchAttachment
                         )
                     }
@@ -222,6 +229,7 @@ fun EmailDetailScreen(
 @Composable
 private fun ThreadConversationContent(
     emails: List<Email>,
+    decryptedBodies: Map<String, PgpDecryptionResult> = emptyMap(),
     modifier: Modifier = Modifier,
     isConversationView: Boolean = true,
     fontScaleMultiplier: Float = 1f,
@@ -442,6 +450,7 @@ private fun ThreadConversationContent(
                             }
                             MessageBody(
                                 email = email,
+                                decryptedResult = decryptedBodies[email.id],
                                 bgColor = bgColor,
                                 textColor = textColor,
                                 linkColor = linkColor,
@@ -457,6 +466,7 @@ private fun ThreadConversationContent(
             } else {
                 MessageBody(
                     email = email,
+                    decryptedResult = decryptedBodies[email.id],
                     bgColor = bgColor,
                     textColor = textColor,
                     linkColor = linkColor,
@@ -526,6 +536,7 @@ private fun ThreadConversationContent(
 @Composable
 private fun MessageBody(
     email: Email,
+    decryptedResult: PgpDecryptionResult? = null,
     bgColor: String,
     textColor: String,
     linkColor: String,
@@ -537,18 +548,68 @@ private fun MessageBody(
     messageCount: Int = 0,
     modifier: Modifier = Modifier
 ) {
+    val bodyText = decryptedResult?.decryptedBody ?: email.body
+    val bodyIsHtml = decryptedResult?.decryptedBody != null && email.bodyIsHtml
     Column(modifier = modifier) {
+        // Encryption badge
+        if (decryptedResult != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 4.dp)
+                    .background(
+                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
+                        RoundedCornerShape(6.dp)
+                    )
+                    .padding(horizontal = 10.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Lock,
+                    contentDescription = "Encrypted",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Encrypted",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                val sigs = decryptedResult.signatures
+                if (!sigs.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.width(12.dp))
+                    sigs.forEach { sig ->
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(
+                            imageVector = if (sig.isValid) Icons.Rounded.CheckCircle else Icons.Rounded.Warning,
+                            contentDescription = if (sig.isValid) "Valid signature" else "Invalid signature",
+                            tint = if (sig.isValid) MaterialTheme.colorScheme.primary
+                                   else MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Text(
+                            text = sig.signer,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+        }
     val fontSize = (15f * fontScaleMultiplier).coerceIn(10f, 28f)
     val smallFontSize = (13f * fontScaleMultiplier).coerceIn(9f, 24f)
     var showQuotedText by remember { mutableStateOf(false) }
     var showRemoteImages by remember { mutableStateOf(false) }
-    val hasQuotedText = remember(email.body) {
-        email.body.contains("<blockquote", ignoreCase = true) ||
-        email.body.contains("gmail_quote", ignoreCase = true) ||
-        email.body.contains("gmail_extra", ignoreCase = true) ||
-        email.body.contains("yahoo_quoted", ignoreCase = true) ||
-        email.body.contains("moz-cite-prefix", ignoreCase = true) ||
-        email.body.contains("On ", ignoreCase = true) && email.body.contains(" wrote:", ignoreCase = true)
+    val hasQuotedText = remember(bodyText) {
+        bodyText.contains("<blockquote", ignoreCase = true) ||
+        bodyText.contains("gmail_quote", ignoreCase = true) ||
+        bodyText.contains("gmail_extra", ignoreCase = true) ||
+        bodyText.contains("yahoo_quoted", ignoreCase = true) ||
+        bodyText.contains("moz-cite-prefix", ignoreCase = true) ||
+        bodyText.contains("On ", ignoreCase = true) && bodyText.contains(" wrote:", ignoreCase = true)
     }
     if (showSender) {
         val isMsgUnread = !email.isRead
@@ -658,22 +719,22 @@ private fun MessageBody(
 
         // Images blocked banner (shown when loadRemoteImages is off and showRemoteImages is still false)
 
-        val htmlContent = remember(email.id, email.body, bgColor, textColor, linkColor, fontScaleMultiplier, showQuotedText, loadRemoteImages, showRemoteImages, renderMarkdown) {
+        val htmlContent = remember(email.id, bodyText, bgColor, textColor, linkColor, fontScaleMultiplier, showQuotedText, loadRemoteImages, showRemoteImages, renderMarkdown) {
             // Determine body: preserve or strip quoted text
-            val bodyText = if (showQuotedText) email.body else stripQuotedText(email.body)
+            val displayBody = if (showQuotedText) bodyText else stripQuotedText(bodyText)
 
             // Convert markdown to HTML for plain text bodies if enabled
-            val preparedBody = if (email.bodyIsHtml) {
-                bodyText
+            val preparedBody = if (bodyIsHtml) {
+                displayBody
             } else if (renderMarkdown) {
                 try {
-                    markdownToHtml(bodyText)
+                    markdownToHtml(displayBody)
                 } catch (_: Exception) {
-                    TextUtils.htmlEncode(bodyText)
+                    TextUtils.htmlEncode(displayBody)
                         .replace("\n", "<br>")
                 }
             } else {
-                TextUtils.htmlEncode(bodyText)
+                TextUtils.htmlEncode(displayBody)
                     .replace("\n", "<br>")
             }
 
@@ -771,8 +832,8 @@ private fun MessageBody(
 
         // "Images blocked" banner — only shown when remote images are disabled by setting
         if (!loadRemoteImages && !showRemoteImages) {
-            val hasExternalImages = remember(email.body) {
-                email.body.contains("""src="http""", ignoreCase = true)
+            val hasExternalImages = remember(bodyText) {
+                bodyText.contains("""src="http""", ignoreCase = true)
             }
             if (hasExternalImages) {
                 Row(

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -548,8 +548,11 @@ private fun MessageBody(
     messageCount: Int = 0,
     modifier: Modifier = Modifier
 ) {
-    val bodyText = decryptedResult?.decryptedBody ?: email.body
-    val bodyIsHtml = decryptedResult?.decryptedBody != null && email.bodyIsHtml
+    val isEncryptedBlob = decryptedResult == null &&
+            (email.body.contains("-----BEGIN PGP MESSAGE-----") ||
+             email.body.contains("multipart/encrypted"))
+    val bodyText = if (isEncryptedBlob) "" else (decryptedResult?.decryptedBody ?: email.body)
+    val bodyIsHtml = if (isEncryptedBlob) false else (decryptedResult?.decryptedBody != null && email.bodyIsHtml)
     Column(modifier = modifier) {
         // Encryption badge
         if (decryptedResult != null) {
@@ -598,6 +601,21 @@ private fun MessageBody(
                     }
                 }
             }
+        }
+        // Show decrypting placeholder while PGP decryption is in progress
+        if (isEncryptedBlob) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 32.dp)
+            ) {
+                Text(
+                    text = "Decrypting…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                )
+            }
+            return
         }
     val fontSize = (15f * fontScaleMultiplier).coerceIn(10f, 28f)
     val smallFontSize = (13f * fontScaleMultiplier).coerceIn(9f, 24f)

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
@@ -3,10 +3,13 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.shrivatsav.monomail.data.model.Email
+import com.shrivatsav.monomail.data.pgp.PgpDecryptionResult
+import com.shrivatsav.monomail.data.pgp.PgpManager
 import com.shrivatsav.monomail.data.repository.EmailRepository
 import com.shrivatsav.monomail.data.settings.FontScale
 import com.shrivatsav.monomail.data.settings.SettingsDataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -14,6 +17,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 sealed class EmailDetailState {
     data class Success(val emails: List<Email>, val isRefreshing: Boolean = false, val refreshError: String? = null) : EmailDetailState()
@@ -23,11 +27,15 @@ sealed class EmailDetailState {
 class EmailDetailViewModel @Inject constructor(
     private val repository: EmailRepository,
     private val settingsDataStore: SettingsDataStore,
+    private val pgpManager: PgpManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     private val threadId: String = savedStateHandle.get<String>("threadId") ?: ""
     private val _isLoading = kotlinx.coroutines.flow.MutableStateFlow(true)
     private val _error = kotlinx.coroutines.flow.MutableStateFlow<String?>(null)
+
+    private val _decryptedBodies = MutableStateFlow<Map<String, PgpDecryptionResult>>(emptyMap())
+    val decryptedBodies: StateFlow<Map<String, PgpDecryptionResult>> = _decryptedBodies.asStateFlow()
 
     val fontScaleMultiplier: StateFlow<Float> = settingsDataStore.settingsFlow
         .map { settings ->
@@ -96,6 +104,25 @@ class EmailDetailViewModel @Inject constructor(
                     if (unreadIds.isNotEmpty()) {
                         repository.markEmailsAsRead(unreadIds)
                     }
+                }
+            }
+        }
+        // PGP decryption — detect and decrypt encrypted messages
+        viewModelScope.launch {
+            state.collect { s ->
+                if (s is EmailDetailState.Success) {
+                    val decrypted = mutableMapOf<String, PgpDecryptionResult>()
+                    for (email in s.emails) {
+                        if (pgpManager.isPgpMessage(email.body)) {
+                            val result = withContext(Dispatchers.Default) {
+                                pgpManager.decryptBody(email.body)
+                            }
+                            if (result != null) {
+                                decrypted[email.id] = result
+                            }
+                        }
+                    }
+                    _decryptedBodies.value = decrypted
                 }
             }
         }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.shrivatsav.monomail.ui.screens.detail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.util.Log
 import com.shrivatsav.monomail.data.model.Email
 import com.shrivatsav.monomail.data.pgp.PgpDecryptionResult
 import com.shrivatsav.monomail.data.pgp.PgpManager
@@ -113,10 +114,13 @@ class EmailDetailViewModel @Inject constructor(
                 if (s is EmailDetailState.Success) {
                     val decrypted = mutableMapOf<String, PgpDecryptionResult>()
                     for (email in s.emails) {
-                        if (pgpManager.isPgpMessage(email.body)) {
+                        val isPgp = pgpManager.isPgpMessage(email.body)
+                        Log.d("EmailDetailVM", "Email ${email.id}: isPgp=$isPgp, bodyStart=${email.body.take(80)}")
+                        if (isPgp) {
                             val result = withContext(Dispatchers.Default) {
                                 pgpManager.decryptBody(email.body)
                             }
+                            Log.d("EmailDetailVM", "Decrypt result: ${result != null}")
                             if (result != null) {
                                 decrypted[email.id] = result
                             }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/pgp/PgpKeyManagementScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/pgp/PgpKeyManagementScreen.kt
@@ -1,0 +1,336 @@
+package com.shrivatsav.monomail.ui.screens.pgp
+
+import androidx.compose.animation.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.shrivatsav.monomail.data.pgp.PgpKeyInfo
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PgpKeyManagementScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: PgpKeyManagementViewModel = hiltViewModel()
+) {
+    val keys by viewModel.keys.collectAsState()
+    val exportedKey by viewModel.exportedKey.collectAsState()
+    var showGenerateDialog by remember { mutableStateOf(false) }
+    var showImportDialog by remember { mutableStateOf(false) }
+    var showExportDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        contentWindowInsets = WindowInsets(
+            top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding(),
+            bottom = 0.dp
+        ),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("PGP Keys", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back", tint = MaterialTheme.colorScheme.onSurface)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        },
+        floatingActionButton = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                SmallFloatingActionButton(
+                    onClick = { showImportDialog = true },
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ) {
+                    Icon(Icons.Rounded.FileUpload, contentDescription = "Import Key")
+                }
+                FloatingActionButton(
+                    onClick = { showGenerateDialog = true },
+                    containerColor = MaterialTheme.colorScheme.onSurface,
+                    contentColor = MaterialTheme.colorScheme.surface
+                ) {
+                    Icon(Icons.Rounded.Add, contentDescription = "Generate Key")
+                }
+            }
+        }
+    ) { padding ->
+        if (keys.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Icon(Icons.Rounded.Lock, contentDescription = null, modifier = Modifier.size(48.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))
+                    Text("No PGP Keys", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("Generate or import a key to get started.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f))
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(top = 8.dp, bottom = 88.dp)
+            ) {
+                items(keys, key = { it.fingerprint }) { key ->
+                    KeyCard(
+                        key = key,
+                        onExport = { viewModel.exportKey(key.fingerprint); showExportDialog = true },
+                        onDelete = { viewModel.deleteKey(key.fingerprint) }
+                    )
+                }
+            }
+        }
+    }
+
+    if (showGenerateDialog) {
+        GenerateKeyDialog(
+            onDismiss = { showGenerateDialog = false },
+            onGenerate = { userId ->
+                viewModel.generateKey(userId)
+                showGenerateDialog = false
+            }
+        )
+    }
+
+    if (showImportDialog) {
+        ImportKeyDialog(
+            onDismiss = { showImportDialog = false },
+            onImport = { armored ->
+                viewModel.importKey(armored)
+                showImportDialog = false
+            }
+        )
+    }
+
+    if (showExportDialog && exportedKey != null) {
+        ExportKeyDialog(
+            armoredKey = exportedKey!!,
+            onDismiss = { viewModel.clearExportedKey(); showExportDialog = false },
+            onCopied = { viewModel.clearExportedKey(); showExportDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun KeyCard(
+    key: PgpKeyInfo,
+    onExport: () -> Unit,
+    onDelete: () -> Unit
+) {
+    var showMenu by remember { mutableStateOf(false) }
+    val dateFormat = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
+
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(if (key.isPrivate) MaterialTheme.colorScheme.primary.copy(alpha = 0.15f) else MaterialTheme.colorScheme.tertiary.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = if (key.isPrivate) Icons.Rounded.VpnKey else Icons.Rounded.Lock,
+                    contentDescription = null,
+                    tint = if (key.isPrivate) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = key.userId,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = key.fingerprint.take(32) + "...",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = key.algorithm,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = dateFormat.format(Date(key.creationDate)),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (key.isExpired) {
+                        Text(
+                            text = "Expired",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
+            Box {
+                IconButton(onClick = { showMenu = true }) {
+                    Icon(Icons.Rounded.MoreVert, contentDescription = "Actions", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                    DropdownMenuItem(
+                        text = { Text("Export Public Key") },
+                        onClick = { showMenu = false; onExport() },
+                        leadingIcon = { Icon(Icons.Rounded.Upload, contentDescription = null) }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Delete Key", color = MaterialTheme.colorScheme.error) },
+                        onClick = { showMenu = false; onDelete() },
+                        leadingIcon = { Icon(Icons.Rounded.Delete, contentDescription = null, tint = MaterialTheme.colorScheme.error) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GenerateKeyDialog(
+    onDismiss: () -> Unit,
+    onGenerate: (String) -> Unit
+) {
+    var userId by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Generate PGP Key Pair", fontWeight = FontWeight.SemiBold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Enter your name and email (e.g., \"Alice <alice@example.com>\")", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                OutlinedTextField(
+                    value = userId,
+                    onValueChange = { userId = it },
+                    label = { Text("User ID") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onGenerate(userId) }, enabled = userId.isNotBlank()) {
+                Text("Generate")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}
+
+@Composable
+private fun ImportKeyDialog(
+    onDismiss: () -> Unit,
+    onImport: (String) -> Unit
+) {
+    var armoredKey by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Import PGP Key", fontWeight = FontWeight.SemiBold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Paste the ASCII-armored PGP key below.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                OutlinedTextField(
+                    value = armoredKey,
+                    onValueChange = { armoredKey = it },
+                    label = { Text("Armored Key") },
+                    minLines = 6,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onImport(armoredKey) }, enabled = armoredKey.isNotBlank()) {
+                Text("Import")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}
+
+@Composable
+private fun ExportKeyDialog(
+    armoredKey: String,
+    onDismiss: () -> Unit,
+    onCopied: () -> Unit
+) {
+    val context = LocalContext.current
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Public Key", fontWeight = FontWeight.SemiBold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Copy this key to share with others.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = armoredKey,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier.padding(12.dp),
+                        maxLines = 10,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                clipboard.setPrimaryClip(android.content.ClipData.newPlainText("PGP Public Key", armoredKey))
+                android.widget.Toast.makeText(context, "Copied to clipboard", android.widget.Toast.LENGTH_SHORT).show()
+                onCopied()
+            }) {
+                Text("Copy to Clipboard")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        }
+    )
+}

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/pgp/PgpKeyManagementViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/pgp/PgpKeyManagementViewModel.kt
@@ -1,0 +1,74 @@
+package com.shrivatsav.monomail.ui.screens.pgp
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shrivatsav.monomail.data.pgp.PgpKeyInfo
+import com.shrivatsav.monomail.data.pgp.PgpKeyManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PgpKeyManagementViewModel @Inject constructor(
+    private val keyManager: PgpKeyManager
+) : ViewModel() {
+
+    private val _keys = MutableStateFlow<List<PgpKeyInfo>>(emptyList())
+    val keys: StateFlow<List<PgpKeyInfo>> = _keys.asStateFlow()
+
+    private val _exportedKey = MutableStateFlow<String?>(null)
+    val exportedKey: StateFlow<String?> = _exportedKey.asStateFlow()
+
+    init {
+        refreshKeys()
+    }
+
+    private fun refreshKeys() {
+        _keys.value = keyManager.listKeys().sortedByDescending { it.creationDate }
+    }
+
+    fun generateKey(userId: String) {
+        viewModelScope.launch {
+            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                keyManager.generateKeyPair(userId.trim())
+            }
+            refreshKeys()
+        }
+    }
+
+    fun importKey(armoredKey: String) {
+        viewModelScope.launch {
+            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                keyManager.importKey(armoredKey.trim())
+            }
+            refreshKeys()
+        }
+    }
+
+    fun exportKey(fingerprint: String) {
+        viewModelScope.launch {
+            val armored = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                keyManager.exportPublicKey(fingerprint)
+            }
+            _exportedKey.value = armored
+        }
+    }
+
+    fun clearExportedKey() {
+        _exportedKey.value = null
+    }
+
+    fun deleteKey(fingerprint: String) {
+        viewModelScope.launch {
+            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                keyManager.deleteKey(fingerprint)
+            }
+            refreshKeys()
+        }
+    }
+
+    fun getPgpManager(): PgpKeyManager = keyManager
+}

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ fun SettingsScreen(
     viewModel: SettingsViewModel,
     onNavigateBack: () -> Unit,
     onNavigateToLegal: (String) -> Unit,
+    onNavigateToPgpKeys: () -> Unit = {},
     accountCount: Int = 0
 ) {
     val settings by viewModel.settings.collectAsState()
@@ -331,6 +332,13 @@ fun SettingsScreen(
             }
             SettingsCard {
                 SectionHeader(icon = Icons.Rounded.Info, title = "About")
+                InfoRow(
+                    icon = Icons.Rounded.Lock,
+                    title = "PGP Keys",
+                    value = "",
+                    onClick = onNavigateToPgpKeys
+                )
+                CardDivider()
                 InfoRow(
                     icon = Icons.Rounded.Info,
                     title = "Version",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ hilt = "2.59.2"
 hiltNavigationCompose = "1.2.0"
 googleServices = "4.4.2"
 firebaseMessaging = "24.1.0"
+pgpainless = "2.0.3"
 
 [libraries]
 # Core
@@ -102,6 +103,9 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltNavigationCompose" }
 hilt-work-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltNavigationCompose" }
+
+# PGP
+pgpainless-core = { group = "org.pgpainless", name = "pgpainless-core", version.ref = "pgpainless" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Fixes

### Key generation crash (Ed25519 → X25519)
- Changed the encryption subkey from `Ed25519()` to `X25519()` — Ed25519 is signing-only and threw `IllegalArgumentException` on key generation.

### Decryption not working (metadata storage bug)
- `PgpKeyStorage.saveKeyMetadata` was keying by `info.userId` instead of `fingerprint` — private and public metadata for the same user overwrote each other, losing the `isPrivate` flag.
- `getAvailableEncryptionKeys`, `getAvailableSigningKeys`, and `decryptBody` now check actual file existence (`publicKeyExists`/`privateKeyExists`) instead of relying on the `isPrivate` metadata flag.

### Raw PGP blob flash on open
- Added `isEncryptedBlob` detection in `MessageBody` to show a "Decrypting…" placeholder while the async decryption coroutine is running, instead of briefly rendering the `-----BEGIN PGP MESSAGE-----` text.

### Debuggability
- Added `Log.e` to catch blocks in `PgpManager.decryptBody` and debug logs in `EmailDetailViewModel` so future PGP issues can be diagnosed from logcat.

Closes SHR-103