### PR TITLE
fix: SHR-122 replace !! with proper error handling in importKey

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
@@ -60,14 +60,15 @@ class PgpKeyManager @Inject constructor(
 
         if (isPrivate) {
             val secretKeyRing = PGPainless.readKeyRing().secretKeyRing(armoredKey)
+                ?: throw IllegalArgumentException("Failed to parse private key — invalid or corrupted key data")
             val isProtected = try {
-                secretKeyRing!!.secretKey.keyEncryptionAlgorithm != 0
+                secretKeyRing.secretKey.keyEncryptionAlgorithm != 0
             } catch (_: Exception) { false }
 
-            val info = keyRingToInfo(secretKeyRing!!, isPrivate = true, isPassphraseProtected = isProtected)
+            val info = keyRingToInfo(secretKeyRing, isPrivate = true, isPassphraseProtected = isProtected)
 
             storage.savePrivateKey(info.fingerprint, armoredKey)
-            val publicKeyRing = PGPainless.extractCertificate(secretKeyRing!!)
+            val publicKeyRing = PGPainless.extractCertificate(secretKeyRing)
             val armoredPublic = PGPainless.asciiArmor(publicKeyRing)
             storage.savePublicKey(info.fingerprint, armoredPublic)
             storage.saveKeyMetadata(info.fingerprint, info)
@@ -77,7 +78,8 @@ class PgpKeyManager @Inject constructor(
             return info
         } else {
             val publicKeyRing = PGPainless.readKeyRing().publicKeyRing(armoredKey)
-            val info = keyRingToInfo(publicKeyRing!!, isPrivate = false)
+                ?: throw IllegalArgumentException("Failed to parse public key — invalid or corrupted key data")
+            val info = keyRingToInfo(publicKeyRing, isPrivate = false)
 
             storage.savePublicKey(info.fingerprint, armoredKey)
             storage.saveKeyMetadata(info.fingerprint, info)


### PR DESCRIPTION
Closes SHR-122

Replaces all `!!` force-unwrap operators in `PgpKeyManager.importKey()` with null-safe Elvis operators that throw `IllegalArgumentException` with descriptive messages for corrupted key data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>