### PR TITLE
Minor fixes: release workflow PR context, MSAL, Discord icon, onboarding skip, FAB shift, welcome modal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,29 +210,43 @@ jobs:
       - name: Generate release notes
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           PROMPT=$(cat <<'EOF'
           Write concise, user-facing GitHub release notes.
-
+          
           Group changes under:
           - Features
           - Bug Fixes
           - Maintenance
-
+          
           Omit any empty section.
-
+          
           Use ONLY the commits below.
           Don't invent features.
           Output Markdown only.
-
-          Commits:
           EOF
           )
-
+          
+          if [ -n "$PR_TITLE" ]; then
+            PROMPT="$PROMPT
+          
+          PR Title: $PR_TITLE"
+            if [ -n "$PR_BODY" ]; then
+              PROMPT="$PROMPT
+          
+          PR Description:
+          $PR_BODY"
+            fi
+          fi
+          
           PROMPT="$PROMPT
-
+          
+          Commits:
+          
           $(cat commit_log.txt)"
-
+          
           opencode run "$PROMPT" \
             --model opencode/mimo-v2.5-free \
             --print-logs \

--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -1,4 +1,5 @@
 package com.shrivatsav.monomail.ui.navigation
+import com.shrivatsav.monomail.BuildConfig
 import android.net.Uri
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
@@ -228,6 +229,7 @@ fun NavGraph(
     }
     val startDestination = when {
         isAuthenticated -> Screen.Inbox.route
+        BuildConfig.DEBUG -> Screen.SignIn.route
         !hasSeenWelcomePrompt -> Screen.Onboarding.route
         else -> Screen.SignIn.route
     }

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/ui/screens/auth/OnboardingScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/ui/screens/auth/OnboardingScreen.kt
@@ -62,9 +62,6 @@ private fun SupportPage(uriHandler: androidx.compose.ui.platform.UriHandler, con
                 if (kofiIcon != null) Icon(painter = kofiIcon, contentDescription = null, modifier = Modifier.size(22.dp), tint = Color.Unspecified)
                 else Icon(Icons.Rounded.FavoriteBorder, contentDescription = null, modifier = Modifier.size(22.dp))
             }
-            OnboardingSupportCard(modifier = Modifier.weight(1f), label = "Pay with UPI", onClick = { uriHandler.openUri("upi://pay?pa=shrivatsav@slc&pn=Sharan%20Shrivatsav&mode=02") }) {
-                Icon(Icons.Rounded.Payments, contentDescription = null, modifier = Modifier.size(22.dp))
-            }
         }
         Spacer(modifier = Modifier.height(10.dp))
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/ui/screens/auth/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/ui/screens/auth/SignInScreen.kt
@@ -391,11 +391,9 @@ fun ProviderSelectionDialog(
                     viewModel.signIn(context)
                 },
                 onMicrosoftSignIn = {
-                    if (com.shrivatsav.monomail.feature.auth.BuildConfig.DEBUG) {
-                        context.findActivity()?.let { activity ->
-                            viewModel.signInMicrosoft(activity)
-                        } ?: Toast.makeText(context, "Activity not found", Toast.LENGTH_SHORT).show()
-                    }
+                    context.findActivity()?.let { activity ->
+                        viewModel.signInMicrosoft(activity)
+                    } ?: Toast.makeText(context, "Activity not found", Toast.LENGTH_SHORT).show()
                 },
                 onImapClick = onNavigateToImapSetup
             )

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/BottomDockBar.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/BottomDockBar.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import com.shrivatsav.monomail.data.settings.DockConfig
 import com.shrivatsav.monomail.data.settings.DockTabId
 import com.shrivatsav.monomail.data.settings.AppSettings
