### PR TITLE
fix: SHR-125 fix ContactSuggestionProvider participant emails

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/repository/ContactSuggestionProvider.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/repository/ContactSuggestionProvider.kt
@@ -8,9 +8,8 @@ class ContactSuggestionProvider {
     fun indexFromThreads(threads: List<com.shrivatsav.monomail.data.model.EmailThread>) {
         threads.forEach { thread ->
             contacts.add(EmailContact(thread.from, thread.fromEmail))
-            thread.participants.forEach { name ->
-                contacts.add(EmailContact(name, name))
-            }
+            // Participants list only contains names, not email addresses.
+            // Skip them to avoid using display names as email addresses.
         }
     }
     fun indexFromEmails(emails: List<com.shrivatsav.monomail.data.model.Email>) {


### PR DESCRIPTION
Closes SHR-125

Removes `participants.forEach { contacts.add(EmailContact(name, name)) }` loop that used display name strings as email addresses. The participants list only stores names — not emails — so those entries produced invalid email addresses that caused compose field validation to fail.

The `thread.from / thread.fromEmail` entry already correctly uses the real email address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>