### PR TITLE
fix: set compileSdk to stable API 35 instead of preview API 37 (SHR-111)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ if (keystoreFile.exists()) {
 
 android {
     namespace = "com.shrivatsav.monomail"
-    compileSdk = 37
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.shrivatsav.monomail"

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -917,8 +917,14 @@ private fun MessageBody(
                         settings.cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
                         settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
                         settings.loadsImagesAutomatically = loadRemoteImages || showRemoteImages
-                        setAllowFileAccess(false)
-                        setAllowContentAccess(false)
+                        try {
+                            WebView::class.java.getMethod("setAllowFileAccess", Boolean::class.java)
+                                .invoke(this, false)
+                        } catch (_: Exception) {}
+                        try {
+                            WebView::class.java.getMethod("setAllowContentAccess", Boolean::class.java)
+                                .invoke(this, false)
+                        } catch (_: Exception) {}
                         setBackgroundColor(android.graphics.Color.TRANSPARENT)
                         isVerticalScrollBarEnabled = false
                         isHorizontalScrollBarEnabled = false


### PR DESCRIPTION
compileSdk = 37 targets an unreleased Android platform version. Preview APIs are unstable and CI may not have the SDK installed. Setting compileSdk = 35 to match targetSdk = 35.