### PR TITLE
fix: resolve all deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,65 +130,81 @@ jobs:
           curl -fsSL https://opencode.ai/install | bash
           echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
-      # --------------------------------------------------------------------------
-      # Generate Release Notes
-      # --------------------------------------------------------------------------
+            # --------------------------------------------------------------------------
+            # Generate Release Notes
+            # --------------------------------------------------------------------------
 
-      - name: Gather changelog source
-        run: |
-          if [ -n "${{ steps.committag.outputs.PREV_TAG }}" ]; then
-            RANGE="${{ steps.committag.outputs.PREV_TAG }}..HEAD"
-          else
-            RANGE="HEAD"
-          fi
+            - name: Gather changelog source
+              run: |
+                if [ -n "${{ steps.committag.outputs.PREV_TAG }}" ]; then
+                  RANGE="${{ steps.committag.outputs.PREV_TAG }}..HEAD"
+                else
+                  RANGE="HEAD"
+                fi
 
-          git log "$RANGE" \
-            --pretty=format:'- %s (%h)' \
-            --no-merges > commit_log.txt
+                echo "Using range: $RANGE"
 
-          cat commit_log.txt
+                git log "$RANGE" \
+                  --pretty=format:'%s' \
+                  --no-merges > commit_log.txt
 
-      - name: Generate release notes with OpenCode
-        continue-on-error: true
-        env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-        run: |
-          PROMPT="Write concise, user-facing GitHub release notes.
+                echo "===== Commits ====="
+                cat commit_log.txt
 
-          Group changes under:
-          - Features
-          - Bug Fixes
-          - Maintenance
+            - name: Generate release notes with OpenCode
+              continue-on-error: true
+              env:
+                OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+              run: |
+                PROMPT=$(cat <<'EOF'
+                Write concise, user-facing GitHub release notes.
 
-          Omit any empty section.
+                Group changes under:
+                - Features
+                - Bug Fixes
+                - Maintenance
 
-          Use ONLY the commits below.
-          Don't invent features.
-          Output Markdown only.
+                Omit any empty section.
 
-          Commits:
-          $(cat commit_log.txt)"
+                Use ONLY the commits below.
+                Don't invent features.
+                Keep the wording concise and suitable for GitHub Releases.
+                Output Markdown only.
 
-          opencode "$PROMPT" \
-            --model opencode/mimo-v2.5-free \
-            > release_notes.md 2>/dev/null
+                Commits:
+                EOF
+                )
 
-          cat release_notes.md
+                PROMPT="$PROMPT
 
-      # --------------------------------------------------------------------------
-      # Fallback — if OpenCode failed, use raw commit log
-      # --------------------------------------------------------------------------
+                $(cat commit_log.txt)"
 
-      - name: Fallback release notes
-        run: |
-          if [ ! -s release_notes.md ]; then
-            echo "OpenCode failed — using raw commit log as release notes."
-            cat > release_notes.md << EOF
-          ## What's Changed
+                echo "===== Prompt ====="
+                echo "$PROMPT"
 
-          $(cat commit_log.txt)
-          EOF
-          fi
+                opencode run "$PROMPT" \
+                  --model opencode/mimo-v2.5-free \
+                  --print-logs \
+                  | tee release_notes.md
+
+                echo "===== Generated Release Notes ====="
+                cat release_notes.md
+
+            # --------------------------------------------------------------------------
+            # Fallback — if OpenCode failed
+            # --------------------------------------------------------------------------
+
+            - name: Fallback release notes
+              run: |
+                if [ ! -s release_notes.md ]; then
+                  echo "OpenCode failed. Falling back to commit list."
+
+                  cat > release_notes.md <<EOF
+                ## What's Changed
+
+                $(sed 's/^/- /' commit_log.txt)
+                EOF
+                fi
 
       # --------------------------------------------------------------------------
       # Draft GitHub Release

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyManager.kt
@@ -1,6 +1,7 @@
 package com.shrivatsav.monomail.data.pgp
 
 import android.util.Log
