### PR TITLE
fix: PGP recipient lookup — exact email match instead of substring (SHR-107)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
@@ -85,8 +85,23 @@ class PgpKeyManager @Inject constructor(
         storage.deleteKeyMetadata(fingerprint)
     }
 
+    private fun extractEmailFromUserId(userId: String): String? {
+        // PGP User ID format: "Display Name <email@domain>" or just "email@domain"
+        val angleBracket = userId.lastIndexOf('<')
+        val closeAngle = userId.lastIndexOf('>')
+        if (angleBracket != -1 && closeAngle > angleBracket) {
+            return userId.substring(angleBracket + 1, closeAngle).trim()
+        }
+        // No angle brackets — the whole string might be an email address
+        val trimmed = userId.trim()
+        return if ('@' in trimmed) trimmed else null
+    }
+
     fun getPublicKeyForRecipient(email: String): ByteArray? {
-        val allKeys = listKeys().filter { it.userId.contains(email, ignoreCase = true) }
+        val allKeys = listKeys().filter { info ->
+            val extracted = extractEmailFromUserId(info.userId)
+            extracted != null && extracted.equals(email, ignoreCase = true)
+        }
         for (info in allKeys) {
             val armored = storage.loadPublicKey(info.fingerprint) ?: continue
             try {
@@ -98,7 +113,10 @@ class PgpKeyManager @Inject constructor(
     }
 
     fun getPublicKeyForRecipientAsFingerprint(email: String): String? {
-        val allKeys = listKeys().filter { it.userId.contains(email, ignoreCase = true) }
+        val allKeys = listKeys().filter { info ->
+            val extracted = extractEmailFromUserId(info.userId)
+            extracted != null && extracted.equals(email, ignoreCase = true)
+        }
         for (info in allKeys) {
             val armored = storage.loadPublicKey(info.fingerprint) ?: continue
             try {


### PR DESCRIPTION
getPublicKeyForRecipient and getPublicKeyForRecipientAsFingerprint used `userId.contains(email, ignoreCase = true)`, which matches substrings. An attacker with email 'evil@example.com.attacker.net' could match a recipient lookup for '@example.com'.

Fix: parse the email from the PGP User ID format ('Name <email>') and perform an exact case-insensitive comparison instead.