### PR TITLE
fix: HttpClient logging interceptor — disable in production builds

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/remote/RetrofitClient.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/remote/RetrofitClient.kt
@@ -8,6 +8,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import com.shrivatsav.monomail.BuildConfig
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
 class RetrofitClient(
@@ -54,8 +55,11 @@ class RetrofitClient(
         }
         response
     }
-    private val loggingInterceptor = HttpLoggingInterceptor().apply {
-        level = HttpLoggingInterceptor.Level.BASIC
+    private val loggingInterceptor by lazy {
+        HttpLoggingInterceptor().apply {
+            level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BASIC
+                    else HttpLoggingInterceptor.Level.NONE
+        }
     }
     private val baseHttpClient = OkHttpClient.Builder()
         .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)


### PR DESCRIPTION
**SHR-118** — P2 in v1.6 — Audit Remediation

`HttpLoggingInterceptor` at `Level.BASIC` was added as a global interceptor without conditional disabling, logging every request/response URL to logcat in production (~200 lines per sync cycle).

**Fix:** Set level to `Level.NONE` when `BuildConfig.DEBUG` is false via a `lazy` delegate, keeping the interceptor registered as a no-op in release builds.