### PR TITLE
Refactor mail screens and fix dock tab layout

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/BottomDockBar.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/BottomDockBar.kt
@@ -37,7 +37,10 @@ internal fun BottomDockBar(
     val primaryIds = dockConfig.primaryTabs
     val remainingIds = allTabs.filter { it !in primaryIds }
 
-    Box(contentAlignment = Alignment.TopCenter) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.wrapContentSize()
+    ) {
         RemainingTabsPopup(
             visible = showRemainingTabs,
             remainingIds = remainingIds,

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/BottomDockBar.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/BottomDockBar.kt
@@ -37,10 +37,7 @@ internal fun BottomDockBar(
     val primaryIds = dockConfig.primaryTabs
     val remainingIds = allTabs.filter { it !in primaryIds }
 
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.wrapContentSize()
-    ) {
+    Box(contentAlignment = Alignment.TopCenter) {
         RemainingTabsPopup(
             visible = showRemainingTabs,
             remainingIds = remainingIds,
@@ -52,19 +49,24 @@ internal fun BottomDockBar(
                 showRemainingTabs = false
             }
         )
-        PrimaryDockRow(
-            currentTab = currentTab,
-            primaryIds = primaryIds,
-            unifiedInboxEnabled = unifiedInboxEnabled,
-            appSettings = appSettings,
-            onTabClick = onTabClick
-        )
-        if (remainingIds.isNotEmpty() && currentTab != InboxTab.TRASH && currentTab != InboxTab.SPAM) {
-            MoreTabsButton(
-                showRemainingTabs = showRemainingTabs,
-                navScale = appSettings.navScale,
-                onClick = { showRemainingTabs = !showRemainingTabs }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            PrimaryDockRow(
+                currentTab = currentTab,
+                primaryIds = primaryIds,
+                unifiedInboxEnabled = unifiedInboxEnabled,
+                appSettings = appSettings,
+                onTabClick = onTabClick
             )
+            if (remainingIds.isNotEmpty() && currentTab != InboxTab.TRASH && currentTab != InboxTab.SPAM) {
+                MoreTabsButton(
+                    showRemainingTabs = showRemainingTabs,
+                    navScale = appSettings.navScale,
+                    onClick = { showRemainingTabs = !showRemainingTabs }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/inbox/InboxScreen.kt
@@ -926,7 +926,7 @@ private fun BottomFabArea(
     navBarHeight: Dp,
     onEmptyBin: (isTrash: Boolean) -> Unit
 ) {
-    val tabForDock by remember { derivedStateOf { immediateTab } }
+    val tabForDock = immediateTab
     Row(
         modifier = Modifier.padding(bottom = navBarHeight + 8.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),


### PR DESCRIPTION
## Summary
- Refactored inbox, compose, detail, onboarding, and IMAP setup screens into smaller composables to reduce cognitive complexity and remove dead code.
- Cleaned up navigation transitions and bundled action/state parameters into focused data classes.
- Fixed the bottom dock tab layout and removed a stale `derivedStateOf` wrapper around the tab highlight.
- Simplified email send/build logic in IMAP and Outlook providers, plus a few worker and receiver refactors.
- Addressed additional SonarQube findings across inbox, profile, swipe, and sign-in flows.

## Testing
- Not run
- Recommended: launch the app and verify inbox, compose, detail, onboarding, and IMAP setup screens render correctly.
- Recommended: confirm bottom dock tab highlighting and the more button layout behave as expected.
- Recommended: send a test email through IMAP and Outlook paths to verify message construction still works.
- Recommended: check navigation transitions for compose, thread detail, settings, and onboarding routes.