@@ -39,23 +41,49 @@ internal fun BottomDockBar(
     val allTabs = DockTabId.entries.filter { it != DockTabId.UNIFIED }
     val primaryIds = dockConfig.primaryTabs
     val remainingIds = allTabs.filter { it !in primaryIds }
+    var dockRowHeightPx by remember { mutableStateOf(0f) }
+    val density = LocalDensity.current
 
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Box(
         modifier = Modifier.wrapContentSize()
     ) {
-        RemainingTabsPopup(
-            visible = showRemainingTabs,
-            remainingIds = remainingIds,
-            currentTab = currentTab,
-            unifiedInboxEnabled = unifiedInboxEnabled,
-            navScale = appSettings.navScale,
-            onTabClick = { tab ->
-                onTabClick(tab)
-                showRemainingTabs = false
+        AnimatedVisibility(
+            visible = showRemainingTabs && remainingIds.isNotEmpty(),
+            enter = expandVertically(expandFrom = Alignment.Bottom) + fadeIn(MonoTween.fadeIn),
+            exit = shrinkVertically(shrinkTowards = Alignment.Bottom) + fadeOut(MonoTween.fadeOut),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = (dockRowHeightPx / density.density).dp + 8.dp)
+        ) {
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                shadowElevation = 8.dp,
+            ) {
+                Row(modifier = Modifier.padding(4.dp)) {
+                    remainingIds.forEach { dockTabId ->
+                        val tab = dockTabId.toInboxTab()
+                        RemainingTabItem(
+                            icon = dockTabId.icon(unifiedInboxEnabled),
+                            label = dockTabId.label(unifiedInboxEnabled),
+                            isActive = tab == currentTab,
+                            onClick = {
+                                onTabClick(tab)
+                                showRemainingTabs = false
+                            },
+                            scale = appSettings.navScale,
+                            modifier = Modifier.width((76 * appSettings.navScale).dp)
+                        )
+                    }
+                }
             }
-        )
+        }
         Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .onGloballyPositioned { coordinates ->
+                    dockRowHeightPx = coordinates.size.height.toFloat()
+                },
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -77,42 +105,6 @@ internal fun BottomDockBar(
     }
 }
 
-@Composable
-private fun RemainingTabsPopup(
-    visible: Boolean,
-    remainingIds: List<DockTabId>,
-    currentTab: InboxTab,
-    unifiedInboxEnabled: Boolean,
-    navScale: Float,
-    onTabClick: (InboxTab) -> Unit,
-) {
-    AnimatedVisibility(
-        visible = visible,
-        enter = expandVertically(expandFrom = Alignment.Top) + fadeIn(MonoTween.fadeIn),
-        exit = shrinkVertically(shrinkTowards = Alignment.Top) + fadeOut(MonoTween.fadeOut)
-    ) {
-        Surface(
-            shape = RoundedCornerShape(20.dp),
-            color = MaterialTheme.colorScheme.surfaceContainer,
-            shadowElevation = 8.dp,
-            modifier = Modifier.padding(bottom = 8.dp)
-        ) {
-            Row(modifier = Modifier.padding(4.dp)) { // intentional: horizontal layout fits dock bar orientation
-                remainingIds.forEach { dockTabId ->
-                    val tab = dockTabId.toInboxTab()
-                    RemainingTabItem(
-                        icon = dockTabId.icon(unifiedInboxEnabled),
-                        label = dockTabId.label(unifiedInboxEnabled),
-                        isActive = tab == currentTab,
-                        onClick = { onTabClick(tab) },
-                        scale = navScale,
-                        modifier = Modifier.width((76 * navScale).dp)
-                    )
-                }
-            }
-        }
-    }
-}
 
 @Composable
 private fun PrimaryDockRow(

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.draw.*
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.addPathNodes
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 
 import android.net.ConnectivityManager
@@ -638,7 +639,8 @@ fun InboxScreen(
         }
     }
 
