### PR TITLE
fix: SHR-121 add composite database index for snooze queries

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/AppDatabase.kt
@@ -8,7 +8,7 @@ import com.shrivatsav.monomail.security.SecurityUtil
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 @Database(
     entities = [ThreadEntity::class, EmailEntity::class, ScheduledMessageEntity::class, PendingActionEntity::class],
-    version = 11,
+    version = 12,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -31,7 +31,7 @@ abstract class AppDatabase : RoomDatabase() {
                     "monomail_database"
                 )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12)
                 .fallbackToDestructiveMigration(true)
                 .build()
                 INSTANCE = instance
@@ -91,5 +91,11 @@ val MIGRATION_9_10 = object : androidx.room.migration.Migration(9, 10) {
 val MIGRATION_10_11 = object : androidx.room.migration.Migration(10, 11) {
     override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE scheduled_messages ADD COLUMN fromAlias TEXT DEFAULT NULL")
+    }
+}
+val MIGRATION_11_12 = object : androidx.room.migration.Migration(11, 12) {
+    override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_threads_snooze ON threads(isSnoozed, snoozedUntil)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_emails_snooze ON emails(isSnoozed, snoozedUntil)")
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/Entities.kt
@@ -15,7 +15,8 @@ import com.google.gson.Gson
         Index(value = ["accountId", "isStarred", "date"]),
         Index(value = ["accountId", "inTrash", "date"]),
         Index(value = ["accountId", "inSpam", "date"]),
-        Index(value = ["accountId", "isSnoozed", "snoozedUntil"])
+        Index(value = ["accountId", "isSnoozed", "snoozedUntil"]),
+        Index(value = ["isSnoozed", "snoozedUntil"])
     ]
 )
 data class ThreadEntity(
@@ -64,6 +65,7 @@ data class ThreadEntity(
         Index(value = ["accountId", "inTrash", "date"]),
         Index(value = ["accountId", "inSpam", "date"]),
         Index(value = ["accountId", "isSnoozed", "snoozedUntil"]),
+        Index(value = ["isSnoozed", "snoozedUntil"]),
         Index(value = ["threadId", "accountId"])
     ]
 )


### PR DESCRIPTION
Closes SHR-121

Adds `(isSnoozed, snoozedUntil)` composite index to both `threads` and `emails` tables. The existing `(accountId, isSnoozed, snoozedUntil)` index is less efficient for queries without `accountId` filter.

- Bumps DB version 11→12
- Adds MIGRATION_11_12 to create indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>