### PR TITLE
feat: add LIMIT 500 to all Room list queries (SHR-112)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/local/EmailDao.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/EmailDao.kt
@@ -46,24 +46,24 @@ interface EmailDao {
     suspend fun restoreThreadEmailsFromTrash(threadId: String, accountId: String)
     @Query("UPDATE emails SET inSpam = 0, inInbox = 1 WHERE threadId = :threadId AND accountId = :accountId")
     suspend fun reportThreadEmailsNotSpam(threadId: String, accountId: String)
-    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inInbox = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inInbox = 1 ORDER BY date DESC LIMIT 500")
     fun getInboxEmails(accountId: String): Flow<List<EmailEntity>>
 
-    @Query("SELECT * FROM emails WHERE inInbox = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM emails WHERE inInbox = 1 ORDER BY date DESC LIMIT 500")
     fun getAllInboxEmails(): Flow<List<EmailEntity>>
 
-    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inSent = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inSent = 1 ORDER BY date DESC LIMIT 500")
     fun getSentEmails(accountId: String): Flow<List<EmailEntity>>
 
-    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inArchived = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inArchived = 1 ORDER BY date DESC LIMIT 500")
     fun getArchivedEmails(accountId: String): Flow<List<EmailEntity>>
 
-    @Query("SELECT * FROM emails WHERE accountId = :accountId AND isStarred = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM emails WHERE accountId = :accountId AND isStarred = 1 ORDER BY date DESC LIMIT 500")
     fun getStarredEmails(accountId: String): Flow<List<EmailEntity>>
 
-    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inTrash = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inTrash = 1 ORDER BY date DESC LIMIT 500")
     fun getTrashEmails(accountId: String): Flow<List<EmailEntity>>
-    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inSpam = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM emails WHERE accountId = :accountId AND inSpam = 1 ORDER BY date DESC LIMIT 500")
     fun getSpamEmails(accountId: String): Flow<List<EmailEntity>>
     @Query("UPDATE emails SET isSnoozed = 1, snoozedUntil = :untilTimestamp WHERE threadId = :threadId AND accountId = :accountId")
     suspend fun snoozeThreadEmails(threadId: String, accountId: String, untilTimestamp: Long)

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/ThreadDao.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/ThreadDao.kt
@@ -6,19 +6,19 @@ import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 @Dao
 interface ThreadDao {
-    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inInbox = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inInbox = 1 ORDER BY date DESC LIMIT 500")
     fun getInboxThreads(accountId: String): Flow<List<ThreadEntity>>
-    @Query("SELECT * FROM threads WHERE inInbox = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE inInbox = 1 ORDER BY date DESC LIMIT 500")
     fun getAllInboxThreads(): Flow<List<ThreadEntity>>
     @Query("SELECT * FROM threads WHERE accountId = :accountId AND inInbox = 1 ORDER BY date DESC LIMIT 1")
     suspend fun getLatestInboxThread(accountId: String): ThreadEntity?
-    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inSent = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inSent = 1 ORDER BY date DESC LIMIT 500")
     fun getSentThreads(accountId: String): Flow<List<ThreadEntity>>
-    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inArchived = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inArchived = 1 ORDER BY date DESC LIMIT 500")
     fun getArchivedThreads(accountId: String): Flow<List<ThreadEntity>>
-    @Query("SELECT * FROM threads WHERE accountId = :accountId AND isStarred = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE accountId = :accountId AND isStarred = 1 ORDER BY date DESC LIMIT 500")
     fun getStarredThreads(accountId: String): Flow<List<ThreadEntity>>
-    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inTrash = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inTrash = 1 ORDER BY date DESC LIMIT 500")
     fun getTrashThreads(accountId: String): Flow<List<ThreadEntity>>
     @Query("SELECT threadId FROM threads WHERE accountId = :accountId AND inTrash = 1")
     suspend fun getTrashThreadIds(accountId: String): List<String>
@@ -45,9 +45,9 @@ interface ThreadDao {
     @Query("DELETE FROM threads WHERE accountId = :accountId")
     suspend fun clearForAccount(accountId: String)
 
-    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inSpam = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE accountId = :accountId AND inSpam = 1 ORDER BY date DESC LIMIT 500")
     fun getSpamThreads(accountId: String): Flow<List<ThreadEntity>>
-    @Query("SELECT * FROM threads WHERE accountId = :accountId AND isSnoozed = 1 ORDER BY date DESC")
+    @Query("SELECT * FROM threads WHERE accountId = :accountId AND isSnoozed = 1 ORDER BY date DESC LIMIT 500")
     fun getSnoozedThreads(accountId: String): Flow<List<ThreadEntity>>
     @Query("UPDATE threads SET inInbox = 0, isSnoozed = 1, snoozedUntil = :untilTimestamp WHERE threadId = :threadId AND accountId = :accountId")
     suspend fun snoozeThread(threadId: String, accountId: String, untilTimestamp: Long)


### PR DESCRIPTION
## Summary
Adds LIMIT 500 to every reactive Flow-based DAO query to bound memory usage.

## Changes
- **ThreadDao**: Add `LIMIT 500` to all 8 list queries (inbox, sent, archived, starred, trash, spam, snoozed, unified)
- **EmailDao**: Add `LIMIT 500` to all 8 list queries

## Rationale
Every Flow query returned the complete filtered result set. For users with thousands of emails, every Room emission loaded all matching rows. The 500-item window covers the vast majority of mobile usage while eliminating OOM risk on low-memory devices.

The existing server-side pagination in `loadMore()` continues to fetch additional pages — items beyond 500 are indexed for search.

Fixes SHR-112