### PR TITLE
fix: SHR-126 remove Material3 duplicate version declaration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,7 +115,6 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons)
     implementation(libs.androidx.compose.ui.text.google.fonts)
-    implementation(libs.androidx.material3)
     implementation(libs.androidx.graphics.path)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ room = "2.7.1"
 work = "2.10.1"
 coil = "2.7.0"
 datastore = "1.1.1"
-material3 = "1.4.0"
 foundation = "1.11.2"
 securityCrypto = "1.1.0"
 sqlcipher = "4.6.1"
@@ -90,7 +89,6 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 sqlcipher = { group = "net.zetetic", name = "sqlcipher-android", version.ref = "sqlcipher" }


### PR DESCRIPTION
Closes SHR-126

Removes the redundant `libs.androidx.material3` (1.4.0) dependency. Both `androidx-compose-material3` (1.5.0-alpha21) and `androidx-material3` (1.4.0) resolve to the same Maven coordinate `androidx.compose.material3:material3`. Gradle was already picking the higher version, making the duplicate declaration redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>