### PR TITLE
fix: retain ProGuard mapping files for crash deobfuscation (SHR-128)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,3 +195,27 @@ dependencies {
 tasks.matching { it.name.contains("Github", ignoreCase = true) && it.name.contains("GoogleServices", ignoreCase = true) }.configureEach {
     enabled = false
 }
+
+// Retain ProGuard/R8 mapping files for crash deobfuscation across releases.
+// After each release build, the mapping file is copied to a versioned archive
+// so crash reports from any published version can be deobfuscated.
+val archiveMapping by tasks.registering {
+    group = "Reporting"
+    description = "Archive all release ProGuard mapping files with version info"
+    doLast {
+        val variants = listOf("githubRelease", "playstoreRelease")
+        for (variant in variants) {
+            val mappingFile = layout.buildDirectory.file("outputs/mapping/$variant/mapping.txt").get().asFile
+            if (mappingFile.exists()) {
+                val archiveDir = layout.buildDirectory.dir("outputs/mapping/archive").get().asFile
+                archiveDir.mkdirs()
+                mappingFile.copyTo(
+                    File(archiveDir, "mapping-${android.defaultConfig.versionName}-${android.defaultConfig.versionCode}-$variant.txt"),
+                    overwrite = true
+                )
+            }
+        }
+    }
+}
+tasks.matching { it.name.matches(Regex("assemble(Github|Playstore)Release")) }
+    .configureEach { finalizedBy(archiveMapping) }


### PR DESCRIPTION
Add a Gradle task that archives ProGuard/R8 mapping files after each release build, naming them with version name, version code, and variant so crash reports from any published version can be deobfuscated.

The archive task runs after `assemble(Github|Playstore)Release` and copies `mapping.txt` from each release variant to `build/outputs/mapping/archive/mapping-<version>-<variant>.txt`.

Closes SHR-128