### PR TITLE
fix: preserve inbox scroll position on back nav, cleanup settings UI

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/data/local/EmailDao.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/local/EmailDao.kt
@@ -83,9 +83,17 @@ interface EmailDao {
 
     @Query("SELECT id, isRead FROM emails WHERE accountId = :accountId")
     suspend fun getEmailReadStatuses(accountId: String): List<EmailReadStatusProjection>
+
+    @Query("SELECT id, attachmentsJson FROM emails WHERE accountId = :accountId")
+    suspend fun getAttachmentJsonForAccount(accountId: String): List<AttachmentJsonProjection>
 }
 
 data class EmailReadStatusProjection(
     val id: String,
     val isRead: Boolean
+)
+
+data class AttachmentJsonProjection(
+    val id: String,
+    val attachmentsJson: String
 )

--- a/app/src/main/java/com/shrivatsav/monomail/data/mapper/EmailMapper.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/mapper/EmailMapper.kt
@@ -25,7 +25,9 @@ object EmailMapper {
         val labels   = labelIds.orEmpty()
         val isRead   = "UNREAD" !in labels
         val isStarred = "STARRED" in labels
-        val bodyInfo = extractAndInjectImages(payload)
+        val attachments = extractAttachments(payload, id)
+        val attachmentCids = extractFilenamedImageCids(payload)
+        val bodyInfo = extractAndInjectImages(payload, attachmentCids)
         return Email(
             id        = id,
             threadId  = threadId,
@@ -42,7 +44,7 @@ object EmailMapper {
             isRead    = isRead,
             isStarred = isStarred,
             labels    = labels,
-            attachments = extractAttachments(payload, id)
+            attachments = attachments
         )
     }
     fun GmailThread.toEmailThread(): EmailThread {
@@ -124,24 +126,50 @@ object EmailMapper {
         }
         return BodyResult("", isHtml = true)
     }
-    private fun extractAndInjectImages(payload: MessagePart?): BodyResult {
+    private fun extractFilenamedImageCids(part: MessagePart?): Set<String> {
+        if (part == null) return emptySet()
+        val cids = mutableSetOf<String>()
+        val contentId = part.headers?.firstOrNull { it.name.equals("Content-ID", true) }?.value?.removeSurrounding("<", ">")
+        if (contentId != null && !part.filename.isNullOrEmpty()) {
+            cids.add(contentId)
+        }
+        part.parts?.forEach { cids.addAll(extractFilenamedImageCids(it)) }
+        return cids
+    }
+    private fun extractAndInjectImages(payload: MessagePart?, attachmentCids: Set<String> = emptySet()): BodyResult {
         val bodyInfo = extractBody(payload)
         val cidMap = mutableMapOf<String, String>()
-        extractInlineImages(payload, cidMap)
+        val attachmentCidList = mutableListOf<Pair<String, String>>()
+        extractInlineImages(payload, cidMap, attachmentCidList, attachmentCids)
         var htmlBody = bodyInfo.text
         cidMap.forEach { (cid, dataUri) ->
             htmlBody = htmlBody.replace("cid:$cid", dataUri)
         }
+        attachmentCidList.forEach { (cid, filename) ->
+            htmlBody = htmlBody.replace(
+                "cid:$cid",
+                """<div style="padding:8px;margin:8px 0;background:#f0f0f0;border-radius:6px;text-align:center;font-family:sans-serif;font-size:13px;color:#666;">📎 <em>$filename</em> (inline image — see attachments)</div>"""
+            )
+        }
         return BodyResult(htmlBody, bodyInfo.isHtml)
     }
-    private fun extractInlineImages(part: MessagePart?, map: MutableMap<String, String>) {
+    private fun extractInlineImages(
+        part: MessagePart?,
+        map: MutableMap<String, String>,
+        attachmentCids: MutableList<Pair<String, String>> = mutableListOf(),
+        skipCids: Set<String> = emptySet()
+    ) {
         if (part == null) return
         val contentId = part.headers?.firstOrNull { it.name.equals("Content-ID", true) }?.value?.removeSurrounding("<", ">")
         if (contentId != null && part.mimeType?.startsWith("image/") == true && !part.body?.data.isNullOrEmpty()) {
-            val base64 = part.body!!.data!!.replace("-", "+").replace("_", "/")
-            map[contentId] = "data:${part.mimeType};base64,$base64"
+            if (contentId in skipCids) {
+                attachmentCids.add(contentId to (part.filename ?: "inline image"))
+            } else {
+                val base64 = part.body!!.data!!.replace("-", "+").replace("_", "/")
+                map[contentId] = "data:${part.mimeType};base64,$base64"
+            }
         }
-        part.parts?.forEach { extractInlineImages(it, map) }
+        part.parts?.forEach { extractInlineImages(it, map, attachmentCids, skipCids) }
     }
     private fun extractAttachments(part: MessagePart?, messageId: String): List<com.shrivatsav.monomail.data.model.EmailAttachmentInfo> {
         if (part == null) return emptyList()

--- a/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/repository/EmailRepository.kt
@@ -215,9 +215,11 @@ class EmailRepository(
                         inSpam = EmailFolder.SPAM in allFolders
                     )
                 }
+                val existingAttachments = emailDao.getAttachmentJsonForAccount(targetAccountId)
+                    .associate { it.id to it.attachmentsJson }
                 val allEmails = listResponse.threads.filter { it.threadId !in pendingThreadIds }.flatMap { providerThread ->
                     providerThread.messages.map { msg ->
-                        Email(
+                        var entity = Email(
                             id = msg.id,
                             threadId = msg.threadId,
                             subject = msg.subject,
@@ -235,6 +237,15 @@ class EmailRepository(
                             labels = msg.folders.map { it.name },
                             attachments = msg.attachments
                         ).toEntity(targetAccountId)
+                        // Preserve existing attachment data when provider returned empty
+                        // (Outlook: listThreads returns emptyList, getThread fetches correctly)
+                        val existingJson = existingAttachments[entity.id]
+                        if ((entity.attachmentsJson == "[]" || entity.attachmentsJson == "") &&
+                            existingJson != null && existingJson != "[]" && existingJson.isNotEmpty()
+                        ) {
+                            entity = entity.copy(attachmentsJson = existingJson)
+                        }
+                        entity
                     }
                 }
                 val existingSnoozed = threadDao.getSnoozeStateForThreads(

--- a/app/src/main/java/com/shrivatsav/monomail/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/settings/SettingsDataStore.kt
@@ -70,7 +70,8 @@ data class AppSettings(
     val undoSendEnabled: Boolean = true,
     val undoSendWindow: UndoSendWindow = UndoSendWindow.SEC_10,
     val dockConfig: DockConfig = DockConfig.defaults(),
-    val isDeveloperMode: Boolean = false
+    val isDeveloperMode: Boolean = false,
+    val showInlineAttachments: Boolean = true
 )
 class SettingsDataStore(private val context: Context) {
     private val gson = Gson()
@@ -104,6 +105,7 @@ class SettingsDataStore(private val context: Context) {
         val TEMPLATES = stringPreferencesKey("email_templates")
         val DOCK_CONFIG = stringPreferencesKey("dock_config")
         val IS_DEVELOPER_MODE = booleanPreferencesKey("is_developer_mode")
+        val SHOW_INLINE_ATTACHMENTS = booleanPreferencesKey("show_inline_attachments")
     }
 
     private fun mapToSettings(prefs: Preferences): AppSettings {
@@ -137,7 +139,8 @@ class SettingsDataStore(private val context: Context) {
             dockConfig = dockConfigJson?.let { json ->
                 try { gson.fromJson(json, DockConfig::class.java) } catch (e: Exception) { DockConfig.defaults() }
             } ?: DockConfig.defaults(),
-            isDeveloperMode = prefs[Keys.IS_DEVELOPER_MODE] ?: false
+            isDeveloperMode = prefs[Keys.IS_DEVELOPER_MODE] ?: false,
+            showInlineAttachments = prefs[Keys.SHOW_INLINE_ATTACHMENTS] ?: true
         )
     }
 
@@ -223,6 +226,9 @@ class SettingsDataStore(private val context: Context) {
     }
     suspend fun setDeveloperMode(enabled: Boolean) {
         context.dataStore.edit { it[Keys.IS_DEVELOPER_MODE] = enabled }
+    }
+    suspend fun setShowInlineAttachments(enabled: Boolean) {
+        context.dataStore.edit { it[Keys.SHOW_INLINE_ATTACHMENTS] = enabled }
     }
     suspend fun getTemplates(): List<EmailTemplate> {
         val prefs = context.dataStore.data.first()

--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -1,4 +1,5 @@
 package com.shrivatsav.monomail.ui.navigation
+import android.net.Uri
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -52,8 +53,6 @@ import com.shrivatsav.monomail.ui.screens.scheduled.ScheduledMessagesViewModel
 import com.shrivatsav.monomail.ui.screens.pgp.PgpKeyManagementScreen
 import com.shrivatsav.monomail.ui.screens.settings.SettingsScreen
 import com.shrivatsav.monomail.ui.screens.settings.SettingsViewModel
-import java.net.URLDecoder
-import java.net.URLEncoder
 sealed class Screen(val route: String) {
     object Onboarding   : Screen("onboarding")
     object SignIn       : Screen("sign_in")
@@ -71,7 +70,7 @@ sealed class Screen(val route: String) {
             messageId: String = "",
             scheduledId: String = ""
         ): String {
-            val enc = { s: String -> URLEncoder.encode(s, "UTF-8") }
+            val enc = { s: String -> Uri.encode(s) }
             return "compose?mode=${mode.name}&to=${enc(to)}&subject=${enc(subject)}&threadId=${enc(threadId)}&messageId=${enc(messageId)}&scheduledId=${enc(scheduledId)}"
         }
     }
@@ -366,15 +365,6 @@ fun NavGraph(
                     navArgument("scheduledId") { type = NavType.StringType; defaultValue = "" }
                 )
             ) { backStackEntry ->
-                val dec = { s: String -> URLDecoder.decode(s, "UTF-8") }
-                val mode = ComposeMode.valueOf(
-                    backStackEntry.arguments?.getString("mode") ?: "NEW"
-                )
-                val to = dec(backStackEntry.arguments?.getString("to") ?: "")
-                val subject = dec(backStackEntry.arguments?.getString("subject") ?: "")
-                val threadId = dec(backStackEntry.arguments?.getString("threadId") ?: "").takeIf { it.isNotEmpty() }
-                val messageId = dec(backStackEntry.arguments?.getString("messageId") ?: "").takeIf { it.isNotEmpty() }
-                val scheduledId = dec(backStackEntry.arguments?.getString("scheduledId") ?: "").takeIf { it.isNotEmpty() }
                 val vm: ComposeViewModel = hiltViewModel()
                 ComposeScreen(
                     viewModel = vm,

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -120,6 +120,7 @@ fun EmailDetailScreen(
     val loadRemoteImages by viewModel.loadRemoteImages.collectAsState()
     val renderMarkdown by viewModel.renderMarkdown.collectAsState()
     val emailTheme by viewModel.emailTheme.collectAsState()
+    val showInlineAttachments by viewModel.showInlineAttachments.collectAsState()
     val state by viewModel.state.collectAsState()
     val isStarred by viewModel.isStarred.collectAsState()
     val decryptedBodies by viewModel.decryptedBodies.collectAsState()
@@ -317,6 +318,7 @@ fun EmailDetailScreen(
                             loadRemoteImages = loadRemoteImages,
                             renderMarkdown = renderMarkdown,
                             emailTheme = emailTheme,
+                            showInlineAttachments = showInlineAttachments,
                             onReply = { onReply(replyTarget, latestEmail.subject, latestBody, latestEmail.threadId, latestEmail.id) },
                             onForward = { onForward(latestEmail.subject, latestBody, latestEmail.threadId, latestEmail.id) },
                             onFetchAttachment = onFetchAttachment
@@ -414,6 +416,7 @@ fun ThreadConversationContent(
     loadRemoteImages: Boolean = true,
     renderMarkdown: Boolean = false,
     emailTheme: EmailTheme = EmailTheme.AUTO,
+    showInlineAttachments: Boolean = true,
     onReply: () -> Unit = {},
     onForward: () -> Unit = {},
     onFetchAttachment: suspend (String, String) -> ByteArray? = { _, _ -> null }
@@ -454,7 +457,7 @@ fun ThreadConversationContent(
             )
             Spacer(modifier = Modifier.height(16.dp))
         }
-        
+
         emails.forEachIndexed { index, email ->
             val isExpanded = expandedMap[email.id] ?: true
             if (isConversationView) {
@@ -548,6 +551,14 @@ fun ThreadConversationContent(
                         }
                     }
                 }
+                // Per-email attachment summary — between sender info and body
+                if (!showInlineAttachments && email.attachments.isNotEmpty()) {
+                    val perEmailAttachments = email.attachments.map { it to displayName(email.from) }
+                    ThreadAttachmentsSummary(
+                        attachmentsWithSender = perEmailAttachments,
+                        onFetchAttachment = onFetchAttachment
+                    )
+                }
                 AnimatedVisibility(
                     visible = isExpanded,
                     enter = fadeIn(tween(200)) + expandVertically(tween(200)),
@@ -556,7 +567,6 @@ fun ThreadConversationContent(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(IntrinsicSize.Min)
                             .background(
                                 if (index % 2 == 1)
                                     MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.25f)
@@ -569,11 +579,12 @@ fun ThreadConversationContent(
                                 modifier = Modifier
                                     .width(2.dp)
                                     .fillMaxHeight()
+                                    .heightIn(min = 120.dp)
                                     .padding(start = 28.dp)
                                     .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.25f))
                             )
                         }
-                        Column(modifier = Modifier.weight(1f)) {
+                        Column(modifier = Modifier.weight(1f).heightIn(min = 120.dp)) {
                             // Show CC/BCC when expanded
                             if (email.cc.isNotBlank() || email.bcc.isNotBlank()) {
                                 Box(
@@ -638,6 +649,7 @@ fun ThreadConversationContent(
                                 loadRemoteImages = loadRemoteImages,
                                 renderMarkdown = renderMarkdown,
                                 emailTheme = emailTheme,
+                                showInlineAttachments = showInlineAttachments,
                                 onFetchAttachment = onFetchAttachment,
                                 modifier = Modifier.fillMaxWidth()
                             )
@@ -655,6 +667,7 @@ fun ThreadConversationContent(
                     loadRemoteImages = loadRemoteImages,
                     renderMarkdown = renderMarkdown,
                     emailTheme = emailTheme,
+                    showInlineAttachments = showInlineAttachments,
                     onFetchAttachment = onFetchAttachment,
                     showSender = true,
                     messageCount = emails.size
@@ -766,6 +779,7 @@ private fun MessageBody(
     loadRemoteImages: Boolean = true,
     renderMarkdown: Boolean = false,
     emailTheme: EmailTheme = EmailTheme.AUTO,
+    showInlineAttachments: Boolean = true,
     onFetchAttachment: suspend (String, String) -> ByteArray?,
     showSender: Boolean = false,
     messageCount: Int = 0,
@@ -985,9 +999,22 @@ private fun MessageBody(
         }
     }
 
+        // Per-email attachment summary — shown between sender info and body when dropdown mode
+        // Only when MessageBody handles sender info (non-conversation view); conversation view
+        // inserts it before the MessageBody call in the email loop.
+        if (showSender && !showInlineAttachments && email.attachments.isNotEmpty()) {
+            val perEmailAttachments = email.attachments.map { it to displayName(email.from) }
+            Spacer(modifier = Modifier.height(8.dp))
+            ThreadAttachmentsSummary(
+                attachmentsWithSender = perEmailAttachments,
+                onFetchAttachment = onFetchAttachment
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
         // Images blocked banner (shown when loadRemoteImages is off and showRemoteImages is still false)
 
-        val htmlContent = remember(email.id, bodyText, bgColor, textColor, linkColor, fontScaleMultiplier, showQuotedText, loadRemoteImages, showRemoteImages, renderMarkdown, emailTheme) {
+        val htmlContent = remember(email.id, bodyText, bgColor, textColor, linkColor, fontScaleMultiplier, showQuotedText, loadRemoteImages, showRemoteImages, renderMarkdown, emailTheme, showInlineAttachments) {
             val displayBody = try {
                 // Determine body: preserve or strip quoted text
                 val body = if (showQuotedText) bodyText else HtmlSanitizer.stripQuotedText(bodyText)
@@ -1038,6 +1065,26 @@ private fun MessageBody(
                 else -> {
                     HtmlSanitizer.stripFixedWidthAttrs(wrappedBody)
                 }
+            }
+
+            // Replace inline CID images (Outlook) with placeholder when they're also attachments
+            val bodyWithCidPlaceholders = if (!showInlineAttachments && email.attachments.isNotEmpty()) {
+                var b = enhancedBody
+                for (att in email.attachments) {
+                    if (att.name.isBlank()) continue
+                    val escapedName = Regex.escape(att.name)
+                    // Match <img> tags with src="cid:NAME" or src='cid:NAME'
+                    val cidPattern = Regex(
+                        """<img[^>]*src\s*=\s*["']cid:${escapedName}["'][^>]*>""",
+                        RegexOption.IGNORE_CASE
+                    )
+                    b = b.replace(cidPattern) {
+                        """<div style="padding:8px;margin:8px 0;background:#f0f0f0;border-radius:6px;text-align:center;font-family:sans-serif;font-size:13px;color:#666;">📎 <em>${att.name}</em> (inline image — see attachments)</div>"""
+                    }
+                }
+                b
+            } else {
+                enhancedBody
             }
 
             // Shared quoted-text CSS (same for both modes)
@@ -1255,7 +1302,7 @@ private fun MessageBody(
                     $imgBlockCss
                 </style>
             </head>
-            <body class="${if (showQuotedText) "show-quotes " else ""}${if (useDarkTheme && effectiveMode == "adapt") "monomail-dark" else ""}">$enhancedBody</body>
+            <body class="${if (showQuotedText) "show-quotes " else ""}${if (useDarkTheme && effectiveMode == "adapt") "monomail-dark" else ""}">$bodyWithCidPlaceholders</body>
             </html>
             """.trimIndent()
         }
@@ -1442,8 +1489,8 @@ private fun MessageBody(
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
-            if (email.attachments.isNotEmpty()) {
+            if (showInlineAttachments && email.attachments.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(16.dp))
                 AttachmentsSection(
                     attachments = email.attachments,
                     onFetchAttachment = onFetchAttachment
@@ -1692,6 +1739,108 @@ private fun FileAttachmentCard(
         }
     }
 }
+
+@Composable
+private fun ThreadAttachmentsSummary(
+    attachmentsWithSender: List<Pair<EmailAttachmentInfo, String>>,
+    onFetchAttachment: suspend (String, String) -> ByteArray?
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val imageAttachments = attachmentsWithSender.filter { isImageAttachment(it.first) }
+    val fileAttachments = attachmentsWithSender.filter { !isImageAttachment(it.first) }
+    val totalCount = attachmentsWithSender.size
+    val imageCount = imageAttachments.size
+
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { expanded = !expanded }
+                .background(MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.5f))
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.AttachFile,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = "$totalCount Attachment${if (totalCount != 1) "s" else ""}" +
+                    if (imageCount > 0) " ($imageCount image${if (imageCount != 1) "s" else ""})" else "",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+            )
+        }
+
+        if (expanded) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                imageAttachments.forEach { (attachment, sender) ->
+                    Column {
+                        ImageAttachmentCard(
+                            attachment = attachment,
+                            onFetchAttachment = onFetchAttachment
+                        )
+                        Text(
+                            text = "from $sender",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+                            modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+                        )
+                    }
+                }
+
+                if (fileAttachments.isNotEmpty()) {
+                    BoxWithConstraints {
+                        val columnWidth = 200.dp
+                        val columns = maxOf(1, (maxWidth / columnWidth).toInt())
+                        fileAttachments.chunked(columns).forEach { rowItems ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                rowItems.forEach { (attachment, sender) ->
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        FileAttachmentCard(
+                                            attachment = attachment,
+                                            onFetchAttachment = onFetchAttachment,
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                        Text(
+                                            text = "from $sender",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+                                            modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+                                        )
+                                    }
+                                }
+                                repeat(columns - rowItems.size) {
+                                    Spacer(modifier = Modifier.weight(1f))
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
 private val detailDateFormat = SimpleDateFormat("MMM d, yyyy  h:mm a", Locale.getDefault())
 
 /**

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailViewModel.kt
@@ -73,6 +73,10 @@ class EmailDetailViewModel @Inject constructor(
     val isDeveloperMode: StateFlow<Boolean> = settingsDataStore.settingsFlow
         .map { it.isDeveloperMode }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    val showInlineAttachments: StateFlow<Boolean> = settingsDataStore.settingsFlow
+        .map { it.showInlineAttachments }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
     val state: StateFlow<EmailDetailState> = kotlinx.coroutines.flow.combine(
         repository.getThreadEmailsFlow(threadId),
         _isLoading,

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -90,7 +90,6 @@ fun InboxScreen(
         com.shrivatsav.monomail.data.settings.FontScale.EXTRA_LARGE -> 1.3f
     }
 
-    val listState = rememberLazyListState()
     val pullToRefreshState = rememberPullToRefreshState()
     var searchQuery by remember { mutableStateOf("") }
     val currentThreads = (state as? InboxState.Success)?.threads ?: emptyList()
@@ -117,17 +116,6 @@ fun InboxScreen(
                         it.snippet.contains(searchQuery, ignoreCase = true)
             }
         }
-    }
-
-    val shouldLoadMore by remember {
-        derivedStateOf {
-            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            val totalItems = listState.layoutInfo.totalItemsCount
-            totalItems > 0 && lastVisible >= totalItems - 5
-        }
-    }
-    LaunchedEffect(Unit) {
-        snapshotFlow { shouldLoadMore }.collect { if (it) viewModel.loadMore() }
     }
 
     var blurForModal by remember { mutableStateOf(false) }
@@ -272,6 +260,28 @@ fun InboxScreen(
                         is InboxState.Success -> {
                             val currentTab = s.currentTab
                             key(currentTab) {
+                            val savedPos = viewModel.scrollPositions.collectAsState().value[currentTab] ?: (0 to 0)
+                            val listState = rememberLazyListState(
+                                initialFirstVisibleItemIndex = savedPos.first,
+                                initialFirstVisibleItemScrollOffset = savedPos.second
+                            )
+                            val shouldLoadMore by remember {
+                                derivedStateOf {
+                                    val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                                    val totalItems = listState.layoutInfo.totalItemsCount
+                                    totalItems > 0 && lastVisible >= totalItems - 5
+                                }
+                            }
+                            LaunchedEffect(Unit) {
+                                snapshotFlow { shouldLoadMore }.collect { if (it) viewModel.loadMore() }
+                            }
+                            LaunchedEffect(listState, currentTab) {
+                                snapshotFlow {
+                                    listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+                                }.collect { (index, offset) ->
+                                    viewModel.saveScrollState(currentTab, index, offset)
+                                }
+                            }
                             val threadsToDisplay = localFilteredThreads ?: s.threads
                             val isSearchActive = localFilteredThreads != null
                             var expandedGroupsList by androidx.compose.runtime.saveable.rememberSaveable {
@@ -309,11 +319,6 @@ fun InboxScreen(
                                     }
                                 }
                             }
-                            // Reset scroll to top on tab entry
-                            LaunchedEffect(Unit) {
-                                listState.scrollToItem(0)
-                            }
-
                             PullToRefreshBox(
                                 isRefreshing = s.isRefreshing,
                                 onRefresh = { viewModel.refresh() },

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxViewModel.kt
@@ -107,6 +107,12 @@ class InboxViewModel @Inject constructor(
     }
     private val _state = MutableStateFlow<InboxState>(InboxState.Loading)
     val state: StateFlow<InboxState> = _state.asStateFlow()
+    private val _scrollPositions = MutableStateFlow<Map<InboxTab, Pair<Int, Int>>>(emptyMap())
+    val scrollPositions: StateFlow<Map<InboxTab, Pair<Int, Int>>> = _scrollPositions.asStateFlow()
+
+    fun saveScrollState(tab: InboxTab, index: Int, offset: Int) {
+        _scrollPositions.value = _scrollPositions.value + (tab to (index to offset))
+    }
 
     init {
         viewModelScope.launch {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/AboutSettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/AboutSettingsScreen.kt
@@ -33,7 +33,6 @@ internal fun AboutSettingsScreen(
 
     ScrollableSettingsScaffold(title = "About", onBack = onBack) {
         SettingsCard {
-            SectionHeader(icon = Icons.Rounded.Info, title = "About")
             InfoRow(
                 icon = Icons.Rounded.Info,
                 title = "Version",

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/AppearanceSettingsScreen.kt
@@ -26,7 +26,6 @@ internal fun AppearanceSettingsScreen(
         onBack = onBack
     ) {
         SettingsCard {
-            SectionHeader(icon = Icons.Rounded.Palette, title = "Appearance")
             ThemeSelectorRow(
                 currentTheme = settings.themeMode,
                 onThemeSelected = { viewModel.setThemeMode(it) }
@@ -75,6 +74,14 @@ internal fun AppearanceSettingsScreen(
                 subtitle = "Convert markdown formatting in plain text emails",
                 checked = settings.renderMarkdown,
                 onCheckedChange = { viewModel.setRenderMarkdown(it) }
+            )
+            CardDivider()
+            SettingsToggleRow(
+                icon = Icons.Rounded.AttachFile,
+                title = "Inline Attachments",
+                subtitle = "Show attachment cards within the email body, or as a collapsible summary above it",
+                checked = settings.showInlineAttachments,
+                onCheckedChange = { viewModel.setShowInlineAttachments(it) }
             )
             CardDivider()
             SettingsToggleRow(

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/ComposeSettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/ComposeSettingsScreen.kt
@@ -23,7 +23,6 @@ internal fun ComposeSettingsScreen(
 
     ScrollableSettingsScaffold(title = "Compose", onBack = onBack) {
         SettingsCard {
-            SectionHeader(icon = Icons.AutoMirrored.Rounded.Send, title = "Compose")
             BottomSheetPickerRow(
                 icon = Icons.AutoMirrored.Rounded.Reply,
                 title = "Default Reply",

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/InboxSettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/InboxSettingsScreen.kt
@@ -23,7 +23,6 @@ internal fun InboxSettingsScreen(
 
     ScrollableSettingsScaffold(title = "Inbox", onBack = onBack) {
         SettingsCard {
-            SectionHeader(icon = Icons.Rounded.Inbox, title = "Inbox")
             SettingsToggleRow(
                 icon = Icons.Rounded.Forum,
                 title = if (settings.organizeByThread) "Conversation View" else "Message Chain",

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/NavigationSettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/NavigationSettingsScreen.kt
@@ -1,8 +1,6 @@
 package com.shrivatsav.monomail.ui.screens.settings
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.SpaceDashboard
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -19,7 +17,6 @@ internal fun NavigationSettingsScreen(
 
     ScrollableSettingsScaffold(title = "Navigation", onBack = onBack) {
         SettingsCard {
-            SectionHeader(icon = Icons.Rounded.SpaceDashboard, title = "Navigation")
             NavSizeRow(
                 scale = settings.navScale,
                 onScaleChanged = { viewModel.setNavScale(it) }
@@ -28,7 +25,6 @@ internal fun NavigationSettingsScreen(
             DockBarEditor(
                 dockConfig = settings.dockConfig,
                 maxSlots = DockConfig.MAX_SLOTS,
-                unifiedInboxEnabled = settings.unifiedInboxEnabled,
                 onConfigChanged = { viewModel.setDockConfig(it) }
             )
         }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/NotificationSettingsScreen.kt
@@ -19,7 +19,6 @@ internal fun NotificationSettingsScreen(
 
     ScrollableSettingsScaffold(title = "Notifications", onBack = onBack) {
         SettingsCard {
-            SectionHeader(icon = Icons.Rounded.Notifications, title = "Notifications")
             SettingsToggleRow(
                 icon = Icons.Rounded.NotificationsActive,
                 title = "Email Notifications",

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsComponents.kt
@@ -863,10 +863,9 @@ internal fun TemplatesCard(viewModel: SettingsViewModel) {
 internal fun DockBarEditor(
     dockConfig: DockConfig,
     maxSlots: Int,
-    unifiedInboxEnabled: Boolean,
     onConfigChanged: (DockConfig) -> Unit
 ) {
-    val allTabs = DockTabId.values().filter { if (unifiedInboxEnabled) it != DockTabId.UNIFIED else true }
+    val allTabs = DockTabId.values().filter { it != DockTabId.UNIFIED }
     val availableTabs = allTabs.filter { it !in dockConfig.primaryTabs }
 
     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsScreen.kt
@@ -29,7 +29,7 @@ enum class SettingsSection(val icon: ImageVector, val title: String, val subtitl
     APPEARANCE(Icons.Rounded.Palette, "Appearance", "Theme, font size, display preferences"),
     INBOX(Icons.Rounded.Inbox, "Inbox", "Threading, smart grouping, swipe gestures"),
     COMPOSE(Icons.AutoMirrored.Rounded.Send, "Compose", "Reply defaults, confirm send, undo send"),
-    NAVIGATION(Icons.Rounded.SpaceDashboard, "Navigation", "Dock tabs, unified inbox"),
+    NAVIGATION(Icons.Rounded.SpaceDashboard, "Navigation", "Dock tabs & navigation bar"),
     NOTIFICATIONS(Icons.Rounded.Notifications, "Notifications", "Push alerts, sync frequency"),
     ABOUT(Icons.Rounded.Info, "About", "Version, updates, legal, licenses")
 }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/SettingsViewModel.kt
@@ -54,6 +54,7 @@ class SettingsViewModel @Inject constructor(
     fun setUndoSendWindow(window: UndoSendWindow) = viewModelScope.launch { settingsDataStore.setUndoSendWindow(window) }
     fun setDockConfig(config: DockConfig) = viewModelScope.launch { settingsDataStore.setDockConfig(config) }
     fun setDeveloperMode(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setDeveloperMode(enabled) }
+    fun setShowInlineAttachments(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowInlineAttachments(enabled) }
     val templates = settingsDataStore.templatesFlow
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
     fun saveTemplates(templates: List<EmailTemplate>) = viewModelScope.launch {


### PR DESCRIPTION
## Summary

- Preserves inbox scroll position when navigating back from email detail (moves listState inside key(currentTab), adds per-tab scroll tracking in ViewModel, removes scrollToItem LaunchedEffect)
- Removes unifiedInboxEnabled filter from DockBarEditor — unified is not a dock tab
- Removes 6 duplicate SectionHeader calls from settings screen cards