### PR TITLE
fix: restore removed Appearance settings (dividers, compact, snippet)

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/screens/settings/AppearanceSettingsScreen.kt
@@ -48,6 +48,30 @@ internal fun AppearanceSettingsScreen(
                 currentTheme = settings.emailTheme,
                 onThemeSelected = { viewModel.setEmailTheme(it) }
             )
+            CardDivider()
+            SettingsToggleRow(
+                icon = Icons.Rounded.DataArray,
+                title = "Show Dividers",
+                subtitle = "Show horizontal lines between emails",
+                checked = settings.showDividers,
+                onCheckedChange = { viewModel.setShowDividers(it) }
+            )
+            CardDivider()
+            SettingsToggleRow(
+                icon = Icons.Rounded.ViewHeadline,
+                title = "Compact List",
+                subtitle = "Reduce email list spacing",
+                checked = settings.compactList,
+                onCheckedChange = { viewModel.setCompactList(it) }
+            )
+            CardDivider()
+            SettingsToggleRow(
+                icon = Icons.Rounded.ShortText,
+                title = "Show Snippet",
+                subtitle = "Preview email body text in the list",
+                checked = settings.showSnippet,
+                onCheckedChange = { viewModel.setShowSnippet(it) }
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
         SettingsCard {


### PR DESCRIPTION
UI overhaul removed 3 Appearance settings that were still wired in the data layer and used by the inbox UI. Restoring them:

- Show Dividers
- Compact List
- Show Snippet Preview