### PR TITLE
fix: parallelize EmailSyncWorker across accounts (SHR-130)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/auth/AuthManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/auth/AuthManager.kt
@@ -36,6 +36,7 @@ class AuthManager(
     private val _isSignedIn = MutableStateFlow(false)
     val isSignedIn: StateFlow<Boolean> = _isSignedIn.asStateFlow()
     private var _userProfile: UserProfile? = null
+    private var _pendingConsentProfile: UserProfile? = null
     val currentUser: UserProfile? get() = _userProfile
     val accountsFlow = accountManager.accountsFlow
     val activeAccountFlow = accountManager.activeAccountFlow
@@ -138,11 +139,12 @@ class AuthManager(
         }
     }
     suspend fun handleConsentResult(activityContext: Context): SignInResult {
-        val profile = _userProfile
-            ?: return SignInResult.Failure(IllegalStateException("No profile available"))
+        val profile = _pendingConsentProfile
+            ?: return SignInResult.Failure(IllegalStateException("No pending consent profile"))
+        _pendingConsentProfile = null
         return requestAccessToken(
             activityContext, profile.email, profile.displayName,
-            profile.photoUrl, "" 
+            profile.photoUrl, ""
         )
     }
     suspend fun getAccounts(): List<UserProfile> = accountManager.getAccounts()
