### PR TITLE
feat: complete PGP passphrase support (SHR-109)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
@@ -1,5 +1,6 @@
 package com.shrivatsav.monomail.data.pgp
 
+import android.util.Log
 import org.pgpainless.PGPainless
 import org.pgpainless.algorithm.KeyFlag
 import org.pgpainless.algorithm.PublicKeyAlgorithm
@@ -36,7 +37,10 @@ class PgpKeyManager @Inject constructor(
         val secretKeyRing = openPgpKey.pgpSecretKeyRing
         val publicKeyRing = PGPainless.extractCertificate(secretKeyRing)
 
-        val info = keyRingToInfo(secretKeyRing, isPrivate = true)
+        val info = keyRingToInfo(
+            secretKeyRing, isPrivate = true,
+            isPassphraseProtected = passphrase != null
+        )
 
         val armoredSecret = PGPainless.asciiArmor(secretKeyRing)
         storage.savePrivateKey(info.fingerprint, armoredSecret)
@@ -45,6 +49,9 @@ class PgpKeyManager @Inject constructor(
         storage.savePublicKey(info.fingerprint, armoredPublic)
 
         storage.saveKeyMetadata(info.fingerprint, info)
+        if (passphrase != null) {
+            storage.savePassphrase(info.fingerprint, passphrase)
+        }
         return info
     }
 
@@ -53,13 +60,20 @@ class PgpKeyManager @Inject constructor(
 
         if (isPrivate) {
             val secretKeyRing = PGPainless.readKeyRing().secretKeyRing(armoredKey)
-            val info = keyRingToInfo(secretKeyRing!!, isPrivate = true)
+            val isProtected = try {
+                secretKeyRing!!.secretKey.keyEncryptionAlgorithm != 0
+            } catch (_: Exception) { false }
+
+            val info = keyRingToInfo(secretKeyRing!!, isPrivate = true, isPassphraseProtected = isProtected)
 
             storage.savePrivateKey(info.fingerprint, armoredKey)
             val publicKeyRing = PGPainless.extractCertificate(secretKeyRing!!)
             val armoredPublic = PGPainless.asciiArmor(publicKeyRing)
             storage.savePublicKey(info.fingerprint, armoredPublic)
             storage.saveKeyMetadata(info.fingerprint, info)
+            if (passphrase != null) {
+                storage.savePassphrase(info.fingerprint, passphrase)
+            }
             return info
         } else {
             val publicKeyRing = PGPainless.readKeyRing().publicKeyRing(armoredKey)
@@ -107,7 +121,10 @@ class PgpKeyManager @Inject constructor(
             try {
                 val publicKeyRing = PGPainless.readKeyRing().publicKeyRing(armored)
                 return publicKeyRing!!.encoded
-            } catch (_: Exception) { continue }
+            } catch (e: Exception) {
+                Log.w("PgpKeyManager", "Failed to parse public key ring for recipient", e)
+                continue
+            }
         }
         return null
     }
@@ -122,7 +139,10 @@ class PgpKeyManager @Inject constructor(
             try {
                 PGPainless.readKeyRing().publicKeyRing(armored)
                 return info.fingerprint
-            } catch (_: Exception) { continue }
+            } catch (e: Exception) {
+                Log.w("PgpKeyManager", "Failed to parse public key ring for fingerprint lookup", e)
+                continue
+            }
         }
         return null
     }
@@ -131,19 +151,26 @@ class PgpKeyManager @Inject constructor(
         val armored = storage.loadPrivateKey(fingerprint) ?: return null
         return try {
             PGPainless.readKeyRing().secretKeyRing(armored)
-        } catch (_: Exception) { null }
+        } catch (e: Exception) {
+            Log.w("PgpKeyManager", "Failed to load secret key ring for $fingerprint", e)
+            null
+        }
     }
 
     fun loadPublicKeyRing(fingerprint: String): org.bouncycastle.openpgp.PGPPublicKeyRing? {
         val armored = storage.loadPublicKey(fingerprint) ?: return null
         return try {
             PGPainless.readKeyRing().publicKeyRing(armored)
-        } catch (_: Exception) { null }
+        } catch (e: Exception) {
+            Log.w("PgpKeyManager", "Failed to load public key ring for $fingerprint", e)
+            null
+        }
     }
 
     private fun keyRingToInfo(
         ring: org.bouncycastle.openpgp.PGPSecretKeyRing,
-        isPrivate: Boolean
+        isPrivate: Boolean,
+        isPassphraseProtected: Boolean = false
     ): PgpKeyInfo {
         val info = PGPainless.inspectKeyRing(ring)
         return PgpKeyInfo(
@@ -152,7 +179,8 @@ class PgpKeyManager @Inject constructor(
             algorithm = info.algorithm.name,
             creationDate = info.creationDate.time,
             isPrivate = isPrivate,
-            isExpired = info.primaryKeyExpirationDate?.let { it.before(Date()) } ?: false
+            isExpired = info.primaryKeyExpirationDate?.let { it.before(Date()) } ?: false,
+            isPassphraseProtected = isPassphraseProtected
         )
     }
 

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
@@ -2,6 +2,7 @@ package com.shrivatsav.monomail.data.pgp
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.google.gson.Gson
@@ -87,6 +88,7 @@ class PgpKeyStorage @Inject constructor(
             val type = object : TypeToken<Map<String, PgpKeyInfo>>() {}.type
             gson.fromJson(json, type) ?: emptyMap()
         } catch (e: Exception) {
+            Log.w("PgpKeyStorage", "Failed to deserialize key metadata", e)
             emptyMap()
         }
     }
