### PR TITLE
fix: stop sending Gmail OAuth access token to push backend + fix HTML email rendering (SHR-106)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/push/PushBackendClient.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/push/PushBackendClient.kt
@@ -19,7 +19,6 @@ class PushBackendClient @Inject constructor() {
         accountId: String,
         email: String,
         fcmToken: String,
-        accessToken: String,
         provider: String
     ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
@@ -32,7 +31,6 @@ class PushBackendClient @Inject constructor() {
                 put("accountId", accountId)
                 put("email", email)
                 put("fcmToken", fcmToken)
-                put("accessToken", accessToken)
                 put("provider", provider)
             }
 

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -552,7 +552,7 @@ private fun MessageBody(
             (email.body.contains("-----BEGIN PGP MESSAGE-----") ||
              email.body.contains("multipart/encrypted"))
     val bodyText = if (isEncryptedBlob) "" else (decryptedResult?.decryptedBody ?: email.body)
-    val bodyIsHtml = if (isEncryptedBlob) false else (decryptedResult?.decryptedBody != null && email.bodyIsHtml)
+    val bodyIsHtml = !isEncryptedBlob && email.bodyIsHtml
     Column(modifier = modifier) {
         // Encryption badge
         if (decryptedResult != null) {

--- a/app/src/playstore/java/com/shrivatsav/monomail/push/PushNotificationManagerImpl.kt
+++ b/app/src/playstore/java/com/shrivatsav/monomail/push/PushNotificationManagerImpl.kt
@@ -29,7 +29,6 @@ class PushNotificationManagerImpl @Inject constructor(
                 accountId = account.id,
                 email = account.email,
                 fcmToken = fcmToken,
-                accessToken = account.accessToken,
                 provider = account.provider
             )
             if (result.isSuccess) {
@@ -55,7 +54,6 @@ class PushNotificationManagerImpl @Inject constructor(
                         accountId = account.id,
                         email = account.email,
                         fcmToken = newToken,
-                        accessToken = account.accessToken,
                         provider = account.provider
                     )
                 }


### PR DESCRIPTION
**SHR-106:** PushRegistration sent the user's Gmail access token (full email API access) to the push relay backend, which only needs the FCM token and email to deliver push notifications. If the backend were compromised, the OAuth token would grant full mailbox access.

Fixed: removed accessToken from the registerDevice request payload and method signature.

**HTML rendering fix:** The expression `(decryptedResult?.decryptedBody != null && email.bodyIsHtml)` short-circuited to false for all non-PGP emails because the safe-call on null returned false, causing every HTML email to display raw tags. Simplified to `!isEncryptedBlob && email.bodyIsHtml`.