@@ -266,12 +268,12 @@ class AuthManager(
             try { pushNotificationManager.registerForPushNotifications(profile) } catch (e: Exception) { android.util.Log.w("AuthManager", "registerForPushNotifications failed", e) }
             SignInResult.Success(profile)
         } catch (e: UserRecoverableAuthException) {
-            _userProfile = UserProfile(
-                id = "gmail_$email", displayName = displayName, email = email,
-                photoUrl = photoUrl, accessToken = "", provider = "gmail", refreshToken = ""
-            )
             val consentIntent = e.intent
             if (consentIntent != null) {
+                _pendingConsentProfile = UserProfile(
+                    id = "gmail_$email", displayName = displayName, email = email,
+                    photoUrl = photoUrl, accessToken = "", provider = "gmail", refreshToken = ""
+                )
                 SignInResult.NeedsConsent(consentIntent)
             } else {
                 SignInResult.Failure(e)

--- a/app/src/main/java/com/shrivatsav/monomail/worker/EmailSyncWorker.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/worker/EmailSyncWorker.kt
@@ -26,6 +26,11 @@ import com.shrivatsav.monomail.data.repository.EmailRepository
 import com.shrivatsav.monomail.ui.screens.inbox.InboxTab
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
 
 @HiltWorker
@@ -57,49 +62,59 @@ class EmailSyncWorker @AssistedInject constructor(
             Log.w("EmailSyncWorker", "No accounts found to sync")
             return Result.success()
         }
-        var hasFailure = false
-        var hasAuthFailure = false
-        for (account in accounts) {
-            val accountId = account.id
-            val lastKnownTimestamp = accountManager.getLastKnownEmailId(accountId)
-            Log.i("EmailSyncWorker", "Starting sync for account $accountId (lastKnownTimestamp: $lastKnownTimestamp)")
-            val result = emailRepository.refreshInbox(InboxTab.INBOX, accountId = accountId)
-            Log.i("EmailSyncWorker", "Refresh result for $accountId: isSuccess=${result.isSuccess}")
-            if (result.isFailure) {
-                val error = result.exceptionOrNull()
-                val msg = error?.message ?: ""
-                if (msg.contains("sign in", ignoreCase = true) || msg.contains("Session expired", ignoreCase = true) || msg.contains("Authentication failed", ignoreCase = true)) {
-                    Log.w("EmailSyncWorker", "Auth failure for account $accountId — skipping retry")
-                    hasAuthFailure = true
-                } else {
-                    Log.e("EmailSyncWorker", "refreshInbox failed for account $accountId", error)
-                    hasFailure = true
+        val results = coroutineScope {
+            accounts.map { account ->
+                async(Dispatchers.IO) {
+                    val accountId = account.id
+                    val lastKnownTimestamp = accountManager.getLastKnownEmailId(accountId)
+                    Log.i("EmailSyncWorker", "Starting sync for account $accountId (lastKnownTimestamp: $lastKnownTimestamp)")
+                    val refreshResult = emailRepository.refreshInbox(InboxTab.INBOX, accountId = accountId)
+                    Log.i("EmailSyncWorker", "Refresh result for $accountId: isSuccess=${refreshResult.isSuccess}")
+
+                    var hasFailure = false
+                    var hasAuthFailure = false
+
+                    if (refreshResult.isFailure) {
+                        val error = refreshResult.exceptionOrNull()
+                        val msg = error?.message ?: ""
+                        if (msg.contains("sign in", ignoreCase = true) || msg.contains("Session expired", ignoreCase = true) || msg.contains("Authentication failed", ignoreCase = true)) {
+                            Log.w("EmailSyncWorker", "Auth failure for account $accountId — skipping retry")
+                            hasAuthFailure = true
+                        } else {
+                            Log.e("EmailSyncWorker", "refreshInbox failed for account $accountId", error)
+                            hasFailure = true
+                        }
+                    } else {
+                        val newestThread = emailRepository.getLatestInboxThread(accountId)
+                        if (newestThread != null) {
+                            val newTimestamp = newestThread.date
+                            Log.i("EmailSyncWorker", "Latest thread for $accountId: subject='${newestThread.subject}', date=$newTimestamp")
+                            if (lastKnownTimestamp != null && newTimestamp.toString() != lastKnownTimestamp) {
+                                Log.i("EmailSyncWorker", "New email detected for $accountId! Showing notification...")
+                                showNotification(
+                                    accountId = accountId,
+                                    thread = newestThread,
+                                    notificationId = accountId.hashCode()
+                                )
+                            } else if (lastKnownTimestamp == null) {
+                                Log.i("EmailSyncWorker", "lastKnownTimestamp was null (first sync baseline). Skipping notification banner.")
+                            } else {
+                                Log.i("EmailSyncWorker", "No new emails detected (timestamp matched lastKnownTimestamp).")
+                            }
+                            accountManager.setLastKnownEmailId(accountId, newTimestamp.toString())
+                        } else {
+                            Log.w("EmailSyncWorker", "getLatestInboxThread returned null for $accountId")
+                        }
+                    }
+
+                    Pair(hasFailure, hasAuthFailure)
                 }
-                continue
-            }
-            val newestThread = emailRepository.getLatestInboxThread(accountId)
-            if (newestThread != null) {
-                val newTimestamp = newestThread.date
-                Log.i("EmailSyncWorker", "Latest thread for $accountId: subject='${newestThread.subject}', date=$newTimestamp")
-                if (lastKnownTimestamp != null && newTimestamp.toString() != lastKnownTimestamp) {
-                    Log.i("EmailSyncWorker", "New email detected for $accountId! Showing notification...")
-                    showNotification(
-                        accountId = accountId,
-                        thread = newestThread,
-                        notificationId = accountId.hashCode()
-                    )
-                } else if (lastKnownTimestamp == null) {
-                    Log.i("EmailSyncWorker", "lastKnownTimestamp was null (first sync baseline). Skipping notification banner.")
-                } else {
-                    Log.i("EmailSyncWorker", "No new emails detected (timestamp matched lastKnownTimestamp).")
-                }
-                accountManager.setLastKnownEmailId(accountId, newTimestamp.toString())
-            } else {
-                Log.w("EmailSyncWorker", "getLatestInboxThread returned null for $accountId")
-            }
+            }.awaitAll()
         }
         scheduleNextAdaptiveSync(applicationContext, accountManager)
-        return if (hasFailure && !hasAuthFailure) Result.retry() else Result.success()
+        val overallHasFailure = results.any { it.first }
+        val overallHasAuthFailure = results.any { it.second }
+        return if (overallHasFailure && !overallHasAuthFailure) Result.retry() else Result.success()
     }
 
     private suspend fun scheduleNextAdaptiveSync(context: Context, accountManager: AccountManager) {


### PR DESCRIPTION
Replace the sequential for-loop over accounts with parallel `async` coroutines so that multi-account sync completes faster. Each account's refresh and notification logic runs in its own `Dispatchers.IO` coroutine, and all results are aggregated before determining the final `Result`.

Closes SHR-130