### PR TITLE
fix: snooze feature server sync and state preservation (SHR-114)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
@@ -162,7 +162,7 @@ data class ScheduledMessageEntity(
 )
 
 enum class PendingActionType {
-    TOGGLE_STAR, MARK_READ, MARK_UNREAD, ARCHIVE, UNARCHIVE, DELETE, RESTORE
+    TOGGLE_STAR, MARK_READ, MARK_UNREAD, ARCHIVE, UNARCHIVE, DELETE, RESTORE, SNOOZE, UNSNOOZE
 }
 
 enum class PendingActionStatus {

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/ThreadDao.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/ThreadDao.kt
@@ -55,6 +55,9 @@ interface ThreadDao {
     suspend fun unsnoozeThread(threadId: String, accountId: String)
     @Query("SELECT * FROM threads WHERE isSnoozed = 1 AND snoozedUntil > 0 AND snoozedUntil <= :now")
     suspend fun getDueUnsnoozeThreads(now: Long): List<ThreadEntity>
+
+    @Query("SELECT threadId, isSnoozed, snoozedUntil FROM threads WHERE threadId IN (:threadIds) AND accountId = :accountId")
+    suspend fun getSnoozeStateForThreads(threadIds: List<String>, accountId: String): List<ThreadSnoozeProjection>
     @Query("DELETE FROM threads WHERE accountId = :accountId AND inTrash = 1")
     suspend fun emptyTrash(accountId: String)
     @Query("DELETE FROM threads WHERE accountId = :accountId AND inSpam = 1")
@@ -75,4 +78,10 @@ data class ThreadReadStatusProjection(
 data class ThreadSnippetProjection(
     val threadId: String,
     val snippet: String
+)
+
+data class ThreadSnoozeProjection(
+    val threadId: String,
+    val isSnoozed: Boolean,
+    val snoozedUntil: Long
 )

--- a/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
@@ -212,8 +212,14 @@ class EmailRepository(
                         ).toEntity(targetAccountId)
                     }
                 }
+                val existingSnoozed = threadDao.getSnoozeStateForThreads(
+                    entities.map { it.threadId }, targetAccountId
+                ).filter { it.isSnoozed }.associateBy { it.threadId }
                 database.withTransaction {
                     threadDao.insertThreads(entities)
+                    existingSnoozed.forEach { (threadId, state) ->
+                        threadDao.snoozeThread(threadId, targetAccountId, state.snoozedUntil)
+                    }
                     emailDao.insertEmails(allEmails)
                 }
             }
@@ -537,11 +543,13 @@ class EmailRepository(
     suspend fun getScheduledMessageById(id: String) = scheduledMessageDao.getScheduledMessageById(id)
     suspend fun snoozeThread(threadId: String, untilTimestamp: Long, explicitAccountId: String? = null) {
         val activeAccountId = explicitAccountId ?: getActiveAccountId()
+        insertPendingAction(PendingActionType.SNOOZE, activeAccountId, threadId, payload = untilTimestamp.toString())
         threadDao.snoozeThread(threadId, activeAccountId, untilTimestamp)
         emailDao.snoozeThreadEmails(threadId, activeAccountId, untilTimestamp)
     }
     suspend fun unsnoozeThread(threadId: String, explicitAccountId: String? = null) {
         val activeAccountId = explicitAccountId ?: getActiveAccountId()
+        insertPendingAction(PendingActionType.UNSNOOZE, activeAccountId, threadId)
         threadDao.unsnoozeThread(threadId, activeAccountId)
         emailDao.unsnoozeThreadEmails(threadId, activeAccountId)
     }

--- a/app/src/main/java/com/shrivatsav/monomail/data/worker/ActionQueueManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/worker/ActionQueueManager.kt
@@ -91,6 +91,15 @@ class ActionQueueManager @Inject constructor(
                 PendingActionType.UNARCHIVE -> provider.unarchiveThread(action.threadId)
                 PendingActionType.DELETE -> provider.trashThread(action.threadId)
                 PendingActionType.RESTORE -> provider.restoreThread(action.threadId)
+                PendingActionType.SNOOZE -> {
+                    // Provider-level snooze is not yet supported; the pending action
+                    // keeps the thread excluded during sync cycles so the local
+                    // snoozed state is not overwritten by the server response.
+                }
+                PendingActionType.UNSNOOZE -> {
+                    // No-op pending action to gate sync overwrites during the
+                    // brief window before the action is processed and deleted.
+                }
             }
             pendingActionDao.delete(action.id)
             Log.d(tag, "Completed ${action.actionType} for thread ${action.threadId}")


### PR DESCRIPTION
## Summary
Fixes the snooze feature so snoozed threads are not overwritten by server sync.

## Root cause
`refreshInbox()` uses `OnConflictStrategy.REPLACE` which overwrites all columns including `isSnoozed`/ `snoozedUntil` with defaults (false/0). Additionally, snooze/unsnooze operations never enqueued `PendingActionEntity` rows, so the threads were not excluded from sync via the existing pending-thread gating.

## Changes
- **ThreadDao**: Add `getSnoozeStateForThreads` projection query
- **EmailRepository**: Query existing snoozed state before `refreshInbox` insert and re-apply `isSnoozed`/ `snoozedUntil` after REPLACE
- **EmailRepository**: Add `insertPendingAction()` to `snoozeThread()` and `unsnoozeThread()` (SNOOZE/UNSNOOZE)
- **Entities**: Add `SNOOZE`/ `UNSNOOZE` to `PendingActionType`
- **ActionQueueManager**: Add no-op handlers (providers lack snooze APIs; the pending action gates sync overwrites)

Fixes SHR-114