### PR TITLE
Refactor email screens and address Sonar issues

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -47,6 +47,7 @@ import com.shrivatsav.monomail.ui.screens.compose.ComposeViewModel
 import com.shrivatsav.monomail.ui.screens.detail.EmailDetailScreen
 import com.shrivatsav.monomail.ui.screens.detail.EmailDetailViewModel
 import com.shrivatsav.monomail.ui.screens.inbox.InboxScreen
+import com.shrivatsav.monomail.ui.screens.inbox.InboxNavActions
 import com.shrivatsav.monomail.ui.screens.inbox.InboxViewModel
 import com.shrivatsav.monomail.ui.screens.scheduled.ScheduledMessagesScreen
 import com.shrivatsav.monomail.ui.screens.scheduled.ScheduledMessagesViewModel
@@ -265,33 +266,35 @@ fun NavGraph(
                 InboxScreen(
                     viewModel    = vm,
                     userProfile  = activeAccount,
-                    onEmailClick = { threadId ->
-                        navController.navigate(Screen.ThreadDetail.createRoute(threadId)) { launchSingleTop = true }
-                    },
-                    onSignOut = {
-                        inboxScope.launch {
-                            authManager.signOutActiveAccount()
-                            val accounts = authManager.getAccounts()
-                            if (accounts.isEmpty()) {
-                                navController.navigate(Screen.SignIn.route) {
-                                    popUpTo(0) { inclusive = true }
+                    navActions = InboxNavActions(
+                        onEmailClick = { threadId ->
+                            navController.navigate(Screen.ThreadDetail.createRoute(threadId)) { launchSingleTop = true }
+                        },
+                        onSignOut = {
+                            inboxScope.launch {
+                                authManager.signOutActiveAccount()
+                                val accounts = authManager.getAccounts()
+                                if (accounts.isEmpty()) {
+                                    navController.navigate(Screen.SignIn.route) {
+                                        popUpTo(0) { inclusive = true }
+                                    }
+                                    emailRepository.clearLocalData()
                                 }
-                                emailRepository.clearLocalData()
                             }
+                        },
+                        onCompose = {
+                            navController.navigate(Screen.Compose.createRoute()) { launchSingleTop = true }
+                        },
+                        onSettings = {
+                            navController.navigate(Screen.Settings.route) { launchSingleTop = true }
+                        },
+                        onScheduledClick = {
+                            navController.navigate(Screen.Scheduled.route) { launchSingleTop = true }
+                        },
+                        onNavigateToImapSetup = {
+                            navController.navigate(Screen.ImapSetup.route) { launchSingleTop = true }
                         }
-                    },
-                    onCompose = {
-                        navController.navigate(Screen.Compose.createRoute()) { launchSingleTop = true }
-                    },
-                    onSettings = {
-                        navController.navigate(Screen.Settings.route) { launchSingleTop = true }
-                    },
-                    onScheduledClick = {
-                        navController.navigate(Screen.Scheduled.route) { launchSingleTop = true }
-                    },
-                    onNavigateToImapSetup = {
-                        navController.navigate(Screen.ImapSetup.route) { launchSingleTop = true }
-                    }
+                    )
                 )
             }
             composable(Screen.Settings.route) {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -656,7 +656,7 @@ private fun MessageBody(
             }
             return
         }
-        MessageBodyContent(email, safeBodyText, bodyIsHtml, config, decryptedResult, showSender, messageCount, onFetchAttachment)
+        MessageBodyContent(email, safeBodyText, bodyIsHtml, config, showSender, messageCount, onFetchAttachment)
     }
 }
 
@@ -671,7 +671,6 @@ private fun MessageBodyContent(
     safeBodyText: String,
     bodyIsHtml: Boolean,
     config: EmailDisplayConfig,
-    decryptedResult: PgpDecryptionResult?,
     showSender: Boolean,
     messageCount: Int,
     onFetchAttachment: suspend (String, String) -> ByteArray?

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/detail/EmailDetailScreen.kt
@@ -639,11 +639,7 @@ private fun MessageBody(
     messageCount: Int = 0,
     modifier: Modifier = Modifier
 ) {
-    val isEncryptedBlob = decryptedResult == null && (
-        email.body.startsWith("-----BEGIN PGP MESSAGE-----") ||
-        email.body.contains("multipart/encrypted;") ||
-        email.body.contains("multipart/encrypted\r\n")
-    )
+    val isEncryptedBlob = isEncryptedBlob(email)
     val normalizedBody = if (isEncryptedBlob) {
         normalizeEmailBody("", bodyIsHtml = false)
     } else {
@@ -660,55 +656,75 @@ private fun MessageBody(
             }
             return
         }
-        var showQuotedText by remember { mutableStateOf(false) }
-        val hasQuotedText = remember(safeBodyText) {
-            safeBodyText.contains("<blockquote", ignoreCase = true) ||
-            safeBodyText.contains("gmail_quote", ignoreCase = true) ||
-            safeBodyText.contains("gmail_extra", ignoreCase = true) ||
-            safeBodyText.contains("yahoo_quoted", ignoreCase = true) ||
-            safeBodyText.contains("moz-cite-prefix", ignoreCase = true) ||
-            safeBodyText.contains("appendonsend", ignoreCase = true) ||
-            safeBodyText.contains("divRplyFwdMsg", ignoreCase = true) ||
-            safeBodyText.contains("On ", ignoreCase = true) && safeBodyText.contains(" wrote:", ignoreCase = true)
-        }
-        if (showSender) {
-            SenderInfoSection(email, messageCount)
-        }
-        if (showSender && !config.showInlineAttachments && email.attachments.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(8.dp))
-            ThreadAttachmentsSummary(
-                attachmentsWithSender = email.attachments.map { it to displayName(email.from) },
-                onFetchAttachment = onFetchAttachment
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-        var showRemoteImages by remember { mutableStateOf(false) }
-        RemoteImagesBanner(config.loadRemoteImages, showRemoteImages, bodyIsHtml) { showRemoteImages = true }
-        val textColor = String.format("#%06X", 0xFFFFFF and MaterialTheme.colorScheme.onBackground.toArgb())
-        val linkColor = String.format("#%06X", 0xFFFFFF and MaterialTheme.colorScheme.primary.toArgb())
-        val useOverviewScaling = remember(safeBodyText, bodyIsHtml) {
-            bodyIsHtml && looksFixedWidthTemplate(safeBodyText) && !looksMobileFriendly(safeBodyText) && !looksDataTableEmail(safeBodyText)
-        }
-        val emailZoomFactor = if (useOverviewScaling) {
-            val screenWidthDp = LocalConfiguration.current.screenWidthDp
-            ((screenWidthDp - 56).toFloat() / 600f).coerceIn(0.3f, 1.0f)
-        } else 1.0f
-        val htmlContent = remember(email.id, safeBodyText, config.fontScaleMultiplier, showQuotedText, config.showInlineAttachments, config.loadRemoteImages, showRemoteImages, config.emailTheme, useOverviewScaling, emailZoomFactor) {
-            buildEmailHtml(email, safeBodyText, bodyIsHtml, config.fontScaleMultiplier, HtmlBuildParams(showQuotedText, config.showInlineAttachments, config.loadRemoteImages, showRemoteImages, useOverviewScaling, emailZoomFactor, textColor, linkColor))
-        }
-        EmailWebViewCard(email.id, htmlContent, config.emailTheme, useOverviewScaling)
-        if (hasQuotedText) {
-            QuotedTextToggle(showQuotedText) { showQuotedText = !showQuotedText }
-        }
-        if (config.isDeveloperMode) {
-            DeveloperCopyButton(email)
-        }
-        if (config.showInlineAttachments && email.attachments.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(16.dp))
-            AttachmentsSection(attachments = email.attachments, onFetchAttachment = onFetchAttachment)
-        }
+        MessageBodyContent(email, safeBodyText, bodyIsHtml, config, decryptedResult, showSender, messageCount, onFetchAttachment)
     }
 }
+
+private fun isEncryptedBlob(email: Email): Boolean =
+    email.body.startsWith("-----BEGIN PGP MESSAGE-----") ||
+        email.body.contains("multipart/encrypted;") ||
+        email.body.contains("multipart/encrypted\r\n")
+
+@Composable
+private fun MessageBodyContent(
+    email: Email,
+    safeBodyText: String,
+    bodyIsHtml: Boolean,
+    config: EmailDisplayConfig,
+    decryptedResult: PgpDecryptionResult?,
+    showSender: Boolean,
+    messageCount: Int,
+    onFetchAttachment: suspend (String, String) -> ByteArray?
+) {
+    var showQuotedText by remember { mutableStateOf(false) }
+    val hasQuotedText = remember(safeBodyText) { hasQuotedTextBlock(safeBodyText) }
+    if (showSender) {
+        SenderInfoSection(email, messageCount)
+    }
+    if (showSender && !config.showInlineAttachments && email.attachments.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(8.dp))
+        ThreadAttachmentsSummary(
+            attachmentsWithSender = email.attachments.map { it to displayName(email.from) },
+            onFetchAttachment = onFetchAttachment
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+    var showRemoteImages by remember { mutableStateOf(false) }
+    RemoteImagesBanner(config.loadRemoteImages, showRemoteImages, bodyIsHtml) { showRemoteImages = true }
+    val textColor = String.format("#%06X", 0xFFFFFF and MaterialTheme.colorScheme.onBackground.toArgb())
+    val linkColor = String.format("#%06X", 0xFFFFFF and MaterialTheme.colorScheme.primary.toArgb())
+    val useOverviewScaling = remember(safeBodyText, bodyIsHtml) {
+        bodyIsHtml && looksFixedWidthTemplate(safeBodyText) && !looksMobileFriendly(safeBodyText) && !looksDataTableEmail(safeBodyText)
+    }
+    val emailZoomFactor = if (useOverviewScaling) {
+        val screenWidthDp = LocalConfiguration.current.screenWidthDp
+        ((screenWidthDp - 56).toFloat() / 600f).coerceIn(0.3f, 1.0f)
+    } else 1.0f
+    val htmlContent = remember(email.id, safeBodyText, config.fontScaleMultiplier, showQuotedText, config.showInlineAttachments, config.loadRemoteImages, showRemoteImages, config.emailTheme, useOverviewScaling, emailZoomFactor) {
+        buildEmailHtml(email, safeBodyText, bodyIsHtml, config.fontScaleMultiplier, HtmlBuildParams(showQuotedText, config.showInlineAttachments, config.loadRemoteImages, showRemoteImages, useOverviewScaling, emailZoomFactor, textColor, linkColor))
+    }
+    EmailWebViewCard(email.id, htmlContent, config.emailTheme, useOverviewScaling)
+    if (hasQuotedText) {
+        QuotedTextToggle(showQuotedText) { showQuotedText = !showQuotedText }
+    }
+    if (config.isDeveloperMode) {
+        DeveloperCopyButton(email)
+    }
+    if (config.showInlineAttachments && email.attachments.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(16.dp))
+        AttachmentsSection(attachments = email.attachments, onFetchAttachment = onFetchAttachment)
+    }
+}
+
+private fun hasQuotedTextBlock(body: String): Boolean =
+    body.contains("<blockquote", ignoreCase = true) ||
+        body.contains("gmail_quote", ignoreCase = true) ||
+        body.contains("gmail_extra", ignoreCase = true) ||
+        body.contains("yahoo_quoted", ignoreCase = true) ||
+        body.contains("moz-cite-prefix", ignoreCase = true) ||
+        body.contains("appendonsend", ignoreCase = true) ||
+        body.contains("divRplyFwdMsg", ignoreCase = true) ||
+        (body.contains("On ", ignoreCase = true) && body.contains(" wrote:", ignoreCase = true))
 
 @Composable
 private fun EncryptionBadge(decryptedResult: PgpDecryptionResult?) {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/EmailItem.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/EmailItem.kt
@@ -52,6 +52,14 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 private val displayNameRegex = Regex("""^"?([^"<]+?)"?\s*<""")
 
+data class SelectionState(
+    val isSelected: Boolean = false,
+    val isBulkMode: Boolean = false,
+    val onSelectToggle: () -> Unit = {},
+    val onRangeSelect: () -> Unit = {},
+    val onAvatarLongClick: () -> Unit = {}
+)
+
 @Composable
 fun EmailItem(
     thread: EmailThread,
@@ -59,11 +67,7 @@ fun EmailItem(
     onLongClick: () -> Unit = {},
     showSnippet: Boolean = true,
     compactMode: Boolean = false,
-    isSelected: Boolean = false,
-    isBulkMode: Boolean = false,
-    onSelectToggle: () -> Unit = {},
-    onRangeSelect: () -> Unit = {},
-    onAvatarLongClick: () -> Unit = {},
+    selection: SelectionState = SelectionState(),
     modifier: Modifier = Modifier
 ) {
     val isUnread = !thread.isRead
@@ -74,7 +78,7 @@ fun EmailItem(
     }
     val verticalPad = if (compactMode) 7.dp else 11.dp
     val hapticFeedback = LocalHapticFeedback.current
-    val avatarClickAction = if (isBulkMode) onSelectToggle else onClick
+    val avatarClickAction = if (selection.isBulkMode) selection.onSelectToggle else onClick
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val rowScale by animateFloatAsState(
@@ -91,11 +95,11 @@ fun EmailItem(
             .scale(rowScale)
             .background(backgroundColor)
             .then(
-                if (isBulkMode) {
+                if (selection.isBulkMode) {
                     Modifier.combinedClickable(
                         interactionSource = interactionSource,
-                        onClick = onRangeSelect,
-                        onLongClick = onSelectToggle
+                        onClick = selection.onRangeSelect,
+                        onLongClick = selection.onSelectToggle
                     )
                 } else {
                     Modifier.combinedClickable(
@@ -111,18 +115,18 @@ fun EmailItem(
         Box {
             SenderAvatar(
                 senderInitial = senderInitial,
-                isSelected = isSelected,
-                isBulkMode = isBulkMode,
+                isSelected = selection.isSelected,
+                isBulkMode = selection.isBulkMode,
                 onClick = avatarClickAction,
                 onLongClick = {
-                    if (!isBulkMode) {
+                    if (!selection.isBulkMode) {
                         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                        onAvatarLongClick()
+                        selection.onAvatarLongClick()
                     }
                 },
                 modifier = Modifier.padding(top = 2.dp)
             )
-            UnreadDot(isUnread = isUnread, isBulkMode = isBulkMode)
+            UnreadDot(isUnread = isUnread, isBulkMode = selection.isBulkMode)
         }
         Spacer(modifier = Modifier.width(16.dp))
         Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -1062,28 +1062,48 @@ private fun LongPressMenu(
 @Composable
 private fun LongPressActionRow(thread: EmailThread, tabForMenu: InboxTab, actions: LongPressMenuActions, onDismiss: () -> Unit) {
     Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp), horizontalArrangement = Arrangement.SpaceEvenly, verticalAlignment = Alignment.Bottom) {
-        if (tabForMenu == InboxTab.SNOOZED) {
-            LongPressAction(icon = Icons.Rounded.Restore, label = "Unsnooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onUnsnooze(); onDismiss() })
-        } else {
-            LongPressAction(icon = if (thread.isStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder, label = if (thread.isStarred) "Unstar" else "Star", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onStar(); onDismiss() })
-        }
-        LongPressAction(
-            icon = if (tabForMenu == InboxTab.ARCHIVED) Icons.Rounded.Inbox else Icons.Rounded.Archive,
-            label = when (tabForMenu) { InboxTab.ARCHIVED -> "Unarchive"; InboxTab.SPAM -> "Not spam"; else -> "Archive" },
-            tint = MaterialTheme.colorScheme.onSurface,
-            onClick = { actions.onArchive(tabForMenu); onDismiss() }
-        )
-        LongPressAction(icon = if (thread.isRead) Icons.Rounded.MarkEmailUnread else Icons.Rounded.CheckCircle, label = if (thread.isRead) "Unread" else "Read", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onToggleRead(); onDismiss() })
+        StarOrUnsnoozeAction(thread, tabForMenu, actions, onDismiss)
+        ArchiveOrRestoreAction(tabForMenu, actions, onDismiss)
+        ReadUnreadAction(thread, actions, onDismiss)
         if (tabForMenu != InboxTab.TRASH && tabForMenu != InboxTab.SNOOZED && tabForMenu != InboxTab.SPAM) {
             LongPressAction(icon = Icons.Rounded.Schedule, label = "Snooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { onDismiss(); actions.onSnooze() })
         }
-        LongPressAction(
-            icon = if (tabForMenu == InboxTab.TRASH) Icons.Rounded.Restore else Icons.Rounded.Delete,
-            label = if (tabForMenu == InboxTab.TRASH) "Restore" else "Delete",
-            tint = if (tabForMenu == InboxTab.TRASH) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error,
-            onClick = { if (tabForMenu == InboxTab.TRASH) { actions.onArchive(tabForMenu) } else { actions.onDelete() }; onDismiss() }
-        )
+        DeleteOrRestoreAction(tabForMenu, actions, onDismiss)
     }
+}
+
+@Composable
+private fun StarOrUnsnoozeAction(thread: EmailThread, tabForMenu: InboxTab, actions: LongPressMenuActions, onDismiss: () -> Unit) {
+    if (tabForMenu == InboxTab.SNOOZED) {
+        LongPressAction(icon = Icons.Rounded.Restore, label = "Unsnooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onUnsnooze(); onDismiss() })
+    } else {
+        LongPressAction(icon = if (thread.isStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder, label = if (thread.isStarred) "Unstar" else "Star", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onStar(); onDismiss() })
+    }
+}
+
+@Composable
+private fun ArchiveOrRestoreAction(tabForMenu: InboxTab, actions: LongPressMenuActions, onDismiss: () -> Unit) {
+    LongPressAction(
+        icon = if (tabForMenu == InboxTab.ARCHIVED) Icons.Rounded.Inbox else Icons.Rounded.Archive,
+        label = when (tabForMenu) { InboxTab.ARCHIVED -> "Unarchive"; InboxTab.SPAM -> "Not spam"; else -> "Archive" },
+        tint = MaterialTheme.colorScheme.onSurface,
+        onClick = { actions.onArchive(tabForMenu); onDismiss() }
+    )
+}
+
+@Composable
+private fun ReadUnreadAction(thread: EmailThread, actions: LongPressMenuActions, onDismiss: () -> Unit) {
+    LongPressAction(icon = if (thread.isRead) Icons.Rounded.MarkEmailUnread else Icons.Rounded.CheckCircle, label = if (thread.isRead) "Unread" else "Read", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onToggleRead(); onDismiss() })
+}
+
+@Composable
+private fun DeleteOrRestoreAction(tabForMenu: InboxTab, actions: LongPressMenuActions, onDismiss: () -> Unit) {
+    LongPressAction(
+        icon = if (tabForMenu == InboxTab.TRASH) Icons.Rounded.Restore else Icons.Rounded.Delete,
+        label = if (tabForMenu == InboxTab.TRASH) "Restore" else "Delete",
+        tint = if (tabForMenu == InboxTab.TRASH) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error,
+        onClick = { if (tabForMenu == InboxTab.TRASH) { actions.onArchive(tabForMenu) } else { actions.onDelete() }; onDismiss() }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -38,18 +38,22 @@ import com.shrivatsav.monomail.auth.UserProfile
 import com.shrivatsav.monomail.data.model.EmailThread
 import kotlinx.coroutines.launch
 
+data class InboxNavActions(
+    val onEmailClick: (String) -> Unit,
+    val onSignOut: () -> Unit,
+    val onCompose: () -> Unit = {},
+    val onSettings: () -> Unit = {},
+    val onAddAccount: () -> Unit = {},
+    val onScheduledClick: () -> Unit = {},
+    val onNavigateToImapSetup: () -> Unit = {}
+)
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun InboxScreen(
     viewModel: InboxViewModel,
     userProfile: UserProfile?,
-    onEmailClick: (String) -> Unit,
-    onSignOut: () -> Unit,
-    onCompose: () -> Unit = {},
-    onSettings: () -> Unit = {},
-    onAddAccount: () -> Unit = {},
-    onScheduledClick: () -> Unit = {},
-    onNavigateToImapSetup: () -> Unit = {}
+    navActions: InboxNavActions
 ) {
     val state by viewModel.state.collectAsState()
     val unifiedInboxEnabled by viewModel.unifiedInboxEnabled.collectAsState()
@@ -176,7 +180,7 @@ fun InboxScreen(
                         onQueryChange = { searchQuery = it },
                         onServerSearch = { viewModel.searchServer(it) },
                         onMarkAllRead = { viewModel.markAllAsRead() },
-                        onScheduledClick = onScheduledClick,
+                        onScheduledClick = navActions.onScheduledClick,
                         isRefreshing = isRefreshing,
                         toastState = toastState,
                         onUndo = { viewModel.undoAction() },
@@ -384,7 +388,7 @@ fun InboxScreen(
                                                         appSettings = appSettings,
                                                         viewModel = viewModel,
                                                         onThreadToDeleteChange = { threadToDelete = it },
-                                                        onEmailClick = { onEmailClick(displayItem.thread.threadId) },
+                                                        onEmailClick = { navActions.onEmailClick(displayItem.thread.threadId) },
                                                         onLongClick = {
                                                             hapticFeedback.performHapticFeedback(
                                                                 HapticFeedbackType.LongPress
@@ -410,7 +414,7 @@ fun InboxScreen(
                                                         appSettings = appSettings,
                                                         viewModel = viewModel,
                                                         onThreadToDeleteChange = { threadToDelete = it },
-                                                        onEmailClick = { onEmailClick(displayItem.thread.threadId) },
+                                                        onEmailClick = { navActions.onEmailClick(displayItem.thread.threadId) },
                                                         onLongClick = {
                                                             hapticFeedback.performHapticFeedback(
                                                                 HapticFeedbackType.LongPress
@@ -573,7 +577,7 @@ fun InboxScreen(
                                     label = "fabScale"
                                 )
                                 FloatingActionButton(
-                                    onClick = onCompose,
+                                    onClick = navActions.onCompose,
                                     interactionSource = fabInteractionSource,
                                     containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                                     contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
@@ -659,7 +663,7 @@ fun InboxScreen(
                                 thread = thread,
                                 onClick = {
                                     longPressedThread = null
-                                    onEmailClick(thread.threadId)
+                                    navActions.onEmailClick(thread.threadId)
                                 },
                                 onLongClick = {},
                                 modifier = Modifier
@@ -765,7 +769,7 @@ fun InboxScreen(
                 accounts = accounts,
                 callbacks = ModalCallbacks(
                     onDismiss = { activeModal = null },
-                    onSignOut = { activeModal = null; onSignOut() },
+                    onSignOut = { activeModal = null; navActions.onSignOut() },
                     onSwitchAccount = { viewModel.switchAccount(it); activeModal = null },
                     onCycleAccount = { viewModel.switchAccount(it) },
                     onAddAccount = {
@@ -779,8 +783,8 @@ fun InboxScreen(
                     },
                     onShowSwitchAccount = { activeModal = ModalType.SWITCH_ACCOUNT },
                     onBackToProfile = { activeModal = ModalType.PROFILE },
-                    onSettings = { activeModal = null; onSettings() },
-                    onNavigateToImapSetup = onNavigateToImapSetup,
+                    onSettings = { activeModal = null; navActions.onSettings() },
+                    onNavigateToImapSetup = navActions.onNavigateToImapSetup,
                     onToggleUnified = { viewModel.setUnifiedInboxEnabled(it) }
                 ),
                 unifiedInboxEnabled = unifiedInboxEnabled

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -504,8 +504,7 @@ fun InboxScreen(
                     navActions = navActions,
                     viewModel = viewModel,
                     navBarHeight = navBarHeight,
-                    showClearTrashWarning = { showClearTrashWarning = true },
-                    showClearSpamWarning = { showClearSpamWarning = true }
+                    onEmptyBin = { isTrash -> if (isTrash) showClearTrashWarning = true else showClearSpamWarning = true }
                 )
             }
 
@@ -548,20 +547,22 @@ fun InboxScreen(
                     thread = thread,
                     state = state,
                     onDismiss = { longPressedThread = null },
-                    onEmailClick = { navActions.onEmailClick(thread.threadId) },
-                    onStar = { viewModel.toggleStar(thread.threadId) },
-                    onArchive = { tab -> when (tab) {
-                        InboxTab.ARCHIVED -> viewModel.unarchiveThread(thread.threadId)
-                        InboxTab.SPAM -> viewModel.reportNotSpam(thread.threadId)
-                        else -> viewModel.archiveThread(thread.threadId)
-                    } },
-                    onToggleRead = {
-                        if (thread.isRead) viewModel.markThreadAsUnread(thread.threadId)
-                        else viewModel.markThreadAsRead(thread.threadId)
-                    },
-                    onDelete = { threadToDelete = thread.threadId },
-                    onSnooze = { onSnoozeSelected(thread.threadId) },
-                    onUnsnooze = { viewModel.unsnoozeThread(thread.threadId) }
+                    actions = LongPressMenuActions(
+                        onEmailClick = { navActions.onEmailClick(thread.threadId) },
+                        onStar = { viewModel.toggleStar(thread.threadId) },
+                        onArchive = { tab -> when (tab) {
+                            InboxTab.ARCHIVED -> viewModel.unarchiveThread(thread.threadId)
+                            InboxTab.SPAM -> viewModel.reportNotSpam(thread.threadId)
+                            else -> viewModel.archiveThread(thread.threadId)
+                        } },
+                        onToggleRead = {
+                            if (thread.isRead) viewModel.markThreadAsUnread(thread.threadId)
+                            else viewModel.markThreadAsRead(thread.threadId)
+                        },
+                        onDelete = { threadToDelete = thread.threadId },
+                        onSnooze = { onSnoozeSelected(thread.threadId) },
+                        onUnsnooze = { viewModel.unsnoozeThread(thread.threadId) }
+                    )
                 )
             }
 
@@ -923,8 +924,7 @@ private fun BottomFabArea(
     navActions: InboxNavActions,
     viewModel: InboxViewModel,
     navBarHeight: Dp,
-    showClearTrashWarning: () -> Unit,
-    showClearSpamWarning: () -> Unit
+    onEmptyBin: (isTrash: Boolean) -> Unit
 ) {
     val tabForDock by remember { derivedStateOf { immediateTab } }
     Row(
@@ -952,8 +952,8 @@ private fun BottomFabArea(
             }
         ) { state ->
             when (state) {
-                "trash" -> EmptyTrashFab(appSettings, showClearTrashWarning)
-                "spam" -> EmptySpamFab(appSettings, showClearSpamWarning)
+                "trash" -> EmptyTrashFab(appSettings) { onEmptyBin(true) }
+                "spam" -> EmptySpamFab(appSettings) { onEmptyBin(false) }
                 "default" -> ComposeFab(appSettings, navActions.onCompose)
             }
         }
@@ -1016,19 +1016,23 @@ private fun ComposeFab(appSettings: com.shrivatsav.monomail.data.settings.AppSet
     }
 }
 
+private data class LongPressMenuActions(
+    val onEmailClick: () -> Unit,
+    val onStar: () -> Unit,
+    val onArchive: (InboxTab) -> Unit,
+    val onToggleRead: () -> Unit,
+    val onDelete: () -> Unit,
+    val onSnooze: () -> Unit,
+    val onUnsnooze: () -> Unit
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LongPressMenu(
     thread: EmailThread,
     state: InboxState,
     onDismiss: () -> Unit,
-    onEmailClick: () -> Unit,
-    onStar: () -> Unit,
-    onArchive: (InboxTab) -> Unit,
-    onToggleRead: () -> Unit,
-    onDelete: () -> Unit,
-    onSnooze: () -> Unit,
-    onUnsnooze: () -> Unit
+    actions: LongPressMenuActions
 ) {
     val tabForMenu = (state as? InboxState.Success)?.currentTab ?: InboxTab.INBOX
     BackHandler { onDismiss() }
@@ -1040,40 +1044,45 @@ private fun LongPressMenu(
     )
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth(0.85f),
+            modifier = Modifier.fillMaxWidth(0.85f),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
-                EmailItem(thread = thread, onClick = { onDismiss(); onEmailClick() }, onLongClick = {}, modifier = Modifier)
+                EmailItem(thread = thread, onClick = { onDismiss(); actions.onEmailClick() }, onLongClick = {}, modifier = Modifier)
             }
             Spacer(Modifier.height(8.dp))
             Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
-                Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp), horizontalArrangement = Arrangement.SpaceEvenly, verticalAlignment = Alignment.Bottom) {
-                    if (tabForMenu == InboxTab.SNOOZED) {
-                        LongPressAction(icon = Icons.Rounded.Restore, label = "Unsnooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { onUnsnooze(); onDismiss() })
-                    } else {
-                        LongPressAction(icon = if (thread.isStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder, label = if (thread.isStarred) "Unstar" else "Star", tint = MaterialTheme.colorScheme.onSurface, onClick = { onStar(); onDismiss() })
-                    }
-                    LongPressAction(
-                        icon = if (tabForMenu == InboxTab.ARCHIVED) Icons.Rounded.Inbox else Icons.Rounded.Archive,
-                        label = when (tabForMenu) { InboxTab.ARCHIVED -> "Unarchive"; InboxTab.SPAM -> "Not spam"; else -> "Archive" },
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        onClick = { onArchive(tabForMenu); onDismiss() }
-                    )
-                    LongPressAction(icon = if (thread.isRead) Icons.Rounded.MarkEmailUnread else Icons.Rounded.CheckCircle, label = if (thread.isRead) "Unread" else "Read", tint = MaterialTheme.colorScheme.onSurface, onClick = { onToggleRead(); onDismiss() })
-                    if (tabForMenu != InboxTab.TRASH && tabForMenu != InboxTab.SNOOZED && tabForMenu != InboxTab.SPAM) {
-                        LongPressAction(icon = Icons.Rounded.Schedule, label = "Snooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { onDismiss(); onSnooze() })
-                    }
-                    LongPressAction(
-                        icon = if (tabForMenu == InboxTab.TRASH) Icons.Rounded.Restore else Icons.Rounded.Delete,
-                        label = if (tabForMenu == InboxTab.TRASH) "Restore" else "Delete",
-                        tint = if (tabForMenu == InboxTab.TRASH) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error,
-                        onClick = { if (tabForMenu == InboxTab.TRASH) { onArchive(tabForMenu) } else { onDelete() }; onDismiss() }
-                    )
-                }
+                LongPressActionRow(thread, tabForMenu, actions) { onDismiss() }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LongPressActionRow(thread: EmailThread, tabForMenu: InboxTab, actions: LongPressMenuActions, onDismiss: () -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp), horizontalArrangement = Arrangement.SpaceEvenly, verticalAlignment = Alignment.Bottom) {
+        if (tabForMenu == InboxTab.SNOOZED) {
+            LongPressAction(icon = Icons.Rounded.Restore, label = "Unsnooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onUnsnooze(); onDismiss() })
+        } else {
+            LongPressAction(icon = if (thread.isStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder, label = if (thread.isStarred) "Unstar" else "Star", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onStar(); onDismiss() })
+        }
+        LongPressAction(
+            icon = if (tabForMenu == InboxTab.ARCHIVED) Icons.Rounded.Inbox else Icons.Rounded.Archive,
+            label = when (tabForMenu) { InboxTab.ARCHIVED -> "Unarchive"; InboxTab.SPAM -> "Not spam"; else -> "Archive" },
+            tint = MaterialTheme.colorScheme.onSurface,
+            onClick = { actions.onArchive(tabForMenu); onDismiss() }
+        )
+        LongPressAction(icon = if (thread.isRead) Icons.Rounded.MarkEmailUnread else Icons.Rounded.CheckCircle, label = if (thread.isRead) "Unread" else "Read", tint = MaterialTheme.colorScheme.onSurface, onClick = { actions.onToggleRead(); onDismiss() })
+        if (tabForMenu != InboxTab.TRASH && tabForMenu != InboxTab.SNOOZED && tabForMenu != InboxTab.SPAM) {
+            LongPressAction(icon = Icons.Rounded.Schedule, label = "Snooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { onDismiss(); actions.onSnooze() })
+        }
+        LongPressAction(
+            icon = if (tabForMenu == InboxTab.TRASH) Icons.Rounded.Restore else Icons.Rounded.Delete,
+            label = if (tabForMenu == InboxTab.TRASH) "Restore" else "Delete",
+            tint = if (tabForMenu == InboxTab.TRASH) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error,
+            onClick = { if (tabForMenu == InboxTab.TRASH) { actions.onArchive(tabForMenu) } else { actions.onDelete() }; onDismiss() }
+        )
     }
 }
 

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -179,19 +179,23 @@ fun InboxScreen(
                         query = searchQuery,
                         onQueryChange = { searchQuery = it },
                         onServerSearch = { viewModel.searchServer(it) },
-                        onMarkAllRead = { viewModel.markAllAsRead() },
-                        onScheduledClick = navActions.onScheduledClick,
+                        actions = SearchBarActions(
+                            onMarkAllRead = { viewModel.markAllAsRead() },
+                            onScheduledClick = navActions.onScheduledClick,
+                            scheduledCount = scheduledCount,
+                            onUndo = { viewModel.undoAction() },
+                            onOpenProfile = { activeModal = ModalType.PROFILE }
+                        ),
                         isRefreshing = isRefreshing,
                         toastState = toastState,
-                        onUndo = { viewModel.undoAction() },
-                        onOpenProfile = { activeModal = ModalType.PROFILE },
-                        scheduledCount = scheduledCount,
-                        isBulkMode = isBulkMode,
-                        selectedCount = selectedCount,
-                        totalCount = localFilteredThreads?.size ?: currentThreads.size,
-                        onSelectAll = { viewModel.selectAll() },
-                        onDeselectAll = { viewModel.deselectAll() },
-                        onDone = { viewModel.exitBulkSelectMode() },
+                        bulkSelection = BulkSelectionState(
+                            isBulkMode = isBulkMode,
+                            selectedCount = selectedCount,
+                            totalCount = localFilteredThreads?.size ?: currentThreads.size,
+                            onSelectAll = { viewModel.selectAll() },
+                            onDeselectAll = { viewModel.deselectAll() },
+                            onDone = { viewModel.exitBulkSelectMode() }
+                        ),
                         unifiedInboxEnabled = unifiedInboxEnabled
                     )
 

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -387,22 +387,26 @@ fun InboxScreen(
                                                         tabForSwipe = currentTab,
                                                         appSettings = appSettings,
                                                         viewModel = viewModel,
-                                                        onThreadToDeleteChange = { threadToDelete = it },
-                                                        onEmailClick = { navActions.onEmailClick(displayItem.thread.threadId) },
-                                                        onLongClick = {
-                                                            hapticFeedback.performHapticFeedback(
-                                                                HapticFeedbackType.LongPress
-                                                            )
-                                                            longPressedThread = displayItem.thread
-                                                        },
-                                                        isNested = false,
-                                                        isBulkMode = isBulkMode,
-                                                        isSelected = displayItem.thread.threadId in selectedThreadIds,
-                                                        onSelectToggle = { viewModel.toggleThreadSelection(displayItem.thread.threadId) },
-                                                        onRangeSelect = { viewModel.rangeSelectTo(displayItem.thread.threadId, orderedThreadIds) },
-                                                        onAvatarLongClick = {
-                                                            viewModel.enterBulkSelectMode(displayItem.thread.threadId)
-                                                        }
+                                                        callbacks = SwipeCallbacks(
+                                                            onThreadToDeleteChange = { threadToDelete = it },
+                                                            onEmailClick = { navActions.onEmailClick(displayItem.thread.threadId) },
+                                                            onLongClick = {
+                                                                hapticFeedback.performHapticFeedback(
+                                                                    HapticFeedbackType.LongPress
+                                                                )
+                                                                longPressedThread = displayItem.thread
+                                                            },
+                                                            isNested = false
+                                                        ),
+                                                        selection = SelectionState(
+                                                            isSelected = displayItem.thread.threadId in selectedThreadIds,
+                                                            isBulkMode = isBulkMode,
+                                                            onSelectToggle = { viewModel.toggleThreadSelection(displayItem.thread.threadId) },
+                                                            onRangeSelect = { viewModel.rangeSelectTo(displayItem.thread.threadId, orderedThreadIds) },
+                                                            onAvatarLongClick = {
+                                                                viewModel.enterBulkSelectMode(displayItem.thread.threadId)
+                                                            }
+                                                        )
                                                     )
                                                 }
 
@@ -413,22 +417,26 @@ fun InboxScreen(
                                                         tabForSwipe = currentTab,
                                                         appSettings = appSettings,
                                                         viewModel = viewModel,
-                                                        onThreadToDeleteChange = { threadToDelete = it },
-                                                        onEmailClick = { navActions.onEmailClick(displayItem.thread.threadId) },
-                                                        onLongClick = {
-                                                            hapticFeedback.performHapticFeedback(
-                                                                HapticFeedbackType.LongPress
-                                                            )
-                                                            longPressedThread = displayItem.thread
-                                                        },
-                                                        isNested = true,
-                                                        isBulkMode = isBulkMode,
-                                                        isSelected = displayItem.thread.threadId in selectedThreadIds,
-                                                        onSelectToggle = { viewModel.toggleThreadSelection(displayItem.thread.threadId) },
-                                                        onRangeSelect = { viewModel.rangeSelectTo(displayItem.thread.threadId, orderedThreadIds) },
-                                                        onAvatarLongClick = {
-                                                            viewModel.enterBulkSelectMode(displayItem.thread.threadId)
-                                                        }
+                                                        callbacks = SwipeCallbacks(
+                                                            onThreadToDeleteChange = { threadToDelete = it },
+                                                            onEmailClick = { navActions.onEmailClick(displayItem.thread.threadId) },
+                                                            onLongClick = {
+                                                                hapticFeedback.performHapticFeedback(
+                                                                    HapticFeedbackType.LongPress
+                                                                )
+                                                                longPressedThread = displayItem.thread
+                                                            },
+                                                            isNested = true
+                                                        ),
+                                                        selection = SelectionState(
+                                                            isSelected = displayItem.thread.threadId in selectedThreadIds,
+                                                            isBulkMode = isBulkMode,
+                                                            onSelectToggle = { viewModel.toggleThreadSelection(displayItem.thread.threadId) },
+                                                            onRangeSelect = { viewModel.rangeSelectTo(displayItem.thread.threadId, orderedThreadIds) },
+                                                            onAvatarLongClick = {
+                                                                viewModel.enterBulkSelectMode(displayItem.thread.threadId)
+                                                            }
+                                                        )
                                                     )
                                                 }
                                             }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -497,114 +497,16 @@ fun InboxScreen(
                 exit = fadeOut(tween(120)) + scaleOut(tween(120), targetScale = 0.9f),
                 modifier = Modifier.align(Alignment.BottomCenter)
             ) {
-                val tabForDock by remember { derivedStateOf { immediateTab } }
-                Row(
-                    modifier = Modifier.padding(bottom = navBarHeight + 8.dp),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalAlignment = Alignment.Bottom
-                ) {
-                    BottomDockBar(
-                        currentTab = tabForDock,
-                        dockConfig = appSettings.dockConfig,
-                        unifiedInboxEnabled = unifiedInboxEnabled,
-                        appSettings = appSettings,
-                        onTabClick = { viewModel.switchTab(it) }
-                    )
-                    AnimatedContent(
-                        targetState = when {
-                            tabForDock == InboxTab.TRASH -> "trash"
-                            tabForDock == InboxTab.SPAM -> "spam"
-                            else -> "default"
-                        },
-                        label = "FabIconMorph",
-                        transitionSpec = {
-                            (fadeIn(tween(180)) + scaleIn(tween(180), initialScale = 0.85f)) togetherWith
-                                    (fadeOut(tween(120)) + scaleOut(tween(120), targetScale = 0.85f))
-                        }
-                    ) { state ->
-                        when (state) {
-                            "trash" -> {
-                                FloatingActionButton(
-                                    onClick = { showClearTrashWarning = true },
-                                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                                    shape = CircleShape,
-                                    elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 4.dp),
-                                    modifier = Modifier.height((42 * appSettings.navScale).dp)
-                                ) {
-                                    Row(
-                                        modifier = Modifier.padding(horizontal = 12.dp),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(4.dp)
-                                    ) {
-                                        Icon(
-                                            Icons.Rounded.Delete,
-                                            contentDescription = "Empty Trash",
-                                            modifier = Modifier.size((22 * appSettings.navScale).dp)
-                                        )
-                                        Text(
-                                            text = "Empty",
-                                            style = MaterialTheme.typography.labelLarge,
-                                            color = MaterialTheme.colorScheme.onErrorContainer
-                                        )
-                                    }
-                                }
-                            }
-                            "spam" -> {
-                                FloatingActionButton(
-                                    onClick = { showClearSpamWarning = true },
-                                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                                    shape = CircleShape,
-                                    elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 4.dp),
-                                    modifier = Modifier.height((42 * appSettings.navScale).dp)
-                                ) {
-                                    Row(
-                                        modifier = Modifier.padding(horizontal = 12.dp),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(4.dp)
-                                    ) {
-                                        Icon(
-                                            Icons.Rounded.Report,
-                                            contentDescription = "Empty Spam",
-                                            modifier = Modifier.size((22 * appSettings.navScale).dp)
-                                        )
-                                        Text(
-                                            text = "Empty",
-                                            style = MaterialTheme.typography.labelLarge,
-                                            color = MaterialTheme.colorScheme.onErrorContainer
-                                        )
-                                    }
-                                }
-                            }
-                            "default" -> {
-                                val fabInteractionSource = remember { MutableInteractionSource() }
-                                val isFabPressed by fabInteractionSource.collectIsPressedAsState()
-                                val fabScale by animateFloatAsState(
-                                    targetValue = if (isFabPressed) 0.92f else 1f,
-                                    animationSpec = spring(
-                                        dampingRatio = Spring.DampingRatioMediumBouncy,
-                                        stiffness = Spring.StiffnessMedium
-                                    ),
-                                    label = "fabScale"
-                                )
-                                FloatingActionButton(
-                                    onClick = navActions.onCompose,
-                                    interactionSource = fabInteractionSource,
-                                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                                    shape = CircleShape,
-                                    elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 4.dp),
-                                    modifier = Modifier
-                                        .size((52 * appSettings.navScale).dp)
-                                        .graphicsLayer(scaleX = fabScale, scaleY = fabScale)
-                                ) {
-                                    Icon(Icons.Rounded.Edit, contentDescription = "Compose")
-                                }
-                            }
-                        }
-                    }
-                }
+                BottomFabArea(
+                    immediateTab = immediateTab,
+                    appSettings = appSettings,
+                    unifiedInboxEnabled = unifiedInboxEnabled,
+                    navActions = navActions,
+                    viewModel = viewModel,
+                    navBarHeight = navBarHeight,
+                    showClearTrashWarning = { showClearTrashWarning = true },
+                    showClearSpamWarning = { showClearSpamWarning = true }
+                )
             }
 
             AnimatedVisibility(
@@ -642,135 +544,25 @@ fun InboxScreen(
             ) {
                 val thread = displayedThread ?: return@AnimatedVisibility
                 BackHandler { longPressedThread = null }
-
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f))
-                        .clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() }
-                        ) { longPressedThread = null }
+                LongPressMenu(
+                    thread = thread,
+                    state = state,
+                    onDismiss = { longPressedThread = null },
+                    onEmailClick = { navActions.onEmailClick(thread.threadId) },
+                    onStar = { viewModel.toggleStar(thread.threadId) },
+                    onArchive = { tab -> when (tab) {
+                        InboxTab.ARCHIVED -> viewModel.unarchiveThread(thread.threadId)
+                        InboxTab.SPAM -> viewModel.reportNotSpam(thread.threadId)
+                        else -> viewModel.archiveThread(thread.threadId)
+                    } },
+                    onToggleRead = {
+                        if (thread.isRead) viewModel.markThreadAsUnread(thread.threadId)
+                        else viewModel.markThreadAsRead(thread.threadId)
+                    },
+                    onDelete = { threadToDelete = thread.threadId },
+                    onSnooze = { onSnoozeSelected(thread.threadId) },
+                    onUnsnooze = { viewModel.unsnoozeThread(thread.threadId) }
                 )
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth(0.85f)
-                            .animateEnterExit(
-                                enter = scaleIn(
-                                    tween(300, easing = FastOutSlowInEasing),
-                                    initialScale = 0.9f
-                                ),
-                                exit = scaleOut(tween(200), targetScale = 0.9f)
-                            ),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Surface(
-                            shape = RoundedCornerShape(16.dp),
-                            color = MaterialTheme.colorScheme.surfaceContainer,
-                            tonalElevation = 0.dp,
-                            shadowElevation = 8.dp
-                        ) {
-                            EmailItem(
-                                thread = thread,
-                                onClick = {
-                                    longPressedThread = null
-                                    navActions.onEmailClick(thread.threadId)
-                                },
-                                onLongClick = {},
-                                modifier = Modifier
-                            )
-                        }
-                        Spacer(Modifier.height(8.dp))
-                        Surface(
-                            shape = RoundedCornerShape(16.dp),
-                            color = MaterialTheme.colorScheme.surfaceContainer,
-                            tonalElevation = 0.dp,
-                            shadowElevation = 8.dp
-                        ) {
-                            val tabForMenu =
-                                (state as? InboxState.Success)?.currentTab ?: InboxTab.INBOX
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 8.dp, vertical = 8.dp),
-                                horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.Bottom
-                            ) {
-                                if (tabForMenu == InboxTab.SNOOZED) {
-                                    LongPressAction(
-                                        icon = Icons.Rounded.Restore,
-                                        label = "Unsnooze",
-                                        tint = MaterialTheme.colorScheme.onSurface,
-                                        onClick = {
-                                            viewModel.unsnoozeThread(thread.threadId)
-                                            longPressedThread = null
-                                        }
-                                    )
-                                } else {
-                                    LongPressAction(
-                                        icon = if (thread.isStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder,
-                                        label = if (thread.isStarred) "Unstar" else "Star",
-                                        tint = MaterialTheme.colorScheme.onSurface,
-                                        onClick = {
-                                            viewModel.toggleStar(thread.threadId)
-                                            longPressedThread = null
-                                        }
-                                    )
-                                }
-                                LongPressAction(
-                                    icon = if (tabForMenu == InboxTab.ARCHIVED) Icons.Rounded.Inbox else Icons.Rounded.Archive,
-                                    label = when (tabForMenu) {
-                                        InboxTab.ARCHIVED -> "Unarchive"
-                                        InboxTab.SPAM -> "Not spam"
-                                        else -> "Archive"
-                                    },
-                                    tint = MaterialTheme.colorScheme.onSurface,
-                                    onClick = {
-                                        when (tabForMenu) {
-                                            InboxTab.ARCHIVED -> viewModel.unarchiveThread(thread.threadId)
-                                            InboxTab.SPAM -> viewModel.reportNotSpam(thread.threadId)
-                                            else -> viewModel.archiveThread(thread.threadId)
-                                        }
-                                        longPressedThread = null
-                                    }
-                                )
-                                LongPressAction(
-                                    icon = if (thread.isRead) Icons.Rounded.MarkEmailUnread else Icons.Rounded.CheckCircle,
-                                    label = if (thread.isRead) "Unread" else "Read",
-                                    tint = MaterialTheme.colorScheme.onSurface,
-                                    onClick = {
-                                        if (thread.isRead) viewModel.markThreadAsUnread(thread.threadId)
-                                        else viewModel.markThreadAsRead(thread.threadId)
-                                        longPressedThread = null
-                                    }
-                                )
-                                if (tabForMenu != InboxTab.TRASH && tabForMenu != InboxTab.SNOOZED && tabForMenu != InboxTab.SPAM) {
-                                    LongPressAction(
-                                        icon = Icons.Rounded.Schedule,
-                                        label = "Snooze",
-                                        tint = MaterialTheme.colorScheme.onSurface,
-                                        onClick = {
-                                            longPressedThread = null
-                                            onSnoozeSelected(thread.threadId)
-                                        }
-                                    )
-                                }
-                                LongPressAction(
-                                    icon = if (tabForMenu == InboxTab.TRASH) Icons.Rounded.Restore else Icons.Rounded.Delete,
-                                    label = if (tabForMenu == InboxTab.TRASH) "Restore" else "Delete",
-                                    tint = if (tabForMenu == InboxTab.TRASH) MaterialTheme.colorScheme.onSurface
-                                    else MaterialTheme.colorScheme.error,
-                                    onClick = {
-                                        if (tabForMenu == InboxTab.TRASH) viewModel.restoreThread(thread.threadId)
-                                        else threadToDelete = thread.threadId
-                                        longPressedThread = null
-                                    }
-                                )
-                            }
-                        }
-                    }
-                }
             }
 
             
@@ -1033,140 +825,30 @@ fun InboxScreen(
         visible = showClearTrashWarning,
         onDismiss = { showClearTrashWarning = false; isTrashCountdownActive = false }
     ) {
-        var trashCountdown by remember { mutableIntStateOf(5) }
-        LaunchedEffect(showClearTrashWarning) {
-            if (showClearTrashWarning) {
-                trashCountdown = 5
-                isTrashCountdownActive = true
-                while (trashCountdown > 0 && isTrashCountdownActive) {
-                    kotlinx.coroutines.delay(1000)
-                    trashCountdown--
-                }
-                if (isTrashCountdownActive) {
-                    viewModel.emptyTrash()
-                    showClearTrashWarning = false
-                }
-            }
-        }
-
-        Surface(
-            shape = RoundedCornerShape(28.dp),
-            color = MaterialTheme.colorScheme.background,
-            contentColor = MaterialTheme.colorScheme.onBackground,
-            shadowElevation = 32.dp,
-            modifier = Modifier.fillMaxWidth(0.88f)
-        ) {
-            Column(modifier = Modifier.padding(24.dp)) {
-                Text(
-                    text = "Clear Trash?",
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                Text(
-                    text = "Are you sure you want to permanently delete all messages in the trash? This action cannot be undone.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Surface(
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
-                ) {
-                    Text(
-                        text = if (trashCountdown > 0) "Clearing trash in $trashCountdown..."
-                               else "Clearing trash...",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                        fontWeight = FontWeight.Medium,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
-                    )
-                }
-                Spacer(modifier = Modifier.height(20.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End
-                ) {
-                    TextButton(onClick = {
-                        isTrashCountdownActive = false
-                        showClearTrashWarning = false
-                    }) {
-                        Text("Cancel")
-                    }
-                }
-            }
-        }
+        ClearCountdownDialog(
+            title = "Clear Trash?",
+            message = "Are you sure you want to permanently delete all messages in the trash? This action cannot be undone.",
+            onDismiss = { isTrashCountdownActive = false; showClearTrashWarning = false },
+            onCountdownFinished = { viewModel.emptyTrash(); showClearTrashWarning = false },
+            isActive = showClearTrashWarning,
+            isCountdownActive = isTrashCountdownActive,
+            setCountdownActive = { isTrashCountdownActive = it }
+        )
     }
 
     com.shrivatsav.monomail.ui.components.BlurredModalOverlay(
         visible = showClearSpamWarning,
         onDismiss = { showClearSpamWarning = false; isSpamCountdownActive = false }
     ) {
-        var spamCountdown by remember { mutableIntStateOf(5) }
-        LaunchedEffect(showClearSpamWarning) {
-            if (showClearSpamWarning) {
-                spamCountdown = 5
-                isSpamCountdownActive = true
-                while (spamCountdown > 0 && isSpamCountdownActive) {
-                    kotlinx.coroutines.delay(1000)
-                    spamCountdown--
-                }
-                if (isSpamCountdownActive) {
-                    viewModel.emptySpam()
-                    showClearSpamWarning = false
-                }
-            }
-        }
-
-        Surface(
-            shape = RoundedCornerShape(28.dp),
-            color = MaterialTheme.colorScheme.background,
-            contentColor = MaterialTheme.colorScheme.onBackground,
-            shadowElevation = 32.dp,
-            modifier = Modifier.fillMaxWidth(0.88f)
-        ) {
-            Column(modifier = Modifier.padding(24.dp)) {
-                Text(
-                    text = "Clear Spam?",
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                Text(
-                    text = "Are you sure you want to permanently delete all messages in spam? This action cannot be undone.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Surface(
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
-                ) {
-                    Text(
-                        text = if (spamCountdown > 0) "Clearing spam in $spamCountdown..."
-                               else "Clearing spam...",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                        fontWeight = FontWeight.Medium,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
-                    )
-                }
-                Spacer(modifier = Modifier.height(20.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End
-                ) {
-                    TextButton(onClick = {
-                        isSpamCountdownActive = false
-                        showClearSpamWarning = false
-                    }) {
-                        Text("Cancel")
-                    }
-                }
-            }
-        }
+        ClearCountdownDialog(
+            title = "Clear Spam?",
+            message = "Are you sure you want to permanently delete all messages in spam? This action cannot be undone.",
+            onDismiss = { isSpamCountdownActive = false; showClearSpamWarning = false },
+            onCountdownFinished = { viewModel.emptySpam(); showClearSpamWarning = false },
+            isActive = showClearSpamWarning,
+            isCountdownActive = isSpamCountdownActive,
+            setCountdownActive = { isSpamCountdownActive = it }
+        )
     }
 
     if (showSnoozePicker && snoozeThreadId != null) {
@@ -1180,6 +862,220 @@ fun InboxScreen(
     }
 }
 
+
+@Composable
+private fun ClearCountdownDialog(
+    title: String,
+    message: String,
+    onDismiss: () -> Unit,
+    onCountdownFinished: () -> Unit,
+    isActive: Boolean,
+    isCountdownActive: Boolean,
+    setCountdownActive: (Boolean) -> Unit
+) {
+    var countdown by remember { mutableIntStateOf(5) }
+    LaunchedEffect(isActive) {
+        if (isActive) {
+            countdown = 5
+            setCountdownActive(true)
+            while (countdown > 0 && isCountdownActive) {
+                kotlinx.coroutines.delay(1000)
+                countdown--
+            }
+            if (isCountdownActive) onCountdownFinished()
+        }
+    }
+    Surface(
+        shape = RoundedCornerShape(28.dp),
+        color = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+        shadowElevation = 32.dp,
+        modifier = Modifier.fillMaxWidth(0.88f)
+    ) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(message, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(modifier = Modifier.height(16.dp))
+            Surface(shape = RoundedCornerShape(12.dp), color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)) {
+                Text(
+                    text = if (countdown > 0) "Clearing in $countdown..." else "Clearing...",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = { setCountdownActive(false); onDismiss() }) { Text("Cancel") }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun BottomFabArea(
+    immediateTab: InboxTab,
+    appSettings: com.shrivatsav.monomail.data.settings.AppSettings,
+    unifiedInboxEnabled: Boolean,
+    navActions: InboxNavActions,
+    viewModel: InboxViewModel,
+    navBarHeight: Dp,
+    showClearTrashWarning: () -> Unit,
+    showClearSpamWarning: () -> Unit
+) {
+    val tabForDock by remember { derivedStateOf { immediateTab } }
+    Row(
+        modifier = Modifier.padding(bottom = navBarHeight + 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.Bottom
+    ) {
+        BottomDockBar(
+            currentTab = tabForDock,
+            dockConfig = appSettings.dockConfig,
+            unifiedInboxEnabled = unifiedInboxEnabled,
+            appSettings = appSettings,
+            onTabClick = { viewModel.switchTab(it) }
+        )
+        AnimatedContent(
+            targetState = when {
+                tabForDock == InboxTab.TRASH -> "trash"
+                tabForDock == InboxTab.SPAM -> "spam"
+                else -> "default"
+            },
+            label = "FabIconMorph",
+            transitionSpec = {
+                (fadeIn(tween(180)) + scaleIn(tween(180), initialScale = 0.85f)) togetherWith
+                        (fadeOut(tween(120)) + scaleOut(tween(120), targetScale = 0.85f))
+            }
+        ) { state ->
+            when (state) {
+                "trash" -> EmptyTrashFab(appSettings, showClearTrashWarning)
+                "spam" -> EmptySpamFab(appSettings, showClearSpamWarning)
+                "default" -> ComposeFab(appSettings, navActions.onCompose)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyTrashFab(appSettings: com.shrivatsav.monomail.data.settings.AppSettings, onClick: () -> Unit) {
+    FloatingActionButton(
+        onClick = onClick,
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = CircleShape,
+        elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 4.dp),
+        modifier = Modifier.height((42 * appSettings.navScale).dp)
+    ) {
+        Row(modifier = Modifier.padding(horizontal = 12.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Icon(Icons.Rounded.Delete, contentDescription = "Empty Trash", modifier = Modifier.size((22 * appSettings.navScale).dp))
+            Text("Empty", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onErrorContainer)
+        }
+    }
+}
+
+@Composable
+private fun EmptySpamFab(appSettings: com.shrivatsav.monomail.data.settings.AppSettings, onClick: () -> Unit) {
+    FloatingActionButton(
+        onClick = onClick,
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = CircleShape,
+        elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 4.dp),
+        modifier = Modifier.height((42 * appSettings.navScale).dp)
+    ) {
+        Row(modifier = Modifier.padding(horizontal = 12.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Icon(Icons.Rounded.Report, contentDescription = "Empty Spam", modifier = Modifier.size((22 * appSettings.navScale).dp))
+            Text("Empty", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onErrorContainer)
+        }
+    }
+}
+
+@Composable
+private fun ComposeFab(appSettings: com.shrivatsav.monomail.data.settings.AppSettings, onClick: () -> Unit) {
+    val fabInteractionSource = remember { MutableInteractionSource() }
+    val isFabPressed by fabInteractionSource.collectIsPressedAsState()
+    val fabScale by animateFloatAsState(
+        targetValue = if (isFabPressed) 0.92f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "fabScale"
+    )
+    FloatingActionButton(
+        onClick = onClick,
+        interactionSource = fabInteractionSource,
+        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        shape = CircleShape,
+        elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 4.dp),
+        modifier = Modifier.size((52 * appSettings.navScale).dp).graphicsLayer(scaleX = fabScale, scaleY = fabScale)
+    ) {
+        Icon(Icons.Rounded.Edit, contentDescription = "Compose")
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LongPressMenu(
+    thread: EmailThread,
+    state: InboxState,
+    onDismiss: () -> Unit,
+    onEmailClick: () -> Unit,
+    onStar: () -> Unit,
+    onArchive: (InboxTab) -> Unit,
+    onToggleRead: () -> Unit,
+    onDelete: () -> Unit,
+    onSnooze: () -> Unit,
+    onUnsnooze: () -> Unit
+) {
+    val tabForMenu = (state as? InboxState.Success)?.currentTab ?: InboxTab.INBOX
+    BackHandler { onDismiss() }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f))
+            .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) { onDismiss() }
+    )
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.85f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
+                EmailItem(thread = thread, onClick = { onDismiss(); onEmailClick() }, onLongClick = {}, modifier = Modifier)
+            }
+            Spacer(Modifier.height(8.dp))
+            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
+                Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp), horizontalArrangement = Arrangement.SpaceEvenly, verticalAlignment = Alignment.Bottom) {
+                    if (tabForMenu == InboxTab.SNOOZED) {
+                        LongPressAction(icon = Icons.Rounded.Restore, label = "Unsnooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { onUnsnooze(); onDismiss() })
+                    } else {
+                        LongPressAction(icon = if (thread.isStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder, label = if (thread.isStarred) "Unstar" else "Star", tint = MaterialTheme.colorScheme.onSurface, onClick = { onStar(); onDismiss() })
+                    }
+                    LongPressAction(
+                        icon = if (tabForMenu == InboxTab.ARCHIVED) Icons.Rounded.Inbox else Icons.Rounded.Archive,
+                        label = when (tabForMenu) { InboxTab.ARCHIVED -> "Unarchive"; InboxTab.SPAM -> "Not spam"; else -> "Archive" },
+                        tint = MaterialTheme.colorScheme.onSurface,
+                        onClick = { onArchive(tabForMenu); onDismiss() }
+                    )
+                    LongPressAction(icon = if (thread.isRead) Icons.Rounded.MarkEmailUnread else Icons.Rounded.CheckCircle, label = if (thread.isRead) "Unread" else "Read", tint = MaterialTheme.colorScheme.onSurface, onClick = { onToggleRead(); onDismiss() })
+                    if (tabForMenu != InboxTab.TRASH && tabForMenu != InboxTab.SNOOZED && tabForMenu != InboxTab.SPAM) {
+                        LongPressAction(icon = Icons.Rounded.Schedule, label = "Snooze", tint = MaterialTheme.colorScheme.onSurface, onClick = { onDismiss(); onSnooze() })
+                    }
+                    LongPressAction(
+                        icon = if (tabForMenu == InboxTab.TRASH) Icons.Rounded.Restore else Icons.Rounded.Delete,
+                        label = if (tabForMenu == InboxTab.TRASH) "Restore" else "Delete",
+                        tint = if (tabForMenu == InboxTab.TRASH) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error,
+                        onClick = { if (tabForMenu == InboxTab.TRASH) { onArchive(tabForMenu) } else { onDelete() }; onDismiss() }
+                    )
+                }
+            }
+        }
+    }
+}
 
 @Composable
 private fun SnoozePickerDialog(

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxSearchBar.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxSearchBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -79,66 +80,7 @@ internal fun InboxSearchBar(
                         .height(56.dp)
                 ) {
                     if (bulkSelection.isBulkMode) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(start = 20.dp, end = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            AnimatedContent(
-                                targetState = bulkSelection.selectedCount,
-                                label = "selectedCount",
-                                modifier = Modifier.weight(1f),
-                                transitionSpec = {
-                                    (fadeIn(tween(200)) + scaleIn(tween(200))).togetherWith(
-                                        fadeOut(tween(150)) + scaleOut(tween(150))
-                                    )
-                                }
-                            ) { count ->
-                                Text(
-                                    text = if (count == 1) "1 selected" else "$count selected",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            }
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                if (bulkSelection.selectedCount < bulkSelection.totalCount) {
-                                    TextButton(
-                                        onClick = bulkSelection.onSelectAll,
-                                        shape = RoundedCornerShape(24.dp),
-                                        colors = ButtonDefaults.textButtonColors(
-                                            contentColor = MaterialTheme.colorScheme.primary
-                                        )
-                                    ) {
-                                        Text("Select all")
-                                    }
-                                } else {
-                                    TextButton(
-                                        onClick = bulkSelection.onDeselectAll,
-                                        shape = RoundedCornerShape(24.dp),
-                                        colors = ButtonDefaults.textButtonColors(
-                                            contentColor = MaterialTheme.colorScheme.primary
-                                        )
-                                    ) {
-                                        Text("Deselect all")
-                                    }
-                                }
-                                Spacer(Modifier.width(4.dp))
-                                IconButton(
-                                    onClick = bulkSelection.onDone,
-                                    modifier = Modifier.size(40.dp)
-                                ) {
-                                    Icon(
-                                        Icons.Rounded.Close,
-                                        contentDescription = "Done",
-                                        tint = MaterialTheme.colorScheme.onSurface
-                                    )
-                                }
-                            }
-                        }
+                        BulkSelectionContent(bulkSelection)
                     } else {
                         AnimatedContent(
                             targetState = toastState,
@@ -146,136 +88,9 @@ internal fun InboxSearchBar(
                             transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(200)) }
                         ) { toast ->
                             if (toast != null) {
-                                val icon = when (toast.actionType) {
-                                    InboxViewModel.ActionType.ARCHIVE -> Icons.Rounded.Archive
-                                    InboxViewModel.ActionType.DELETE -> Icons.Rounded.Delete
-                                    InboxViewModel.ActionType.EMPTY_TRASH -> Icons.Rounded.Delete
-                                    InboxViewModel.ActionType.SEND -> Icons.AutoMirrored.Rounded.Send
-                                    InboxViewModel.ActionType.SNOOZE -> Icons.Rounded.Schedule
-                                    InboxViewModel.ActionType.UNARCHIVE -> Icons.Rounded.Unarchive
-                                    InboxViewModel.ActionType.RESTORE -> Icons.Rounded.Restore
-                                }
-                                Row(
-                                    modifier = Modifier.fillMaxSize(),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Spacer(Modifier.width(16.dp))
-                                    Icon(
-                                        icon, null,
-                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                        modifier = Modifier.size(20.dp)
-                                    )
-                                    Spacer(Modifier.width(10.dp))
-                                    Text(
-                                        toast.message,
-                                        modifier = Modifier.weight(1f),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        fontWeight = FontWeight.Medium,
-                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                    TextButton(
-                                        onClick = actions.onUndo,
-                                        shape = RoundedCornerShape(24.dp),
-                                        colors = ButtonDefaults.textButtonColors(
-                                            contentColor = MaterialTheme.colorScheme.primary
-                                        )
-                                    ) {
-                                        Text("Undo")
-                                    }
-                                    Spacer(Modifier.width(12.dp))
-                                }
+                                ToastContent(toast, actions)
                             } else {
-                                SearchBarDefaults.InputField(
-                                    query = query,
-                                    onQueryChange = onQueryChange,
-                                    onSearch = { onServerSearch(query) },
-                                    expanded = false,
-                                    onExpandedChange = {},
-                                    placeholder = {
-                                        Text(
-                                            if (isRefreshing) "Syncing..."
-                                            else if (unifiedInboxEnabled) "Search all accounts..."
-                                            else "Search in mail",
-                                            style = MaterialTheme.typography.bodyLarge,
-                                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-                                        )
-                                    },
-                                    leadingIcon = {
-                                        if (isRefreshing) {
-                                            LoadingIndicator(
-                                                modifier = Modifier
-                                                    .padding(start = 8.dp)
-                                                    .size(40.dp),
-                                                color = MaterialTheme.colorScheme.onSurface
-                                            )
-                                        } else {
-                                            Icon(
-                                                Icons.Rounded.Search,
-                                                contentDescription = "Search",
-                                                tint = MaterialTheme.colorScheme.onSurface,
-                                                modifier = Modifier.padding(start = 8.dp)
-                                            )
-                                        }
-                                    },
-                                    trailingIcon = {
-                                        Row(
-                                            verticalAlignment = Alignment.CenterVertically,
-                                        ) {
-                                            BadgedBox(
-                                                badge = {
-                                                    if (actions.scheduledCount > 0) {
-                                                        Badge(
-                                                            containerColor = MaterialTheme.colorScheme.error,
-                                                            contentColor = MaterialTheme.colorScheme.onError
-                                                        ) {
-                                                            Text(
-                                                                if (actions.scheduledCount > 99) "99+" else actions.scheduledCount.toString(),
-                                                                style = MaterialTheme.typography.labelSmall
-                                                            )
-                                                        }
-                                                    }
-                                                }
-                                            ) {
-                                                IconButton(
-                                                    onClick = actions.onScheduledClick,
-                                                    modifier = Modifier.size(40.dp)
-                                                ) {
-                                                    Icon(
-                                                        Icons.Rounded.CalendarMonth,
-                                                        contentDescription = "Scheduled",
-                                                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                                                        modifier = Modifier.size(25.dp)
-                                                    )
-                                                }
-                                            }
-                                            IconButton(
-                                                onClick = actions.onMarkAllRead,
-                                                modifier = Modifier.size(40.dp)
-                                            ) {
-                                                Icon(
-                                                    Icons.Rounded.CheckCircle,
-                                                    contentDescription = "Mark all as read",
-                                                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                                                    modifier = Modifier.size(25.dp)
-                                                )
-                                            }
-                                            Spacer(Modifier.width(4.dp))
-                                            if (unifiedInboxEnabled && accounts.size > 1) {
-                                                StackedAccountAvatars(
-                                                    accounts = accounts,
-                                                    onClick = actions.onOpenProfile
-                                                )
-                                            } else {
-                                                AvatarButton(
-                                                    userProfile = userProfile,
-                                                    onClick = actions.onOpenProfile
-                                                )
-                                            }
-                                        }
-                                    }
-                                )
+                                SearchInputContent(query, onQueryChange, onServerSearch, isRefreshing, unifiedInboxEnabled, accounts, actions, userProfile)
                             }
                         }
                     }
@@ -289,6 +104,142 @@ internal fun InboxSearchBar(
             windowInsets = WindowInsets(0.dp)
         ) {}
     }
+}
+
+@Composable
+private fun BulkSelectionContent(bulkSelection: BulkSelectionState) {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 20.dp, end = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AnimatedContent(
+            targetState = bulkSelection.selectedCount,
+            label = "selectedCount",
+            modifier = Modifier.weight(1f),
+            transitionSpec = {
+                (fadeIn(tween(200)) + scaleIn(tween(200))).togetherWith(
+                    fadeOut(tween(150)) + scaleOut(tween(150))
+                )
+            }
+        ) { count ->
+            Text(
+                text = if (count == 1) "1 selected" else "$count selected",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (bulkSelection.selectedCount < bulkSelection.totalCount) {
+                TextButton(
+                    onClick = bulkSelection.onSelectAll,
+                    shape = RoundedCornerShape(24.dp),
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
+                ) { Text("Select all") }
+            } else {
+                TextButton(
+                    onClick = bulkSelection.onDeselectAll,
+                    shape = RoundedCornerShape(24.dp),
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
+                ) { Text("Deselect all") }
+            }
+            Spacer(Modifier.width(4.dp))
+            IconButton(onClick = bulkSelection.onDone, modifier = Modifier.size(40.dp)) {
+                Icon(Icons.Rounded.Close, contentDescription = "Done", tint = MaterialTheme.colorScheme.onSurface)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToastContent(toast: InboxViewModel.ToastState, actions: SearchBarActions) {
+    val icon = when (toast.actionType) {
+        InboxViewModel.ActionType.ARCHIVE -> Icons.Rounded.Archive
+        InboxViewModel.ActionType.DELETE -> Icons.Rounded.Delete
+        InboxViewModel.ActionType.EMPTY_TRASH -> Icons.Rounded.Delete
+        InboxViewModel.ActionType.SEND -> Icons.AutoMirrored.Rounded.Send
+        InboxViewModel.ActionType.SNOOZE -> Icons.Rounded.Schedule
+        InboxViewModel.ActionType.UNARCHIVE -> Icons.Rounded.Unarchive
+        InboxViewModel.ActionType.RESTORE -> Icons.Rounded.Restore
+    }
+    Row(modifier = Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
+        Spacer(Modifier.width(16.dp))
+        Icon(icon, null, tint = MaterialTheme.colorScheme.onSecondaryContainer, modifier = Modifier.size(20.dp))
+        Spacer(Modifier.width(10.dp))
+        Text(
+            toast.message, modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer, maxLines = 1, overflow = TextOverflow.Ellipsis
+        )
+        TextButton(
+            onClick = actions.onUndo, shape = RoundedCornerShape(24.dp),
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
+        ) { Text("Undo") }
+        Spacer(Modifier.width(12.dp))
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun SearchInputContent(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onServerSearch: (String) -> Unit,
+    isRefreshing: Boolean,
+    unifiedInboxEnabled: Boolean,
+    accounts: List<UserProfile>,
+    actions: SearchBarActions,
+    userProfile: UserProfile?
+) {
+    SearchBarDefaults.InputField(
+        query = query,
+        onQueryChange = onQueryChange,
+        onSearch = { onServerSearch(query) },
+        expanded = false,
+        onExpandedChange = {},
+        placeholder = {
+            Text(
+                if (isRefreshing) "Syncing..." else if (unifiedInboxEnabled) "Search all accounts..." else "Search in mail",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            )
+        },
+        leadingIcon = {
+            if (isRefreshing) {
+                LoadingIndicator(modifier = Modifier.padding(start = 8.dp).size(40.dp), color = MaterialTheme.colorScheme.onSurface)
+            } else {
+                Icon(Icons.Rounded.Search, contentDescription = "Search", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.padding(start = 8.dp))
+            }
+        },
+        trailingIcon = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                BadgedBox(badge = {
+                    if (actions.scheduledCount > 0) {
+                        Badge(containerColor = MaterialTheme.colorScheme.error, contentColor = MaterialTheme.colorScheme.onError) {
+                            Text(if (actions.scheduledCount > 99) "99+" else actions.scheduledCount.toString(), style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }) {
+                    IconButton(onClick = actions.onScheduledClick, modifier = Modifier.size(40.dp)) {
+                        Icon(Icons.Rounded.CalendarMonth, contentDescription = "Scheduled", tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f), modifier = Modifier.size(25.dp))
+                    }
+                }
+                IconButton(onClick = actions.onMarkAllRead, modifier = Modifier.size(40.dp)) {
+                    Icon(Icons.Rounded.CheckCircle, contentDescription = "Mark all as read", tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f), modifier = Modifier.size(25.dp))
+                }
+                Spacer(Modifier.width(4.dp))
+                if (unifiedInboxEnabled && accounts.size > 1) {
+                    StackedAccountAvatars(accounts = accounts, onClick = actions.onOpenProfile)
+                } else {
+                    AvatarButton(userProfile = userProfile, onClick = actions.onOpenProfile)
+                }
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxSearchBar.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxSearchBar.kt
@@ -43,6 +43,13 @@ data class BulkSelectionState(
     val onDone: () -> Unit = {}
 )
 
+data class SearchDisplayState(
+    val isRefreshing: Boolean = false,
+    val unifiedInboxEnabled: Boolean = false,
+    val accounts: List<UserProfile> = emptyList(),
+    val userProfile: UserProfile? = null
+)
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun InboxSearchBar(
@@ -90,7 +97,7 @@ internal fun InboxSearchBar(
                             if (toast != null) {
                                 ToastContent(toast, actions)
                             } else {
-                                SearchInputContent(query, onQueryChange, onServerSearch, isRefreshing, unifiedInboxEnabled, accounts, actions, userProfile)
+                                SearchInputContent(query, onQueryChange, onServerSearch, actions, SearchDisplayState(isRefreshing, unifiedInboxEnabled, accounts, userProfile))
                             }
                         }
                     }
@@ -189,11 +196,8 @@ private fun SearchInputContent(
     query: String,
     onQueryChange: (String) -> Unit,
     onServerSearch: (String) -> Unit,
-    isRefreshing: Boolean,
-    unifiedInboxEnabled: Boolean,
-    accounts: List<UserProfile>,
     actions: SearchBarActions,
-    userProfile: UserProfile?
+    display: SearchDisplayState
 ) {
     SearchBarDefaults.InputField(
         query = query,
@@ -203,43 +207,46 @@ private fun SearchInputContent(
         onExpandedChange = {},
         placeholder = {
             Text(
-                if (isRefreshing) "Syncing..." else if (unifiedInboxEnabled) "Search all accounts..." else "Search in mail",
+                if (display.isRefreshing) "Syncing..." else if (display.unifiedInboxEnabled) "Search all accounts..." else "Search in mail",
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
             )
         },
         leadingIcon = {
-            if (isRefreshing) {
+            if (display.isRefreshing) {
                 LoadingIndicator(modifier = Modifier.padding(start = 8.dp).size(40.dp), color = MaterialTheme.colorScheme.onSurface)
             } else {
                 Icon(Icons.Rounded.Search, contentDescription = "Search", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.padding(start = 8.dp))
             }
         },
-        trailingIcon = {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                BadgedBox(badge = {
-                    if (actions.scheduledCount > 0) {
-                        Badge(containerColor = MaterialTheme.colorScheme.error, contentColor = MaterialTheme.colorScheme.onError) {
-                            Text(if (actions.scheduledCount > 99) "99+" else actions.scheduledCount.toString(), style = MaterialTheme.typography.labelSmall)
-                        }
-                    }
-                }) {
-                    IconButton(onClick = actions.onScheduledClick, modifier = Modifier.size(40.dp)) {
-                        Icon(Icons.Rounded.CalendarMonth, contentDescription = "Scheduled", tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f), modifier = Modifier.size(25.dp))
-                    }
-                }
-                IconButton(onClick = actions.onMarkAllRead, modifier = Modifier.size(40.dp)) {
-                    Icon(Icons.Rounded.CheckCircle, contentDescription = "Mark all as read", tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f), modifier = Modifier.size(25.dp))
-                }
-                Spacer(Modifier.width(4.dp))
-                if (unifiedInboxEnabled && accounts.size > 1) {
-                    StackedAccountAvatars(accounts = accounts, onClick = actions.onOpenProfile)
-                } else {
-                    AvatarButton(userProfile = userProfile, onClick = actions.onOpenProfile)
+        trailingIcon = { SearchTrailingIcon(actions, display) }
+    )
+}
+
+@Composable
+private fun SearchTrailingIcon(actions: SearchBarActions, display: SearchDisplayState) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        BadgedBox(badge = {
+            if (actions.scheduledCount > 0) {
+                Badge(containerColor = MaterialTheme.colorScheme.error, contentColor = MaterialTheme.colorScheme.onError) {
+                    Text(if (actions.scheduledCount > 99) "99+" else actions.scheduledCount.toString(), style = MaterialTheme.typography.labelSmall)
                 }
             }
+        }) {
+            IconButton(onClick = actions.onScheduledClick, modifier = Modifier.size(40.dp)) {
+                Icon(Icons.Rounded.CalendarMonth, contentDescription = "Scheduled", tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f), modifier = Modifier.size(25.dp))
+            }
         }
-    )
+        IconButton(onClick = actions.onMarkAllRead, modifier = Modifier.size(40.dp)) {
+            Icon(Icons.Rounded.CheckCircle, contentDescription = "Mark all as read", tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f), modifier = Modifier.size(25.dp))
+        }
+        Spacer(Modifier.width(4.dp))
+        if (display.unifiedInboxEnabled && display.accounts.size > 1) {
+            StackedAccountAvatars(accounts = display.accounts, onClick = actions.onOpenProfile)
+        } else {
+            AvatarButton(userProfile = display.userProfile, onClick = actions.onOpenProfile)
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxSearchBar.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxSearchBar.kt
@@ -25,6 +25,23 @@ import androidx.compose.foundation.layout.offset
 import com.shrivatsav.monomail.auth.UserProfile
 import com.shrivatsav.monomail.data.settings.SwipeAction
 
+data class SearchBarActions(
+    val onMarkAllRead: () -> Unit,
+    val onScheduledClick: () -> Unit = {},
+    val scheduledCount: Int = 0,
+    val onUndo: () -> Unit,
+    val onOpenProfile: () -> Unit
+)
+
+data class BulkSelectionState(
+    val isBulkMode: Boolean = false,
+    val selectedCount: Int = 0,
+    val totalCount: Int = 0,
+    val onSelectAll: () -> Unit = {},
+    val onDeselectAll: () -> Unit = {},
+    val onDone: () -> Unit = {}
+)
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun InboxSearchBar(
@@ -33,24 +50,15 @@ internal fun InboxSearchBar(
     query: String,
     onQueryChange: (String) -> Unit,
     onServerSearch: (String) -> Unit,
-    onMarkAllRead: () -> Unit,
-    onScheduledClick: () -> Unit = {},
-    scheduledCount: Int = 0,
+    actions: SearchBarActions,
     isRefreshing: Boolean,
     toastState: InboxViewModel.ToastState?,
-    onUndo: () -> Unit,
-    onOpenProfile: () -> Unit,
-    isBulkMode: Boolean = false,
-    selectedCount: Int = 0,
-    totalCount: Int = 0,
-    onSelectAll: () -> Unit = {},
-    onDeselectAll: () -> Unit = {},
-    onDone: () -> Unit = {},
+    bulkSelection: BulkSelectionState = BulkSelectionState(),
     unifiedInboxEnabled: Boolean = false,
 ) {
     val containerColor by animateColorAsState(
         targetValue = when {
-            isBulkMode -> MaterialTheme.colorScheme.secondaryContainer
+            bulkSelection.isBulkMode -> MaterialTheme.colorScheme.secondaryContainer
             toastState != null -> MaterialTheme.colorScheme.secondaryContainer
             else -> MaterialTheme.colorScheme.surfaceContainer
         },
@@ -70,7 +78,7 @@ internal fun InboxSearchBar(
                         .fillMaxWidth()
                         .height(56.dp)
                 ) {
-                    if (isBulkMode) {
+                    if (bulkSelection.isBulkMode) {
                         Row(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -78,7 +86,7 @@ internal fun InboxSearchBar(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             AnimatedContent(
-                                targetState = selectedCount,
+                                targetState = bulkSelection.selectedCount,
                                 label = "selectedCount",
                                 modifier = Modifier.weight(1f),
                                 transitionSpec = {
@@ -97,9 +105,9 @@ internal fun InboxSearchBar(
                                 )
                             }
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                if (selectedCount < totalCount) {
+                                if (bulkSelection.selectedCount < bulkSelection.totalCount) {
                                     TextButton(
-                                        onClick = onSelectAll,
+                                        onClick = bulkSelection.onSelectAll,
                                         shape = RoundedCornerShape(24.dp),
                                         colors = ButtonDefaults.textButtonColors(
                                             contentColor = MaterialTheme.colorScheme.primary
@@ -109,7 +117,7 @@ internal fun InboxSearchBar(
                                     }
                                 } else {
                                     TextButton(
-                                        onClick = onDeselectAll,
+                                        onClick = bulkSelection.onDeselectAll,
                                         shape = RoundedCornerShape(24.dp),
                                         colors = ButtonDefaults.textButtonColors(
                                             contentColor = MaterialTheme.colorScheme.primary
@@ -120,7 +128,7 @@ internal fun InboxSearchBar(
                                 }
                                 Spacer(Modifier.width(4.dp))
                                 IconButton(
-                                    onClick = onDone,
+                                    onClick = bulkSelection.onDone,
                                     modifier = Modifier.size(40.dp)
                                 ) {
                                     Icon(
@@ -168,7 +176,7 @@ internal fun InboxSearchBar(
                                         overflow = TextOverflow.Ellipsis
                                     )
                                     TextButton(
-                                        onClick = onUndo,
+                                        onClick = actions.onUndo,
                                         shape = RoundedCornerShape(24.dp),
                                         colors = ButtonDefaults.textButtonColors(
                                             contentColor = MaterialTheme.colorScheme.primary
@@ -217,13 +225,13 @@ internal fun InboxSearchBar(
                                         ) {
                                             BadgedBox(
                                                 badge = {
-                                                    if (scheduledCount > 0) {
+                                                    if (actions.scheduledCount > 0) {
                                                         Badge(
                                                             containerColor = MaterialTheme.colorScheme.error,
                                                             contentColor = MaterialTheme.colorScheme.onError
                                                         ) {
                                                             Text(
-                                                                if (scheduledCount > 99) "99+" else scheduledCount.toString(),
+                                                                if (actions.scheduledCount > 99) "99+" else actions.scheduledCount.toString(),
                                                                 style = MaterialTheme.typography.labelSmall
                                                             )
                                                         }
@@ -231,7 +239,7 @@ internal fun InboxSearchBar(
                                                 }
                                             ) {
                                                 IconButton(
-                                                    onClick = onScheduledClick,
+                                                    onClick = actions.onScheduledClick,
                                                     modifier = Modifier.size(40.dp)
                                                 ) {
                                                     Icon(
@@ -243,7 +251,7 @@ internal fun InboxSearchBar(
                                                 }
                                             }
                                             IconButton(
-                                                onClick = onMarkAllRead,
+                                                onClick = actions.onMarkAllRead,
                                                 modifier = Modifier.size(40.dp)
                                             ) {
                                                 Icon(
@@ -257,12 +265,12 @@ internal fun InboxSearchBar(
                                             if (unifiedInboxEnabled && accounts.size > 1) {
                                                 StackedAccountAvatars(
                                                     accounts = accounts,
-                                                    onClick = onOpenProfile
+                                                    onClick = actions.onOpenProfile
                                                 )
                                             } else {
                                                 AvatarButton(
                                                     userProfile = userProfile,
-                                                    onClick = onOpenProfile
+                                                    onClick = actions.onOpenProfile
                                                 )
                                             }
                                         }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/ProfileCard.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/ProfileCard.kt
@@ -132,6 +132,36 @@ private fun ProfileAvatarSection(
     }
 }
 
+private fun Modifier.cycleAccountDrag(
+    accounts: List<UserProfile>,
+    userProfile: UserProfile,
+    unifiedInboxEnabled: Boolean,
+    onCycleAccount: (String) -> Unit
+): Modifier = this.pointerInput(accounts, unifiedInboxEnabled) {
+    if (accounts.size > 1 && !unifiedInboxEnabled) {
+        var totalDrag = 0f
+        detectHorizontalDragGestures(
+            onDragStart = { totalDrag = 0f },
+            onHorizontalDrag = { change, dragAmount ->
+                change.consume()
+                totalDrag += dragAmount
+                if (kotlin.math.abs(totalDrag) > 60f) {
+                    val nextId = nextAccountId(accounts, userProfile.id, totalDrag > 0)
+                    if (nextId != null) onCycleAccount(nextId)
+                    totalDrag = 0f
+                }
+            }
+        )
+    }
+}
+
+private fun nextAccountId(accounts: List<UserProfile>, currentId: String, goForward: Boolean): String? {
+    val idx = accounts.indexOfFirst { it.id == currentId }
+    if (idx == -1) return null
+    val nextIdx = if (goForward) (idx + 1) % accounts.size else (idx - 1 + accounts.size) % accounts.size
+    return accounts[nextIdx].id
+}
+
 @Composable
 private fun DraggableAvatarBox(
     userProfile: UserProfile,
@@ -141,29 +171,7 @@ private fun DraggableAvatarBox(
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.pointerInput(accounts, unifiedInboxEnabled) {
-            if (accounts.size > 1 && !unifiedInboxEnabled) {
-                var totalDrag = 0f
-                detectHorizontalDragGestures(
-                    onDragStart = { totalDrag = 0f },
-                    onHorizontalDrag = { change, dragAmount ->
-                        change.consume()
-                        totalDrag += dragAmount
-                        if (kotlin.math.abs(totalDrag) > 60f) {
-                            val currentIdx = accounts.indexOfFirst { it.id == userProfile.id }
-                            if (currentIdx != -1) {
-                                val nextIdx = if (totalDrag > 0)
-                                    (currentIdx + 1) % accounts.size
-                                else
-                                    if (currentIdx - 1 < 0) accounts.size - 1 else currentIdx - 1
-                                callbacks.onCycleAccount(accounts[nextIdx].id)
-                            }
-                            totalDrag = 0f
-                        }
-                    }
-                )
-            }
-        }
+        modifier = Modifier.cycleAccountDrag(accounts, userProfile, unifiedInboxEnabled, callbacks.onCycleAccount)
     ) {
         if (accounts.size > 1) {
             StackedAvatars(userProfile, accounts)

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/ProfileCard.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/ProfileCard.kt
@@ -57,123 +57,9 @@ internal fun ProfileCard(
                     .padding(top = 28.dp, bottom = 20.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                AnimatedContent(
-                    targetState = userProfile.id,
-                    transitionSpec = {
-                        (fadeIn(tween(220)) + scaleIn(tween(220), initialScale = 0.9f)) togetherWith
-                        (fadeOut(tween(150)) + scaleOut(tween(150), targetScale = 0.9f))
-                    },
-                    label = "profileContent"
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier.pointerInput(accounts, unifiedInboxEnabled) {
-                                if (accounts.size > 1 && !unifiedInboxEnabled) {
-                                    var totalDrag = 0f
-                                    detectHorizontalDragGestures(
-                                        onDragStart = { totalDrag = 0f },
-                                        onHorizontalDrag = { change, dragAmount ->
-                                            change.consume()
-                                            totalDrag += dragAmount
-                                            if (kotlin.math.abs(totalDrag) > 60f) {
-                                                val currentIdx = accounts.indexOfFirst { it.id == userProfile.id }
-                                                if (currentIdx != -1) {
-                                                    val nextIdx = if (totalDrag > 0)
-                                                        (currentIdx + 1) % accounts.size
-                                                    else
-                                                        if (currentIdx - 1 < 0) accounts.size - 1 else currentIdx - 1
-                                                    callbacks.onCycleAccount(accounts[nextIdx].id)
-                                                }
-                                                totalDrag = 0f
-                                            }
-                                        }
-                                    )
-                                }
-                            }
-                        ) {
-                            if (accounts.size > 1) {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy((-16).dp),
-                                    modifier = Modifier.offset(x = 28.dp)
-                                ) {
-                                    accounts.filter { it.id != userProfile.id }.take(2).forEach { acc ->
-                                        Box(
-                                            modifier = Modifier
-                                                .size(44.dp)
-                                                .border(2.dp, MaterialTheme.colorScheme.background, CircleShape)
-                                                .clip(CircleShape)
-                                                .alpha(0.45f)
-                                        ) {
-                                            AvatarCircle(
-                                                acc.photoUrl,
-                                                acc.displayName,
-                                                44.dp,
-                                                MaterialTheme.typography.titleSmall
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-                            Box(modifier = Modifier.border(3.dp, MaterialTheme.colorScheme.background, CircleShape)) {
-                                AvatarCircle(
-                                    photoUrl = userProfile.photoUrl,
-                                    displayName = userProfile.displayName,
-                                    size = 72.dp,
-                                    textStyle = MaterialTheme.typography.headlineSmall
-                                )
-                            }
-                        }
-
-                        Spacer(Modifier.height(14.dp))
-                        Text(
-                            text = userProfile.displayName,
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onBackground,
-                            maxLines = 1
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(
-                            text = userProfile.email,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.padding(horizontal = 24.dp)
-                        )
-                    }
-                }
-
+                ProfileAvatarSection(userProfile, accounts, callbacks, unifiedInboxEnabled)
                 if (accounts.size > 1 && !unifiedInboxEnabled) {
-                    Spacer(Modifier.height(12.dp))
-                    Surface(
-                        shape = CircleShape,
-                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.07f),
-                        modifier = Modifier.clickable { callbacks.onShowSwitchAccount() }
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 7.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(6.dp)
-                        ) {
-                            Text(
-                                text = "${accounts.size} accounts",
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.Medium,
-                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-                            )
-                            Icon(
-                                Icons.Rounded.KeyboardArrowDown,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
-                                modifier = Modifier.size(14.dp)
-                            )
-                        }
-                    }
+                    AccountSwitcherButton(accounts, callbacks)
                 }
             }
 
@@ -182,49 +68,8 @@ internal fun ProfileCard(
                 thickness = 0.5.dp
             )
 
-            // Unified inbox toggle
             if (accounts.size > 1) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 8.dp, vertical = 2.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        Icons.Rounded.Inbox,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.55f),
-                        modifier = Modifier
-                            .padding(horizontal = 14.dp)
-                            .size(21.dp)
-                    )
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            "Unified Inbox",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                        if (unifiedInboxEnabled) {
-                            Text(
-                                "All accounts combined",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
-                            )
-                        }
-                    }
-                    Switch(
-                        checked = unifiedInboxEnabled,
-                        onCheckedChange = callbacks.onToggleUnified,
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = MaterialTheme.colorScheme.onBackground,
-                            checkedTrackColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.25f),
-                            uncheckedThumbColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-                            uncheckedTrackColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.12f)
-                        ),
-                        modifier = Modifier.padding(end = 8.dp)
-                    )
-                }
+                UnifiedInboxToggle(unifiedInboxEnabled, callbacks)
             }
 
             Column(
@@ -240,50 +85,228 @@ internal fun ProfileCard(
                 thickness = 0.5.dp
             )
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                OutlinedButton(
-                    onClick = callbacks.onSignOut,
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(14.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = MaterialTheme.colorScheme.onBackground
-                    ),
-                    border = BorderStroke(
-                        1.dp,
-                        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.15f)
-                    ),
-                    contentPadding = PaddingValues(vertical = 12.dp)
-                ) {
-                    Text(
-                        "Sign out",
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold
-                    )
+            ProfileCardButtons(callbacks)
+        }
+    }
+}
+
+@Composable
+private fun ProfileAvatarSection(
+    userProfile: UserProfile,
+    accounts: List<UserProfile>,
+    callbacks: ProfileCardCallbacks,
+    unifiedInboxEnabled: Boolean
+) {
+    AnimatedContent(
+        targetState = userProfile.id,
+        transitionSpec = {
+            (fadeIn(tween(220)) + scaleIn(tween(220), initialScale = 0.9f)) togetherWith
+            (fadeOut(tween(150)) + scaleOut(tween(150), targetScale = 0.9f))
+        },
+        label = "profileContent"
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.pointerInput(accounts, unifiedInboxEnabled) {
+                    if (accounts.size > 1 && !unifiedInboxEnabled) {
+                        var totalDrag = 0f
+                        detectHorizontalDragGestures(
+                            onDragStart = { totalDrag = 0f },
+                            onHorizontalDrag = { change, dragAmount ->
+                                change.consume()
+                                totalDrag += dragAmount
+                                if (kotlin.math.abs(totalDrag) > 60f) {
+                                    val currentIdx = accounts.indexOfFirst { it.id == userProfile.id }
+                                    if (currentIdx != -1) {
+                                        val nextIdx = if (totalDrag > 0)
+                                            (currentIdx + 1) % accounts.size
+                                        else
+                                            if (currentIdx - 1 < 0) accounts.size - 1 else currentIdx - 1
+                                        callbacks.onCycleAccount(accounts[nextIdx].id)
+                                    }
+                                    totalDrag = 0f
+                                }
+                            }
+                        )
+                    }
                 }
-                Button(
-                    onClick = callbacks.onAddAccount,
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(14.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.onBackground,
-                        contentColor = MaterialTheme.colorScheme.background
-                    ),
-                    contentPadding = PaddingValues(vertical = 12.dp)
-                ) {
-                    Icon(Icons.Rounded.Add, contentDescription = null, modifier = Modifier.size(16.dp))
-                    Spacer(Modifier.width(6.dp))
-                    Text(
-                        "Add account",
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold
+            ) {
+                if (accounts.size > 1) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy((-16).dp),
+                        modifier = Modifier.offset(x = 28.dp)
+                    ) {
+                        accounts.filter { it.id != userProfile.id }.take(2).forEach { acc ->
+                            Box(
+                                modifier = Modifier
+                                    .size(44.dp)
+                                    .border(2.dp, MaterialTheme.colorScheme.background, CircleShape)
+                                    .clip(CircleShape)
+                                    .alpha(0.45f)
+                            ) {
+                                AvatarCircle(
+                                    acc.photoUrl,
+                                    acc.displayName,
+                                    44.dp,
+                                    MaterialTheme.typography.titleSmall
+                                )
+                            }
+                        }
+                    }
+                }
+                Box(modifier = Modifier.border(3.dp, MaterialTheme.colorScheme.background, CircleShape)) {
+                    AvatarCircle(
+                        photoUrl = userProfile.photoUrl,
+                        displayName = userProfile.displayName,
+                        size = 72.dp,
+                        textStyle = MaterialTheme.typography.headlineSmall
                     )
                 }
             }
+
+            Spacer(Modifier.height(14.dp))
+            Text(
+                text = userProfile.displayName,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = userProfile.email,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun AccountSwitcherButton(accounts: List<UserProfile>, callbacks: ProfileCardCallbacks) {
+    Spacer(Modifier.height(12.dp))
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.07f),
+        modifier = Modifier.clickable { callbacks.onShowSwitchAccount() }
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text(
+                text = "${accounts.size} accounts",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+            )
+            Icon(
+                Icons.Rounded.KeyboardArrowDown,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                modifier = Modifier.size(14.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun UnifiedInboxToggle(unifiedInboxEnabled: Boolean, callbacks: ProfileCardCallbacks) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            Icons.Rounded.Inbox,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.55f),
+            modifier = Modifier
+                .padding(horizontal = 14.dp)
+                .size(21.dp)
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                "Unified Inbox",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            if (unifiedInboxEnabled) {
+                Text(
+                    "All accounts combined",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+                )
+            }
+        }
+        Switch(
+            checked = unifiedInboxEnabled,
+            onCheckedChange = callbacks.onToggleUnified,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = MaterialTheme.colorScheme.onBackground,
+                checkedTrackColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.25f),
+                uncheckedThumbColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                uncheckedTrackColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.12f)
+            ),
+            modifier = Modifier.padding(end = 8.dp)
+        )
+    }
+}
+
+@Composable
+private fun ProfileCardButtons(callbacks: ProfileCardCallbacks) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        OutlinedButton(
+            onClick = callbacks.onSignOut,
+            modifier = Modifier.weight(1f),
+            shape = RoundedCornerShape(14.dp),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = MaterialTheme.colorScheme.onBackground
+            ),
+            border = BorderStroke(
+                1.dp,
+                MaterialTheme.colorScheme.onBackground.copy(alpha = 0.15f)
+            ),
+            contentPadding = PaddingValues(vertical = 12.dp)
+        ) {
+            Text(
+                "Sign out",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+        Button(
+            onClick = callbacks.onAddAccount,
+            modifier = Modifier.weight(1f),
+            shape = RoundedCornerShape(14.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.onBackground,
+                contentColor = MaterialTheme.colorScheme.background
+            ),
+            contentPadding = PaddingValues(vertical = 12.dp)
+        ) {
+            Icon(Icons.Rounded.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+            Spacer(Modifier.width(6.dp))
+            Text(
+                "Add account",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
         }
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/ProfileCard.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/ProfileCard.kt
@@ -109,64 +109,7 @@ private fun ProfileAvatarSection(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.pointerInput(accounts, unifiedInboxEnabled) {
-                    if (accounts.size > 1 && !unifiedInboxEnabled) {
-                        var totalDrag = 0f
-                        detectHorizontalDragGestures(
-                            onDragStart = { totalDrag = 0f },
-                            onHorizontalDrag = { change, dragAmount ->
-                                change.consume()
-                                totalDrag += dragAmount
-                                if (kotlin.math.abs(totalDrag) > 60f) {
-                                    val currentIdx = accounts.indexOfFirst { it.id == userProfile.id }
-                                    if (currentIdx != -1) {
-                                        val nextIdx = if (totalDrag > 0)
-                                            (currentIdx + 1) % accounts.size
-                                        else
-                                            if (currentIdx - 1 < 0) accounts.size - 1 else currentIdx - 1
-                                        callbacks.onCycleAccount(accounts[nextIdx].id)
-                                    }
-                                    totalDrag = 0f
-                                }
-                            }
-                        )
-                    }
-                }
-            ) {
-                if (accounts.size > 1) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy((-16).dp),
-                        modifier = Modifier.offset(x = 28.dp)
-                    ) {
-                        accounts.filter { it.id != userProfile.id }.take(2).forEach { acc ->
-                            Box(
-                                modifier = Modifier
-                                    .size(44.dp)
-                                    .border(2.dp, MaterialTheme.colorScheme.background, CircleShape)
-                                    .clip(CircleShape)
-                                    .alpha(0.45f)
-                            ) {
-                                AvatarCircle(
-                                    acc.photoUrl,
-                                    acc.displayName,
-                                    44.dp,
-                                    MaterialTheme.typography.titleSmall
-                                )
-                            }
-                        }
-                    }
-                }
-                Box(modifier = Modifier.border(3.dp, MaterialTheme.colorScheme.background, CircleShape)) {
-                    AvatarCircle(
-                        photoUrl = userProfile.photoUrl,
-                        displayName = userProfile.displayName,
-                        size = 72.dp,
-                        textStyle = MaterialTheme.typography.headlineSmall
-                    )
-                }
-            }
+            DraggableAvatarBox(userProfile, accounts, callbacks, unifiedInboxEnabled)
 
             Spacer(Modifier.height(14.dp))
             Text(
@@ -185,6 +128,73 @@ private fun ProfileAvatarSection(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(horizontal = 24.dp)
             )
+        }
+    }
+}
+
+@Composable
+private fun DraggableAvatarBox(
+    userProfile: UserProfile,
+    accounts: List<UserProfile>,
+    callbacks: ProfileCardCallbacks,
+    unifiedInboxEnabled: Boolean
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.pointerInput(accounts, unifiedInboxEnabled) {
+            if (accounts.size > 1 && !unifiedInboxEnabled) {
+                var totalDrag = 0f
+                detectHorizontalDragGestures(
+                    onDragStart = { totalDrag = 0f },
+                    onHorizontalDrag = { change, dragAmount ->
+                        change.consume()
+                        totalDrag += dragAmount
+                        if (kotlin.math.abs(totalDrag) > 60f) {
+                            val currentIdx = accounts.indexOfFirst { it.id == userProfile.id }
+                            if (currentIdx != -1) {
+                                val nextIdx = if (totalDrag > 0)
+                                    (currentIdx + 1) % accounts.size
+                                else
+                                    if (currentIdx - 1 < 0) accounts.size - 1 else currentIdx - 1
+                                callbacks.onCycleAccount(accounts[nextIdx].id)
+                            }
+                            totalDrag = 0f
+                        }
+                    }
+                )
+            }
+        }
+    ) {
+        if (accounts.size > 1) {
+            StackedAvatars(userProfile, accounts)
+        }
+        Box(modifier = Modifier.border(3.dp, MaterialTheme.colorScheme.background, CircleShape)) {
+            AvatarCircle(
+                photoUrl = userProfile.photoUrl,
+                displayName = userProfile.displayName,
+                size = 72.dp,
+                textStyle = MaterialTheme.typography.headlineSmall
+            )
+        }
+    }
+}
+
+@Composable
+private fun StackedAvatars(userProfile: UserProfile, accounts: List<UserProfile>) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy((-16).dp),
+        modifier = Modifier.offset(x = 28.dp)
+    ) {
+        accounts.filter { it.id != userProfile.id }.take(2).forEach { acc ->
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .border(2.dp, MaterialTheme.colorScheme.background, CircleShape)
+                    .clip(CircleShape)
+                    .alpha(0.45f)
+            ) {
+                AvatarCircle(acc.photoUrl, acc.displayName, 44.dp, MaterialTheme.typography.titleSmall)
+            }
         }
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
@@ -88,11 +88,13 @@ internal fun SwipeableEmailItem(
                 onLongClick = onLongClick,
                 showSnippet = appSettings.showSnippet,
                 compactMode = appSettings.compactList,
-                isSelected = isSelected,
-                isBulkMode = true,
-                onSelectToggle = onSelectToggle,
-                onRangeSelect = onRangeSelect,
-                onAvatarLongClick = onAvatarLongClick
+                selection = SelectionState(
+                    isSelected = isSelected,
+                    isBulkMode = true,
+                    onSelectToggle = onSelectToggle,
+                    onRangeSelect = onRangeSelect,
+                    onAvatarLongClick = onAvatarLongClick
+                )
             )
         } else {
         SwipeToDismissBox(
@@ -207,11 +209,13 @@ internal fun SwipeableEmailItem(
                 onLongClick = onLongClick,
                 showSnippet = appSettings.showSnippet,
                 compactMode = appSettings.compactList,
-                isSelected = isSelected,
-                isBulkMode = false,
-                onSelectToggle = onSelectToggle,
-                onRangeSelect = onRangeSelect,
-                onAvatarLongClick = onAvatarLongClick
+                selection = SelectionState(
+                    isSelected = isSelected,
+                    isBulkMode = false,
+                    onSelectToggle = onSelectToggle,
+                    onRangeSelect = onRangeSelect,
+                    onAvatarLongClick = onAvatarLongClick
+                )
             )
         }
         }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
@@ -47,35 +47,28 @@ internal fun SwipeableEmailItem(
 
     LaunchedEffect(dismissState.currentValue) {
         if (dismissState.currentValue == SwipeToDismissBoxValue.Settled) return@LaunchedEffect
-        val action = when (dismissState.currentValue) {
-            SwipeToDismissBoxValue.StartToEnd -> appSettings.swipeRightAction
-            SwipeToDismissBoxValue.EndToStart -> appSettings.swipeLeftAction
-            else -> return@LaunchedEffect
-        }
+        val action = resolveSwipeAction(dismissState, appSettings) ?: return@LaunchedEffect
         when (action) {
             com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE -> {
                 if (tabForSwipe == InboxTab.ARCHIVED) viewModel.unarchiveThread(thread.threadId)
                 else if (tabForSwipe == InboxTab.SPAM) viewModel.reportNotSpam(thread.threadId)
                 else viewModel.archiveThread(thread.threadId)
-                scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
             }
             com.shrivatsav.monomail.data.settings.SwipeAction.STAR -> {
                 optIsStarred = !optIsStarred
                 viewModel.toggleStar(thread.threadId)
-                scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
             }
             com.shrivatsav.monomail.data.settings.SwipeAction.DELETE -> {
                 callbacks.onThreadToDeleteChange(thread.threadId)
-                scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
             }
             com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD -> {
                 val wasRead = optIsRead
                 optIsRead = !wasRead
                 if (wasRead) viewModel.markThreadAsUnread(thread.threadId)
                 else viewModel.markThreadAsRead(thread.threadId)
-                scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
             }
         }
+        scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
     }
 
     Column(
@@ -102,105 +95,7 @@ internal fun SwipeableEmailItem(
             enableDismissFromEndToStart = true,
             enableDismissFromStartToEnd = true,
             backgroundContent = {
-                val getAction = { v: SwipeToDismissBoxValue ->
-                    when (v) {
-                        SwipeToDismissBoxValue.StartToEnd -> appSettings.swipeRightAction
-                        SwipeToDismissBoxValue.EndToStart -> appSettings.swipeLeftAction
-                        else -> null
-                    }
-                }
-                val action =
-                    getAction(dismissState.targetValue) ?: getAction(dismissState.dismissDirection)
-                val color by animateColorAsState(
-                    when (action) {
-                        com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE -> MaterialTheme.colorScheme.primaryContainer
-                        com.shrivatsav.monomail.data.settings.SwipeAction.STAR -> MaterialTheme.colorScheme.tertiaryContainer
-                        com.shrivatsav.monomail.data.settings.SwipeAction.DELETE -> MaterialTheme.colorScheme.errorContainer
-                        com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD -> MaterialTheme.colorScheme.secondaryContainer
-                        else -> Color.Transparent
-                    },
-                    animationSpec = tween(200),
-                    label = "swipeBg"
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(color)
-                        .padding(horizontal = 20.dp),
-                    contentAlignment = if (
-                        dismissState.targetValue == SwipeToDismissBoxValue.StartToEnd ||
-                        dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
-                    ) Alignment.CenterStart else Alignment.CenterEnd
-                ) {
-                    when (action) {
-                        com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE ->
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Icon(
-                                    if (tabForSwipe == InboxTab.ARCHIVED) Icons.Rounded.Inbox else if (tabForSwipe == InboxTab.SPAM) Icons.Rounded.Restore else Icons.Rounded.Archive,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                                Spacer(Modifier.height(4.dp))
-                                Text(
-                                    text = when (tabForSwipe) {
-                                        InboxTab.ARCHIVED -> "Inbox"
-                                        InboxTab.SPAM -> "Restore"
-                                        else -> "Archive"
-                                    },
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Medium,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            }
-                        com.shrivatsav.monomail.data.settings.SwipeAction.STAR ->
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Icon(
-                                    if (optIsStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onTertiaryContainer
-                                )
-                                Spacer(Modifier.height(4.dp))
-                                Text(
-                                    text = if (optIsStarred) "Unstar" else "Star",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Medium,
-                                    color = MaterialTheme.colorScheme.onTertiaryContainer
-                                )
-                            }
-                        com.shrivatsav.monomail.data.settings.SwipeAction.DELETE ->
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Icon(
-                                    Icons.Rounded.Delete,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onErrorContainer
-                                )
-                                Spacer(Modifier.height(4.dp))
-                                Text(
-                                    text = "Delete",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Medium,
-                                    color = MaterialTheme.colorScheme.onErrorContainer
-                                )
-                            }
-                        com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD ->
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Icon(
-                                    if (optIsRead) Icons.Rounded.MarkEmailRead else Icons.Rounded.MarkEmailUnread,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSecondaryContainer
-                                )
-                                Spacer(Modifier.height(4.dp))
-                                Text(
-                                    text = if (optIsRead) "Mark\nUnread" else "Mark\nRead",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Medium,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
-                                )
-                            }
-                        else -> {}
-                    }
-                }
+                SwipeBackground(dismissState, appSettings, tabForSwipe, optIsStarred, optIsRead)
             }
         ) {
             EmailItem(
@@ -225,6 +120,127 @@ internal fun SwipeableEmailItem(
                 thickness = 0.5.dp,
                 modifier = Modifier.padding(horizontal = 20.dp)
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+private fun resolveSwipeAction(
+    state: SwipeToDismissBoxState,
+    appSettings: com.shrivatsav.monomail.data.settings.AppSettings
+): com.shrivatsav.monomail.data.settings.SwipeAction? {
+    return when (state.currentValue) {
+        SwipeToDismissBoxValue.StartToEnd -> appSettings.swipeRightAction
+        SwipeToDismissBoxValue.EndToStart -> appSettings.swipeLeftAction
+        else -> null
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SwipeBackground(
+    dismissState: SwipeToDismissBoxState,
+    appSettings: com.shrivatsav.monomail.data.settings.AppSettings,
+    tabForSwipe: InboxTab,
+    optIsStarred: Boolean,
+    optIsRead: Boolean
+) {
+    val getAction = { v: SwipeToDismissBoxValue ->
+        when (v) {
+            SwipeToDismissBoxValue.StartToEnd -> appSettings.swipeRightAction
+            SwipeToDismissBoxValue.EndToStart -> appSettings.swipeLeftAction
+            else -> null
+        }
+    }
+    val action = getAction(dismissState.targetValue) ?: getAction(dismissState.dismissDirection)
+    val color by animateColorAsState(
+        when (action) {
+            com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE -> MaterialTheme.colorScheme.primaryContainer
+            com.shrivatsav.monomail.data.settings.SwipeAction.STAR -> MaterialTheme.colorScheme.tertiaryContainer
+            com.shrivatsav.monomail.data.settings.SwipeAction.DELETE -> MaterialTheme.colorScheme.errorContainer
+            com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD -> MaterialTheme.colorScheme.secondaryContainer
+            else -> Color.Transparent
+        },
+        animationSpec = tween(200),
+        label = "swipeBg"
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color)
+            .padding(horizontal = 20.dp),
+        contentAlignment = if (
+            dismissState.targetValue == SwipeToDismissBoxValue.StartToEnd ||
+            dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
+        ) Alignment.CenterStart else Alignment.CenterEnd
+    ) {
+        when (action) {
+            com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE ->
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        if (tabForSwipe == InboxTab.ARCHIVED) Icons.Rounded.Inbox else if (tabForSwipe == InboxTab.SPAM) Icons.Rounded.Restore else Icons.Rounded.Archive,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = when (tabForSwipe) {
+                            InboxTab.ARCHIVED -> "Inbox"
+                            InboxTab.SPAM -> "Restore"
+                            else -> "Archive"
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            com.shrivatsav.monomail.data.settings.SwipeAction.STAR ->
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        if (optIsStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = if (optIsStarred) "Unstar" else "Star",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                    )
+                }
+            com.shrivatsav.monomail.data.settings.SwipeAction.DELETE ->
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        Icons.Rounded.Delete,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "Delete",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+            com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD ->
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        if (optIsRead) Icons.Rounded.MarkEmailRead else Icons.Rounded.MarkEmailUnread,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = if (optIsRead) "Mark\nUnread" else "Mark\nRead",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                    )
+                }
+            else -> {}
         }
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.shrivatsav.monomail.data.model.EmailThread
 import kotlinx.coroutines.launch
@@ -154,13 +155,7 @@ private fun SwipeBackground(
     }
     val action = getAction(dismissState.targetValue) ?: getAction(dismissState.dismissDirection)
     val color by animateColorAsState(
-        when (action) {
-            com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE -> MaterialTheme.colorScheme.primaryContainer
-            com.shrivatsav.monomail.data.settings.SwipeAction.STAR -> MaterialTheme.colorScheme.tertiaryContainer
-            com.shrivatsav.monomail.data.settings.SwipeAction.DELETE -> MaterialTheme.colorScheme.errorContainer
-            com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD -> MaterialTheme.colorScheme.secondaryContainer
-            else -> Color.Transparent
-        },
+        swipeActionColor(action),
         animationSpec = tween(200),
         label = "swipeBg"
     )
@@ -174,73 +169,69 @@ private fun SwipeBackground(
             dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
         ) Alignment.CenterStart else Alignment.CenterEnd
     ) {
-        when (action) {
-            com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE ->
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        if (tabForSwipe == InboxTab.ARCHIVED) Icons.Rounded.Inbox else if (tabForSwipe == InboxTab.SPAM) Icons.Rounded.Restore else Icons.Rounded.Archive,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = when (tabForSwipe) {
-                            InboxTab.ARCHIVED -> "Inbox"
-                            InboxTab.SPAM -> "Restore"
-                            else -> "Archive"
-                        },
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-            com.shrivatsav.monomail.data.settings.SwipeAction.STAR ->
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        if (optIsStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onTertiaryContainer
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = if (optIsStarred) "Unstar" else "Star",
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onTertiaryContainer
-                    )
-                }
-            com.shrivatsav.monomail.data.settings.SwipeAction.DELETE ->
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        Icons.Rounded.Delete,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = "Delete",
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                }
-            com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD ->
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        if (optIsRead) Icons.Rounded.MarkEmailRead else Icons.Rounded.MarkEmailUnread,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = if (optIsRead) "Mark\nUnread" else "Mark\nRead",
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        textAlign = androidx.compose.ui.text.style.TextAlign.Center
-                    )
-                }
-            else -> {}
-        }
+        SwipeActionLabel(action, tabForSwipe, optIsStarred, optIsRead)
     }
+}
+
+@Composable
+private fun SwipeActionLabel(
+    action: com.shrivatsav.monomail.data.settings.SwipeAction?,
+    tabForSwipe: InboxTab,
+    optIsStarred: Boolean,
+    optIsRead: Boolean
+) {
+    val (icon, label, tint) = swipeActionVisuals(action, tabForSwipe, optIsStarred, optIsRead) ?: return
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Icon(icon, contentDescription = null, tint = tint)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium,
+            color = tint,
+            textAlign = if (action == com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD) TextAlign.Center else TextAlign.Unspecified
+        )
+    }
+}
+
+@Composable
+private fun swipeActionColor(action: com.shrivatsav.monomail.data.settings.SwipeAction?) =
+    when (action) {
+        com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE -> MaterialTheme.colorScheme.primaryContainer
+        com.shrivatsav.monomail.data.settings.SwipeAction.STAR -> MaterialTheme.colorScheme.tertiaryContainer
+        com.shrivatsav.monomail.data.settings.SwipeAction.DELETE -> MaterialTheme.colorScheme.errorContainer
+        com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD -> MaterialTheme.colorScheme.secondaryContainer
+        else -> Color.Transparent
+    }
+
+private data class SwipeVisuals(val icon: androidx.compose.ui.graphics.vector.ImageVector, val label: String, val tint: Color)
+
+@Composable
+private fun swipeActionVisuals(
+    action: com.shrivatsav.monomail.data.settings.SwipeAction?,
+    tabForSwipe: InboxTab,
+    optIsStarred: Boolean,
+    optIsRead: Boolean
+): SwipeVisuals? = when (action) {
+    com.shrivatsav.monomail.data.settings.SwipeAction.ARCHIVE -> SwipeVisuals(
+        icon = when (tabForSwipe) { InboxTab.ARCHIVED -> Icons.Rounded.Inbox; InboxTab.SPAM -> Icons.Rounded.Restore; else -> Icons.Rounded.Archive },
+        label = when (tabForSwipe) { InboxTab.ARCHIVED -> "Inbox"; InboxTab.SPAM -> "Restore"; else -> "Archive" },
+        tint = MaterialTheme.colorScheme.onPrimaryContainer
+    )
+    com.shrivatsav.monomail.data.settings.SwipeAction.STAR -> SwipeVisuals(
+        icon = if (optIsStarred) Icons.Rounded.Star else Icons.Rounded.StarBorder,
+        label = if (optIsStarred) "Unstar" else "Star",
+        tint = MaterialTheme.colorScheme.onTertiaryContainer
+    )
+    com.shrivatsav.monomail.data.settings.SwipeAction.DELETE -> SwipeVisuals(
+        icon = Icons.Rounded.Delete,
+        label = "Delete",
+        tint = MaterialTheme.colorScheme.onErrorContainer
+    )
+    com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD -> SwipeVisuals(
+        icon = if (optIsRead) Icons.Rounded.MarkEmailRead else Icons.Rounded.MarkEmailUnread,
+        label = if (optIsRead) "Mark\nUnread" else "Mark\nRead",
+        tint = MaterialTheme.colorScheme.onSecondaryContainer
+    )
+    else -> null
 }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/SwipeableEmailItem.kt
@@ -17,6 +17,13 @@ import androidx.compose.ui.unit.dp
 import com.shrivatsav.monomail.data.model.EmailThread
 import kotlinx.coroutines.launch
 
+data class SwipeCallbacks(
+    val onThreadToDeleteChange: (String?) -> Unit,
+    val onEmailClick: () -> Unit,
+    val onLongClick: () -> Unit,
+    val isNested: Boolean = false
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SwipeableEmailItem(
@@ -25,15 +32,8 @@ internal fun SwipeableEmailItem(
     tabForSwipe: InboxTab,
     appSettings: com.shrivatsav.monomail.data.settings.AppSettings,
     viewModel: InboxViewModel,
-    onThreadToDeleteChange: (String?) -> Unit,
-    onEmailClick: () -> Unit,
-    onLongClick: () -> Unit,
-    isNested: Boolean = false,
-    isSelected: Boolean = false,
-    isBulkMode: Boolean = false,
-    onSelectToggle: () -> Unit = {},
-    onRangeSelect: () -> Unit = {},
-    onAvatarLongClick: () -> Unit = {}
+    callbacks: SwipeCallbacks,
+    selection: SelectionState = SelectionState()
 ) {
     var optIsRead by remember(thread.isRead) { mutableStateOf(thread.isRead) }
     var optIsStarred by remember(thread.isStarred) { mutableStateOf(thread.isStarred) }
@@ -65,7 +65,7 @@ internal fun SwipeableEmailItem(
                 scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
             }
             com.shrivatsav.monomail.data.settings.SwipeAction.DELETE -> {
-                onThreadToDeleteChange(thread.threadId)
+                callbacks.onThreadToDeleteChange(thread.threadId)
                 scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
             }
             com.shrivatsav.monomail.data.settings.SwipeAction.READ_UNREAD -> {
@@ -79,21 +79,21 @@ internal fun SwipeableEmailItem(
     }
 
     Column(
-        modifier = modifier.let { if (isNested) it.padding(start = 32.dp) else it }
+        modifier = modifier.let { if (callbacks.isNested) it.padding(start = 32.dp) else it }
     ) {
-        if (isBulkMode) {
+        if (selection.isBulkMode) {
             EmailItem(
                 thread = displayThread,
-                onClick = onEmailClick,
-                onLongClick = onLongClick,
+                onClick = callbacks.onEmailClick,
+                onLongClick = callbacks.onLongClick,
                 showSnippet = appSettings.showSnippet,
                 compactMode = appSettings.compactList,
                 selection = SelectionState(
-                    isSelected = isSelected,
+                    isSelected = selection.isSelected,
                     isBulkMode = true,
-                    onSelectToggle = onSelectToggle,
-                    onRangeSelect = onRangeSelect,
-                    onAvatarLongClick = onAvatarLongClick
+                    onSelectToggle = selection.onSelectToggle,
+                    onRangeSelect = selection.onRangeSelect,
+                    onAvatarLongClick = selection.onAvatarLongClick
                 )
             )
         } else {
@@ -205,16 +205,16 @@ internal fun SwipeableEmailItem(
         ) {
             EmailItem(
                 thread = displayThread,
-                onClick = onEmailClick,
-                onLongClick = onLongClick,
+                onClick = callbacks.onEmailClick,
+                onLongClick = callbacks.onLongClick,
                 showSnippet = appSettings.showSnippet,
                 compactMode = appSettings.compactList,
                 selection = SelectionState(
-                    isSelected = isSelected,
+                    isSelected = selection.isSelected,
                     isBulkMode = false,
-                    onSelectToggle = onSelectToggle,
-                    onRangeSelect = onRangeSelect,
-                    onAvatarLongClick = onAvatarLongClick
+                    onSelectToggle = selection.onSelectToggle,
+                    onRangeSelect = selection.onRangeSelect,
+                    onAvatarLongClick = selection.onAvatarLongClick
                 )
             )
         }

--- a/app/src/main/java/com/shrivatsav/monomail/worker/EmailSyncWorker.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/worker/EmailSyncWorker.kt
@@ -157,13 +157,15 @@ class EmailSyncWorker @AssistedInject constructor(
 
         val replyPendingIntent = NotificationActionReceiver.createReplyPendingIntent(
             context = context,
-            accountId = accountId,
-            threadId = thread.threadId,
-            messageId = thread.latestMessageId,
-            subject = thread.subject,
-            fromEmail = thread.fromEmail,
-            fromName = thread.from,
-            notificationId = notificationId
+            params = NotificationActionReceiver.ReplyParams(
+                accountId = accountId,
+                threadId = thread.threadId,
+                messageId = thread.latestMessageId,
+                subject = thread.subject,
+                fromEmail = thread.fromEmail,
+                fromName = thread.from,
+                notificationId = notificationId
+            )
         )
         val replyRemoteInput = RemoteInput.Builder(NotificationActionReceiver.KEY_TEXT_REPLY)
             .setLabel("Reply")

--- a/app/src/main/java/com/shrivatsav/monomail/worker/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/worker/NotificationActionReceiver.kt
@@ -48,23 +48,19 @@ class NotificationActionReceiver : BroadcastReceiver() {
         const val SNOOZE_REQUEST_CODE_BASE = 40000
         const val UNDO_SNOOZE_REQUEST_CODE_BASE = 50000
 
-        fun createReplyPendingIntent(
-            context: Context, accountId: String, threadId: String,
-            messageId: String, subject: String, fromEmail: String,
-            fromName: String, notificationId: Int
-        ): PendingIntent {
+        fun createReplyPendingIntent(context: Context, params: ReplyParams): PendingIntent {
             val intent = Intent(context, NotificationActionReceiver::class.java).apply {
                 action = ACTION_REPLY
-                putExtra(EXTRA_ACCOUNT_ID, accountId)
-                putExtra(EXTRA_THREAD_ID, threadId)
-                putExtra(EXTRA_MESSAGE_ID, messageId)
-                putExtra(EXTRA_SUBJECT, subject)
-                putExtra(EXTRA_FROM_EMAIL, fromEmail)
-                putExtra(EXTRA_FROM_NAME, fromName)
-                putExtra(EXTRA_NOTIFICATION_ID, notificationId)
+                putExtra(EXTRA_ACCOUNT_ID, params.accountId)
+                putExtra(EXTRA_THREAD_ID, params.threadId)
+                putExtra(EXTRA_MESSAGE_ID, params.messageId)
+                putExtra(EXTRA_SUBJECT, params.subject)
+                putExtra(EXTRA_FROM_EMAIL, params.fromEmail)
+                putExtra(EXTRA_FROM_NAME, params.fromName)
+                putExtra(EXTRA_NOTIFICATION_ID, params.notificationId)
             }
             return PendingIntent.getBroadcast(
-                context, REPLY_REQUEST_CODE_BASE + notificationId, intent,
+                context, REPLY_REQUEST_CODE_BASE + params.notificationId, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
             )
         }
@@ -106,6 +102,16 @@ class NotificationActionReceiver : BroadcastReceiver() {
             fun emailRepository(): EmailRepository
         }
     }
+
+    data class ReplyParams(
+        val accountId: String,
+        val threadId: String,
+        val messageId: String,
+        val subject: String,
+        val fromEmail: String,
+        val fromName: String,
+        val notificationId: Int
+    )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 


### PR DESCRIPTION
## Summary
- Refactors inbox, compose, detail, onboarding, and IMAP setup screens to extract reusable state holders and composables.
- Bundles callback and selection parameters into small data classes to reduce long parameter lists in inbox and email item flows.
- Cleans up navigation transitions, dead code, empty branches, and other SonarQube-flagged patterns across the app.
- Simplifies message building and notification handling in the IMAP provider, Outlook provider, and background worker paths.

## Testing
- Not run
- Recommended check: build the app and verify inbox, compose, detail, onboarding, and IMAP setup screens render correctly.
- Recommended check: sign in, open a thread, compose a message, and confirm navigation transitions still work.
- Recommended check: send/reply flows and email sync behavior still function with IMAP and Outlook accounts.