### PR TITLE
fix: PGP key metadata storage — use commit() instead of apply()

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
@@ -74,7 +74,7 @@ class PgpKeyStorage @Inject constructor(
     fun saveKeyMetadata(fingerprint: String, info: PgpKeyInfo) {
         val all = loadAllMetadata().toMutableMap()
         all[fingerprint] = info
-        prefs.edit().putString(PREF_KEYS, gson.toJson(all)).apply()
+        prefs.edit().putString(PREF_KEYS, gson.toJson(all)).commit()
     }
 
     fun loadKeyMetadata(fingerprint: String): PgpKeyInfo? {
@@ -94,7 +94,7 @@ class PgpKeyStorage @Inject constructor(
     fun deleteKeyMetadata(fingerprint: String) {
         val all = loadAllMetadata().toMutableMap()
         all.entries.removeIf { it.value.fingerprint == fingerprint }
-        prefs.edit().putString(PREF_KEYS, gson.toJson(all)).apply()
+        prefs.edit().putString(PREF_KEYS, gson.toJson(all)).commit()
     }
 
     fun keyFileExists(fingerprint: String): Boolean {


### PR DESCRIPTION
**SHR-116** — P2 in v1.6 — Audit Remediation

`PgpKeyStorage` used `SharedPreferences.edit().apply()` (async) for metadata writes. If the process is killed between writing the key file and the `apply()` flush, keys exist on disk but are invisible.

**Fix:** Changed to `commit()` so the metadata write is synchronous and confirmed before returning.