@@ -108,6 +110,26 @@ class PgpKeyStorage @Inject constructor(
 
     fun privateKeyExists(fingerprint: String): Boolean {
         return File(keysDir, "$fingerprint.asc").exists()
+    }
+
+    fun savePassphrase(fingerprint: String, passphrase: String) {
+        val encrypted = SecurityUtil.encryptString(passphrase)
+        File(keysDir, "${fingerprint}_pass.enc").writeText(encrypted)
+    }
+
+    fun loadPassphrase(fingerprint: String): String? {
+        val file = File(keysDir, "${fingerprint}_pass.enc")
+        if (!file.exists()) return null
+        val encrypted = file.readText()
+        return SecurityUtil.decryptString(encrypted)
+    }
+
+    fun deletePassphrase(fingerprint: String) {
+        File(keysDir, "${fingerprint}_pass.enc").delete()
+    }
+
+    fun isPassphraseProtected(fingerprint: String): Boolean {
+        return File(keysDir, "${fingerprint}_pass.enc").exists()
     }
 
     companion object {

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
@@ -8,6 +8,7 @@ import org.pgpainless.encryption_signing.EncryptionOptions
 import org.pgpainless.encryption_signing.ProducerOptions
 import org.pgpainless.encryption_signing.SigningOptions
 import org.pgpainless.key.protection.SecretKeyRingProtector
+import org.pgpainless.util.Passphrase
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import javax.inject.Inject
@@ -22,6 +23,20 @@ class PgpManager @Inject constructor(
         return body.contains("-----BEGIN PGP MESSAGE-----") ||
                 body.contains("multipart/encrypted") ||
                 body.contains("application/pgp-encrypted")
+    }
+
+    private fun getProtector(
+        secretKeyRing: org.bouncycastle.openpgp.PGPSecretKeyRing,
+        fingerprint: String
+    ): SecretKeyRingProtector {
+        val passphrase = storage.loadPassphrase(fingerprint)
+        if (passphrase != null) {
+            Log.d("PgpManager", "Using passphrase protector for key $fingerprint")
+            return SecretKeyRingProtector.unlockAnyKeyWith(
+                Passphrase.fromPassword(passphrase)
+            )
+        }
+        return SecretKeyRingProtector.unprotectedKeys()
     }
 
     fun decryptBody(emailBody: String, fingerprintHint: String? = null): PgpDecryptionResult? {
@@ -50,7 +65,7 @@ class PgpManager @Inject constructor(
                     continue
                 }
 
-                val protector = SecretKeyRingProtector.unprotectedKeys()
+                val protector = getProtector(secretKeyRing, fp)
 
                 val consumerOptions = ConsumerOptions.get()
                     .addDecryptionKey(secretKeyRing, protector)
@@ -82,6 +97,16 @@ class PgpManager @Inject constructor(
                 )
             } catch (e: Exception) {
                 Log.e("PgpManager", "Decryption failed for $fp", e)
+                // If the key is passphrase-protected but no passphrase is stored,
+                // signal the caller so the UI can prompt the user
+                val metadata = storage.loadKeyMetadata(fp)
+                if (metadata?.isPassphraseProtected == true && storage.loadPassphrase(fp) == null) {
+                    return PgpDecryptionResult(
+                        decryptedBody = "",
+                        needsPassphrase = true,
+                        fingerprint = fp
+                    )
+                }
                 continue
             }
         }
@@ -140,7 +165,7 @@ class PgpManager @Inject constructor(
         }
 
         try {
-            val protector = SecretKeyRingProtector.unprotectedKeys()
+            val protector = getProtector(secretKeyRing, fingerprint)
 
             val signingOptions = SigningOptions.get()
                 .addInlineSignature(protector, secretKeyRing)
@@ -195,7 +220,7 @@ class PgpManager @Inject constructor(
                     return null
                 }
 
-                val protector = SecretKeyRingProtector.unprotectedKeys()
+                val protector = getProtector(secretKeyRing, signingFingerprint)
                 val signingOptions = SigningOptions.get()
                     .addInlineSignature(protector, secretKeyRing)
 

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpModels.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpModels.kt
@@ -6,7 +6,8 @@ data class PgpKeyInfo(
     val algorithm: String,
     val creationDate: Long,
     val isPrivate: Boolean,
-    val isExpired: Boolean
+    val isExpired: Boolean,
+    val isPassphraseProtected: Boolean = false
 )
 
 data class PgpSignature(
@@ -16,7 +17,9 @@ data class PgpSignature(
 
 data class PgpDecryptionResult(
     val decryptedBody: String,
-    val signatures: List<PgpSignature>? = null
+    val signatures: List<PgpSignature>? = null,
+    val needsPassphrase: Boolean = false,
+    val fingerprint: String? = null
 )
 
 data class PgpEncryptionResult(


### PR DESCRIPTION
## Summary

Implements full passphrase support for PGP keys:

### Changes

- **PgpKeyManager**: Store passphrase on key generation and import, detect passphrase protection on imported keys via `keyEncryptionAlgorithm != 0`, set `isPassphraseProtected` in metadata
- **PgpKeyStorage**: Passphrase storage methods (save/load/delete/isPassphraseProtected) already added in prior session
- **PgpManager**: New `getProtector()` helper returns `unlockAnyKeyWith(passphrase)` when a passphrase is stored, `unprotectedKeys()` otherwise. All 3 private key operations (decryptBody, signBody, encryptAndSignBody) now use it
- **PgpModels**: `isPassphraseProtected` on PgpKeyInfo, `needsPassphrase`/fingerprint on PgpDecryptionResult for UI prompt support
- Added logging to previously silent catch blocks

Closes SHR-109

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>