+import org.bouncycastle.openpgp.api.OpenPGPCertificate
 import org.pgpainless.PGPainless
 import org.pgpainless.algorithm.KeyFlag
 import org.pgpainless.algorithm.PublicKeyAlgorithm
@@ -8,6 +9,8 @@ import org.pgpainless.key.OpenPgpFingerprint
 import org.pgpainless.key.generation.KeySpec
 import org.pgpainless.key.generation.type.ecc.Ed25519
 import org.pgpainless.key.generation.type.ecc.X25519
+import org.pgpainless.key.info.KeyRingInfo
+import org.pgpainless.key.parsing.KeyRingReader
 import org.pgpainless.key.protection.SecretKeyRingProtector
 import org.pgpainless.util.Passphrase
 import java.util.Date
@@ -24,7 +27,7 @@ class PgpKeyManager @Inject constructor(
         val subkeySpec = KeySpec.getBuilder(X25519(), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE)
             .build()
 
-        val builder = PGPainless.buildKeyRing()
+        val builder = PGPainless.getInstance().buildKey()
             .setPrimaryKey(keySpec)
             .addSubkey(subkeySpec)
             .addUserId(userId)
@@ -34,18 +37,18 @@ class PgpKeyManager @Inject constructor(
         }
 
         val openPgpKey = builder.build()
-        val secretKeyRing = openPgpKey.pgpSecretKeyRing
-        val publicKeyRing = PGPainless.extractCertificate(secretKeyRing)
+        val secretKeyRing = openPgpKey.getPGPKeyRing() as org.bouncycastle.openpgp.PGPSecretKeyRing
+        val publicKeyRing = openPgpKey.getPGPPublicKeyRing()
 
         val info = keyRingToInfo(
             secretKeyRing, isPrivate = true,
             isPassphraseProtected = passphrase != null
         )
 
-        val armoredSecret = PGPainless.asciiArmor(secretKeyRing)
+        val armoredSecret = openPgpKey.toAsciiArmoredString()
         storage.savePrivateKey(info.fingerprint, armoredSecret)
 
-        val armoredPublic = PGPainless.asciiArmor(publicKeyRing)
+        val armoredPublic = OpenPGPCertificate(publicKeyRing).toAsciiArmoredString()
         storage.savePublicKey(info.fingerprint, armoredPublic)
 
         storage.saveKeyMetadata(info.fingerprint, info)
@@ -59,7 +62,7 @@ class PgpKeyManager @Inject constructor(
         val isPrivate = armoredKey.contains("BEGIN PGP PRIVATE KEY BLOCK")
 
         if (isPrivate) {
-            val secretKeyRing = PGPainless.readKeyRing().secretKeyRing(armoredKey)
+            val secretKeyRing = KeyRingReader().secretKeyRing(armoredKey)
                 ?: throw IllegalArgumentException("Failed to parse private key — invalid or corrupted key data")
             val isProtected = try {
                 secretKeyRing.secretKey.keyEncryptionAlgorithm != 0
@@ -68,8 +71,9 @@ class PgpKeyManager @Inject constructor(
             val info = keyRingToInfo(secretKeyRing, isPrivate = true, isPassphraseProtected = isProtected)
 
             storage.savePrivateKey(info.fingerprint, armoredKey)
-            val publicKeyRing = PGPainless.extractCertificate(secretKeyRing)
-            val armoredPublic = PGPainless.asciiArmor(publicKeyRing)
+            val publicKey = PGPainless.getInstance().toKey(secretKeyRing)
+            val publicKeyRing = publicKey.getPGPPublicKeyRing()
+            val armoredPublic = OpenPGPCertificate(publicKeyRing).toAsciiArmoredString()
             storage.savePublicKey(info.fingerprint, armoredPublic)
             storage.saveKeyMetadata(info.fingerprint, info)
             if (passphrase != null) {
@@ -77,7 +81,7 @@ class PgpKeyManager @Inject constructor(
             }
             return info
         } else {
-            val publicKeyRing = PGPainless.readKeyRing().publicKeyRing(armoredKey)
+            val publicKeyRing = KeyRingReader().publicKeyRing(armoredKey)
                 ?: throw IllegalArgumentException("Failed to parse public key — invalid or corrupted key data")
             val info = keyRingToInfo(publicKeyRing, isPrivate = false)
 
@@ -121,7 +125,7 @@ class PgpKeyManager @Inject constructor(
         for (info in allKeys) {
             val armored = storage.loadPublicKey(info.fingerprint) ?: continue
             try {
-                val publicKeyRing = PGPainless.readKeyRing().publicKeyRing(armored)
+                val publicKeyRing = KeyRingReader().publicKeyRing(armored)
                 return publicKeyRing!!.encoded
             } catch (e: Exception) {
                 Log.w("PgpKeyManager", "Failed to parse public key ring for recipient", e)
@@ -139,7 +143,7 @@ class PgpKeyManager @Inject constructor(
         for (info in allKeys) {
             val armored = storage.loadPublicKey(info.fingerprint) ?: continue
             try {
-                PGPainless.readKeyRing().publicKeyRing(armored)
+                KeyRingReader().publicKeyRing(armored)
                 return info.fingerprint
             } catch (e: Exception) {
                 Log.w("PgpKeyManager", "Failed to parse public key ring for fingerprint lookup", e)
@@ -152,7 +156,7 @@ class PgpKeyManager @Inject constructor(
     fun loadSecretKeyRing(fingerprint: String): org.bouncycastle.openpgp.PGPSecretKeyRing? {
         val armored = storage.loadPrivateKey(fingerprint) ?: return null
         return try {
-            PGPainless.readKeyRing().secretKeyRing(armored)
+            KeyRingReader().secretKeyRing(armored)
         } catch (e: Exception) {
             Log.w("PgpKeyManager", "Failed to load secret key ring for $fingerprint", e)
             null
@@ -162,7 +166,7 @@ class PgpKeyManager @Inject constructor(
     fun loadPublicKeyRing(fingerprint: String): org.bouncycastle.openpgp.PGPPublicKeyRing? {
         val armored = storage.loadPublicKey(fingerprint) ?: return null
         return try {
-            PGPainless.readKeyRing().publicKeyRing(armored)
+            KeyRingReader().publicKeyRing(armored)
         } catch (e: Exception) {
             Log.w("PgpKeyManager", "Failed to load public key ring for $fingerprint", e)
             null
@@ -174,7 +178,7 @@ class PgpKeyManager @Inject constructor(
         isPrivate: Boolean,
         isPassphraseProtected: Boolean = false
     ): PgpKeyInfo {
-        val info = PGPainless.inspectKeyRing(ring)
+        val info = KeyRingInfo(ring)
         return PgpKeyInfo(
             fingerprint = info.fingerprint.toString(),
             userId = info.primaryUserId ?: "Unknown",
@@ -190,7 +194,7 @@ class PgpKeyManager @Inject constructor(
         ring: org.bouncycastle.openpgp.PGPPublicKeyRing,
         isPrivate: Boolean
     ): PgpKeyInfo {
-        val info = PGPainless.inspectKeyRing(ring)
+        val info = KeyRingInfo(ring)
         return PgpKeyInfo(
             fingerprint = info.fingerprint.toString(),
             userId = info.primaryUserId ?: "Unknown",

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpKeyStorage.kt
@@ -21,6 +21,7 @@ class PgpKeyStorage @Inject constructor(
     // Encrypted metadata storage (fingerprint → PgpKeyInfo)
     private val gson = Gson()
 
+    @Suppress("DEPRECATION")
     private val prefs: SharedPreferences by lazy {
         val masterKey = MasterKey.Builder(context)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)

--- a/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/data/pgp/PgpManager.kt
@@ -2,11 +2,13 @@ package com.shrivatsav.monomail.data.pgp
 
 import android.util.Log
 import org.bouncycastle.openpgp.PGPException
+import org.bouncycastle.openpgp.api.OpenPGPCertificate
 import org.pgpainless.PGPainless
 import org.pgpainless.decryption_verification.ConsumerOptions
 import org.pgpainless.encryption_signing.EncryptionOptions
 import org.pgpainless.encryption_signing.ProducerOptions
 import org.pgpainless.encryption_signing.SigningOptions
+import org.pgpainless.key.parsing.KeyRingReader
 import org.pgpainless.key.protection.SecretKeyRingProtector
 import org.pgpainless.util.Passphrase
 import java.io.ByteArrayInputStream
@@ -59,7 +61,7 @@ class PgpManager @Inject constructor(
                     continue
                 }
                 val secretKeyRing = try {
-                    PGPainless.readKeyRing().secretKeyRing(armoredSecret)
+                    KeyRingReader().secretKeyRing(armoredSecret)
                         ?: throw NullPointerException("readKeyRing returned null")
                 } catch (e: Exception) {
                     Log.e("PgpManager", "Failed to parse private key ring for $fp", e)
@@ -69,9 +71,9 @@ class PgpManager @Inject constructor(
                 val protector = getProtector(secretKeyRing, fp)
 
                 val consumerOptions = ConsumerOptions.get()
-                    .addDecryptionKey(secretKeyRing, protector)
+                    .addDecryptionKey(PGPainless.getInstance().toKey(secretKeyRing), protector)
 
-                val decryptionStream = PGPainless.decryptAndOrVerify()
+                val decryptionStream = PGPainless.getInstance().processMessage()
                     .onInputStream(ByteArrayInputStream(emailBody.toByteArray()))
                     .withOptions(consumerOptions)
 
@@ -123,7 +125,7 @@ class PgpManager @Inject constructor(
             val fp = keyManager.getPublicKeyForRecipientAsFingerprint(address) ?: return@mapNotNull null
             val armored = storage.loadPublicKey(fp) ?: return@mapNotNull null
             try {
-                PGPainless.readKeyRing().publicKeyRing(armored)
+                KeyRingReader().publicKeyRing(armored)
             } catch (e: Exception) {
                 Log.w("PgpManager", "Failed to parse public key ring for recipient $address", e)
                 null
@@ -135,13 +137,13 @@ class PgpManager @Inject constructor(
         try {
             val encryptionOptions = EncryptionOptions.get()
             for (ring in recipientRings) {
-                encryptionOptions.addRecipient(ring)
+                encryptionOptions.addRecipient(OpenPGPCertificate(ring))
             }
 
             val producerOptions = ProducerOptions.encrypt(encryptionOptions)
             val outputStream = ByteArrayOutputStream()
 
-            val encryptionStream = PGPainless.encryptAndOrSign()
+            val encryptionStream = PGPainless.getInstance().generateMessage()
                 .onOutputStream(outputStream)
                 .withOptions(producerOptions)
 
@@ -159,7 +161,7 @@ class PgpManager @Inject constructor(
     fun signBody(body: String, fingerprint: String): String? {
         val armoredSecret = storage.loadPrivateKey(fingerprint) ?: return null
         val secretKeyRing = try {
-            PGPainless.readKeyRing().secretKeyRing(armoredSecret)!!
+            KeyRingReader().secretKeyRing(armoredSecret)!!
         } catch (e: Exception) {
             Log.w("PgpManager", "Failed to parse secret key ring for signing $fingerprint", e)
             return null
@@ -169,12 +171,12 @@ class PgpManager @Inject constructor(
             val protector = getProtector(secretKeyRing, fingerprint)
 
             val signingOptions = SigningOptions.get()
-                .addInlineSignature(protector, secretKeyRing)
+                .addInlineSignature(protector, PGPainless.getInstance().toKey(secretKeyRing))
 
             val producerOptions = ProducerOptions.sign(signingOptions)
             val outputStream = ByteArrayOutputStream()
 
-            val signingStream = PGPainless.encryptAndOrSign()
+            val signingStream = PGPainless.getInstance().generateMessage()
                 .onOutputStream(outputStream)
                 .withOptions(producerOptions)
 
@@ -197,7 +199,7 @@ class PgpManager @Inject constructor(
             val fp = keyManager.getPublicKeyForRecipientAsFingerprint(address) ?: return@mapNotNull null
             val armored = storage.loadPublicKey(fp) ?: return@mapNotNull null
             try {
-                PGPainless.readKeyRing().publicKeyRing(armored)
+                KeyRingReader().publicKeyRing(armored)
             } catch (e: Exception) {
                 Log.w("PgpManager", "Failed to parse public key ring for $address (encryptAndSign)", e)
                 null
@@ -209,13 +211,13 @@ class PgpManager @Inject constructor(
         try {
             val encryptionOptions = EncryptionOptions.get()
             for (ring in recipientRings) {
-                encryptionOptions.addRecipient(ring)
+                encryptionOptions.addRecipient(OpenPGPCertificate(ring))
             }
 
             val producerOptions: ProducerOptions = if (signingFingerprint != null) {
                 val armoredSecret = storage.loadPrivateKey(signingFingerprint) ?: return null
                 val secretKeyRing = try {
-                    PGPainless.readKeyRing().secretKeyRing(armoredSecret)!!
+                    KeyRingReader().secretKeyRing(armoredSecret)!!
                 } catch (e: Exception) {
                     Log.w("PgpManager", "Failed to parse secret key ring for signing $signingFingerprint (encryptAndSign)", e)
                     return null
@@ -223,7 +225,7 @@ class PgpManager @Inject constructor(
 
                 val protector = getProtector(secretKeyRing, signingFingerprint)
                 val signingOptions = SigningOptions.get()
-                    .addInlineSignature(protector, secretKeyRing)
+                    .addInlineSignature(protector, PGPainless.getInstance().toKey(secretKeyRing))
 
                 ProducerOptions.signAndEncrypt(encryptionOptions, signingOptions)
             } else {
@@ -231,7 +233,7 @@ class PgpManager @Inject constructor(
             }
 
             val outputStream = ByteArrayOutputStream()
-            val encryptionStream = PGPainless.encryptAndOrSign()
+            val encryptionStream = PGPainless.getInstance().generateMessage()
                 .onOutputStream(outputStream)
                 .withOptions(producerOptions)
 

--- a/app/src/main/java/com/shrivatsav/monomail/security/SecurityUtil.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/security/SecurityUtil.kt
@@ -12,7 +12,6 @@ import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
-@Suppress("DEPRECATION")
 object SecurityUtil {
     private const val KEY_ALIAS = "monomail_data_keystore_alias"
     private const val PREFS_NAME = "monomail_secure_prefs"
@@ -20,6 +19,7 @@ object SecurityUtil {
     private const val TRANSFORMATION = "AES/GCM/NoPadding"
     private const val ANDROID_KEYSTORE = "AndroidKeyStore"
     private const val IV_LENGTH = 12
+    @Suppress("DEPRECATION")
     private fun getSecurePrefs(context: Context): SharedPreferences {
         val masterKey = MasterKey.Builder(context)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)

--- a/app/src/main/java/com/shrivatsav/monomail/util/EmailImageGenerator.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/util/EmailImageGenerator.kt
@@ -225,12 +225,12 @@ object EmailImageGenerator {
                                 
                                 isResumed = true
                                 android.util.Log.d("EmailImageGenerator", "Bitmap captured successfully!")
-                                continuation.resume(bitmap) {}
+                                continuation.resume(bitmap)
                             } catch (e: Exception) {
                                 android.util.Log.e("EmailImageGenerator", "Exception in capture", e)
                                 if (!isResumed) {
                                     isResumed = true
-                                    continuation.resume(null) {}
+                                    continuation.resume(null)
                                 }
                             }
                         }, 500)


### PR DESCRIPTION
Clean up all deprecation warnings from the build output across 5 files:

- **PGP key management**: Migrate from deprecated PGPainless static methods to instance API and BC OpenPGPKey/OpenPGPCertificate types
- **Security/PGP storage**: Suppress unavoidable security-crypto 1.1.0 deprecations (newer API not available)
- **Email image generator**: Remove empty lambda from deprecated resume() overload