-    
+    // ── Welcome to Monomail modal ────────────────────────────────────
+
     com.shrivatsav.monomail.ui.components.BlurredModalOverlay(
         visible = showWelcomePrompt,
         onDismiss = { viewModel.dismissWelcomePrompt() }
@@ -661,25 +663,90 @@ fun InboxScreen(
                 else null
             }
 
-            Column(modifier = Modifier.padding(24.dp)) {
+            val versionName = remember {
+                try {
+                    context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "1.7.24"
+                } catch (_: Exception) { "1.7.24" }
+            }
 
-                // Header
+            val matchedNotes = remember(versionName) {
+                allReleaseNotes.firstOrNull { it.version == versionName }
+            }
+
+            Column(modifier = Modifier.padding(26.dp)) {
+
+                // ── Header ──────────────────────────────────────────────
                 Text(
                     text = "Welcome to Monomail",
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(Modifier.height(4.dp))
                 Text(
-                    text = "Monomail is free & open-source, built with privacy in mind. If you find it useful, here's how you can help.",
+                    text = "v$versionName — An open-source, privacy-first email client",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(Modifier.height(24.dp))
 
-                // Primary 2x2 support grid — card style, icon-on-top
+                // ── What's New ─────────────────────────────────────────
+                Surface(
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.Rounded.NewReleases,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                "What's New",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                        Spacer(Modifier.height(12.dp))
+                        val notes = matchedNotes ?: allReleaseNotes.first()
+                        notes.changes.forEach { change ->
+                            Row(
+                                modifier = Modifier.padding(vertical = 2.dp),
+                                verticalAlignment = Alignment.Top
+                            ) {
+                                Text(
+                                    "•",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(end = 8.dp)
+                                )
+                                Text(
+                                    change,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(20.dp))
+
+                // ── Support ────────────────────────────────────────────
+                Text(
+                    "Support Monomail",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(10.dp))
+
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
@@ -702,42 +769,47 @@ fun InboxScreen(
                     }
                     SupportCard(
                         modifier = Modifier.weight(1f),
-                        label = "Pay with UPI",
-                        onClick = { uriHandler.openUri("upi://pay?pa=shrivatsav@slc&pn=Sharan%20Shrivatsav&mode=02") }
-                    ) {
-                        Icon(Icons.Rounded.Payments, contentDescription = null, modifier = Modifier.size(22.dp))
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    SupportCard(
-                        modifier = Modifier.weight(1f),
                         label = "Star on GitHub",
                         onClick = { uriHandler.openUri("https://github.com/shrivatsav-0/monomail") }
                     ) {
                         Icon(Icons.Rounded.Star, contentDescription = null, modifier = Modifier.size(22.dp))
                     }
-                    SupportCard(
-                        modifier = Modifier.weight(1f),
-                        label = "Join Discord",
-                        onClick = { uriHandler.openUri("https://discord.gg/tZgpycdm") }
-                    ) {
-                        Icon(Icons.Rounded.HeadsetMic, contentDescription = null, modifier = Modifier.size(22.dp))
-                    }
+                }
+                Spacer(Modifier.height(10.dp))
+
+                SupportCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = "Join Discord",
+                    onClick = { uriHandler.openUri("https://discord.gg/tZgpycdm") }
+                ) {
+                    Icon(
+                        imageVector = remember {
+                            ImageVector.Builder(
+                                name = "Discord",
+                            defaultWidth = 22.dp,
+                            defaultHeight = 22.dp,
+                            viewportWidth = 24f,
+                            viewportHeight = 24f
+                        ).addPath(
+                            fill = SolidColor(Color.Black),
+                            pathData = addPathNodes(
+                                "M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"
+                            )
+                        ).build()
+                    },
+                        contentDescription = null,
+                        modifier = Modifier.size(22.dp),
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
                 }
 
-                Spacer(modifier = Modifier.height(20.dp))
+                Spacer(Modifier.height(18.dp))
 
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
 
-                Spacer(modifier = Modifier.height(14.dp))
+                Spacer(Modifier.height(12.dp))
 
-                // Secondary actions — icon-only row, tooltip-style
+                // ── Secondary actions ──────────────────────────────────
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly
@@ -772,14 +844,21 @@ fun InboxScreen(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(20.dp))
+                Spacer(Modifier.height(18.dp))
 
+                // ── Get Started ────────────────────────────────────────
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End
                 ) {
-                    TextButton(onClick = { viewModel.dismissWelcomePrompt() }) {
-                        Text("Get Started")
+                    FilledTonalButton(
+                        onClick = { viewModel.dismissWelcomePrompt() },
+                        shape = RoundedCornerShape(16.dp)
+                    ) {
+                        Text(
+                            "Get Started",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+                        )
                     }
                 }
             }
@@ -1547,3 +1626,26 @@ private fun OfflineBanner() {
         )
     }
 }
+
+// ── Release notes data ──────────────────────────────────────────────────
+
+private data class ReleaseNotes(
+    val version: String,
+    val changes: List<String>
+)
+
+private val allReleaseNotes = listOf(
+    ReleaseNotes(version = "1.7.24", changes = listOf(
+        "Optimized build times with configuration caching",
+        "Fixed MSAL sign-in for release builds",
+        "Enhanced FAB positioning in dock bar",
+        "Improved Discord icon theming",
+        "Various UI polish and bug fixes"
+    )),
+    ReleaseNotes(version = "1.7.23", changes = listOf(
+        "Redesigned bottom dock bar with custom layout options",
+        "Added template-backed scheduled send",
+        "Improved swipe gesture responsiveness",
+        "Enhanced tablet layout support"
+    ))
+)

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -26,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.shrivatsav.monomail.ui.theme.MonoSpring
 import com.shrivatsav.monomail.ui.theme.MonoTween
+import androidx.compose.ui.platform.LocalContext
 
 enum class SettingsSection(val icon: ImageVector, val title: String, val subtitle: String) {
     ACCOUNTS(Icons.Rounded.ManageAccounts, "Accounts", "Manage accounts, providers, connection status"),
@@ -221,6 +223,7 @@ internal fun DeveloperSettingsScreen(
     onBack: () -> Unit
 ) {
     val settings by viewModel.settings.collectAsState()
+    val context = LocalContext.current
     ScrollableSettingsScaffold(
         title = "Developer",
         onBack = onBack
@@ -233,6 +236,52 @@ internal fun DeveloperSettingsScreen(
                 checked = settings.isDeveloperMode,
                 onCheckedChange = { viewModel.setDeveloperMode(it) }
             )
+        }
+        Spacer(Modifier.height(8.dp))
+        SettingsCard {
+            // Preview Welcome button
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = {
+                        viewModel.resetWelcomePrompt()
+                        android.widget.Toast.makeText(
+                            context,
+                            "Welcome prompt will show on next app launch",
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                    })
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Preview,
+                    contentDescription = "Preview Welcome",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(14.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Preview Welcome",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        "Reset welcome prompt and show modal on next app launch",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Rounded.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                    modifier = Modifier.size(18.dp)
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
@@ -56,6 +56,9 @@ class SettingsViewModel @Inject constructor(
     fun setDeveloperMode(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setDeveloperMode(enabled) }
     fun setShowInlineAttachments(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowInlineAttachments(enabled) }
     fun setShowMarkAllRead(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowMarkAllRead(enabled) }
+    fun resetWelcomePrompt() = viewModelScope.launch {
+        settingsDataStore.setHasSeenWelcomePrompt(false)
+    }
     val templates = settingsDataStore.templatesFlow
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
     fun saveTemplates(templates: List<EmailTemplate>) = viewModelScope.launch {

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SupportSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SupportSettingsScreen.kt
@@ -62,7 +62,7 @@ internal fun SupportSettingsScreen(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                         )
                     ) {
-                        Icon(painter = discordIcon, contentDescription = "Discord", tint = Color.Unspecified)
+                        Icon(painter = discordIcon, contentDescription = "Discord", tint = MaterialTheme.colorScheme.onSurface)
                     }
                     IconButton(
                         onClick = {


### PR DESCRIPTION
## Changes

- **Release workflow**: PR title and description are now included in the AI release notes prompt
- **MSAL sign-in**: Removed `BuildConfig.DEBUG` guard — add account now works in release builds
- **Discord icon**: Replaces generic `HeadsetMic` with actual Discord logo, uses `onSurface` tint
- **Onboarding**: Debug builds skip pre-sign-in onboarding
- **FAB shift**: Bottom dock bar popup no longer shifts the compose FAB right
- **Welcome modal**: Redesigned post-sign-in modal with "What's New" section, MD3 design, release notes
- **Settings**: Preview Welcome button in developer settings resets `hasSeenWelcomePrompt`
- **UPI removed**: "Pay with UPI" removed from onboarding and welcome screens

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->