### PR TITLE
UI overhaul: SlideSheet pattern, corner style, Discord icon, dock fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,12 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".CrashActivity"
+            android:exported="false"
+            android:process=":crash"
+            android:theme="@style/Theme.MonoMail" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app/src/main/java/com/shrivatsav/monomail/CrashActivity.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/CrashActivity.kt
@@ -1,0 +1,184 @@
+package com.shrivatsav.monomail
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.shape.CircleShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
+import androidx.compose.foundation.background
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.shrivatsav.monomail.ui.theme.MonoMailTheme
+
+class CrashActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        val errorText = CrashHandler.getLastError(this) ?: "Unknown Error"
+
+        setContent {
+            MonoMailTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    CrashScreen(
+                        errorText = errorText,
+                        onCopyClicked = {
+                            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                            val clip = ClipData.newPlainText("Crash Log", errorText)
+                            clipboard.setPrimaryClip(clip)
+                            Toast.makeText(this, "Crash log copied to clipboard", Toast.LENGTH_SHORT).show()
+                        },
+                        onRestartClicked = {
+                            CrashHandler.clearError(this)
+                            val intent = Intent(this, MainActivity::class.java).apply {
+                                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                            }
+                            startActivity(intent)
+                            finish()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CrashScreen(
+    errorText: String,
+    onCopyClicked: () -> Unit,
+    onRestartClicked: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        // Background Danger Icon & Text
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 80.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(100.dp)
+                    .background(MaterialTheme.colorScheme.errorContainer, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = "Crash",
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.size(56.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "Monomail Crashed",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Whoops! The email hamsters tripped over a wire and the app went boom. Mind sending us the logs?",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+        
+        // Detached Bottom Sheet
+        Surface(
+            shape = cornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            shadowElevation = 8.dp,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .padding(16.dp)
+                .padding(bottom = androidx.compose.foundation.layout.WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Drag handle pill (purely visual)
+                Box(
+                    modifier = Modifier
+                        .width(32.dp)
+                        .height(4.dp)
+                        .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                
+                // Logs container
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    ),
+                    shape = cornerShape(12.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 200.dp)
+                ) {
+                    Text(
+                        text = errorText,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .verticalScroll(rememberScrollState())
+                    )
+                }
+                
+                Spacer(modifier = Modifier.height(24.dp))
+                
+                // Action Buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onCopyClicked,
+                        modifier = Modifier.weight(1f),
+                        shape = cornerShape(12.dp)
+                    ) {
+                        Text("Copy Log")
+                    }
+                    Button(
+                        onClick = onRestartClicked,
+                        modifier = Modifier.weight(1f),
+                        shape = cornerShape(12.dp)
+                    ) {
+                        Text("Restart App")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/shrivatsav/monomail/CrashHandler.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/CrashHandler.kt
@@ -1,0 +1,59 @@
+package com.shrivatsav.monomail
+
+import android.content.Context
+import android.content.Intent
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import kotlin.system.exitProcess
+
+class CrashHandler(
+    private val context: Context,
+    private val defaultHandler: Thread.UncaughtExceptionHandler?
+) : Thread.UncaughtExceptionHandler {
+
+    override fun uncaughtException(thread: Thread, exception: Throwable) {
+        try {
+            val sw = StringWriter()
+            val pw = PrintWriter(sw)
+            exception.printStackTrace(pw)
+            val stackTrace = sw.toString()
+
+            val crashFile = File(context.cacheDir, "last_crash.txt")
+            crashFile.writeText(stackTrace)
+
+            val intent = Intent(context, CrashActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            context.startActivity(intent)
+
+            android.os.Process.killProcess(android.os.Process.myPid())
+            exitProcess(1)
+        } catch (e: Exception) {
+            defaultHandler?.uncaughtException(thread, exception)
+        }
+    }
+
+    companion object {
+        fun install(context: Context) {
+            val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+            if (defaultHandler !is CrashHandler) {
+                Thread.setDefaultUncaughtExceptionHandler(CrashHandler(context.applicationContext, defaultHandler))
+            }
+        }
+        
+        fun getLastError(context: Context): String? {
+            val crashFile = File(context.cacheDir, "last_crash.txt")
+            return if (crashFile.exists()) {
+                crashFile.readText()
+            } else null
+        }
+        
+        fun clearError(context: Context) {
+            val crashFile = File(context.cacheDir, "last_crash.txt")
+            if (crashFile.exists()) {
+                crashFile.delete()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/shrivatsav/monomail/MainActivity.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/MainActivity.kt
@@ -51,6 +51,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+        if (CrashHandler.getLastError(this) != null) {
+            startActivity(android.content.Intent(this, CrashActivity::class.java))
+            finish()
+            return
+        }
         splashScreen.setKeepOnScreenCondition {
             // Keep splash visible until content is ready
             !isContentReady
@@ -74,7 +79,8 @@ class MainActivity : ComponentActivity() {
             ) {
                 MonoMailTheme(
                     themeMode = settings.themeMode.name,
-                    useSystemFont = settings.useSystemFont
+                    useSystemFont = settings.useSystemFont,
+                    cornerStyle = settings.cornerStyle.name
                 ) {
                     Box(modifier = Modifier.fillMaxSize()) {
                         NavGraph(

--- a/app/src/main/java/com/shrivatsav/monomail/MonoMailApp.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/MonoMailApp.kt
@@ -19,6 +19,8 @@ class MonoMailApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        CrashHandler.install(this)
+
 
         initializeMailcap()
         actionQueueManager.start()

--- a/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
@@ -51,7 +51,7 @@ object AppModule {
 
     @Provides @Singleton
     fun provideSentEmailEvents(): MutableSharedFlow<SentEmailEvent> =
-        MutableSharedFlow(replay = 1)
+        MutableSharedFlow(replay = 0, extraBufferCapacity = 1, onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST)
 
     @Provides @Singleton
     fun provideScheduledEmailEvents(): MutableSharedFlow<ScheduledEmailEvent> =

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
 enum class ThemeMode { SYSTEM, LIGHT, DARK }
+enum class CornerStyle { SQUARE, ROUNDED, EXTRA_ROUNDED }
 /**
  * Controls how email HTML bodies are colored when rendered in the detail WebView.
  * - [AUTO]: adapt plain-ish mail to the app theme; render richly-styled mail as-is.
@@ -69,7 +70,9 @@ data class AppSettings(
     val undoSendWindow: UndoSendWindow = UndoSendWindow.SEC_10,
     val dockConfig: DockConfig = DockConfig.defaults(),
     val isDeveloperMode: Boolean = false,
+    val showInlineImages: Boolean = true,
     val showInlineAttachments: Boolean = true,
+    val cornerStyle: CornerStyle = CornerStyle.ROUNDED,
     val showMarkAllRead: Boolean = true
 )
 class SettingsDataStore(private val context: Context) {
@@ -106,8 +109,9 @@ class SettingsDataStore(private val context: Context) {
         val IS_DEVELOPER_MODE = booleanPreferencesKey("is_developer_mode")
         val SHOW_INLINE_ATTACHMENTS = booleanPreferencesKey("show_inline_attachments")
         val SHOW_MARK_ALL_READ = booleanPreferencesKey("show_mark_all_read")
+        val CORNER_STYLE = stringPreferencesKey("corner_style")
+        val SHOW_INLINE_IMAGES = booleanPreferencesKey("show_inline_images")
     }
-
     private fun mapToSettings(prefs: Preferences): AppSettings {
         val dockConfigJson = prefs[Keys.DOCK_CONFIG]
         return AppSettings(
@@ -148,7 +152,9 @@ class SettingsDataStore(private val context: Context) {
                 } catch (e: Exception) { DockConfig.defaults() }
             } ?: DockConfig.defaults(),
             isDeveloperMode = prefs[Keys.IS_DEVELOPER_MODE] ?: false,
+            showInlineImages = prefs[Keys.SHOW_INLINE_IMAGES] ?: true,
             showInlineAttachments = prefs[Keys.SHOW_INLINE_ATTACHMENTS] ?: true,
+            cornerStyle = prefs[Keys.CORNER_STYLE]?.let { CornerStyle.valueOf(it) } ?: CornerStyle.ROUNDED,
             showMarkAllRead = prefs[Keys.SHOW_MARK_ALL_READ] ?: true
         )
     }
@@ -236,11 +242,17 @@ class SettingsDataStore(private val context: Context) {
     suspend fun setDeveloperMode(enabled: Boolean) {
         context.dataStore.edit { it[Keys.IS_DEVELOPER_MODE] = enabled }
     }
+    suspend fun setShowInlineImages(enabled: Boolean) {
+        context.dataStore.edit { it[Keys.SHOW_INLINE_IMAGES] = enabled }
+    }
     suspend fun setShowInlineAttachments(enabled: Boolean) {
         context.dataStore.edit { it[Keys.SHOW_INLINE_ATTACHMENTS] = enabled }
     }
     suspend fun setShowMarkAllRead(enabled: Boolean) {
         context.dataStore.edit { it[Keys.SHOW_MARK_ALL_READ] = enabled }
+    }
+    suspend fun setCornerStyle(style: CornerStyle) {
+        context.dataStore.edit { it[Keys.CORNER_STYLE] = style.name }
     }
     suspend fun getTemplates(): List<EmailTemplate> {
         val prefs = context.dataStore.data.first()

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/SectionHeader.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/SectionHeader.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -49,7 +49,7 @@ fun SectionHeader(
             if (count != null && count > 0) {
                 Spacer(modifier = Modifier.width(8.dp))
                 Surface(
-                    shape = RoundedCornerShape(4.dp),
+                    shape = cornerShape(4.dp),
                     color = MaterialTheme.colorScheme.surfaceContainerHigh
                 ) {
                     Text(

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/ShimmerEffect.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/ShimmerEffect.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -78,7 +78,7 @@ fun EmailItemSkeleton(modifier: Modifier = Modifier) {
                     modifier = Modifier
                         .height(16.dp)
                         .weight(0.4f)
-                        .clip(RoundedCornerShape(4.dp))
+                        .clip(cornerShape(4.dp))
                         .shimmer()
                 )
                 Spacer(modifier = Modifier.weight(0.4f))
@@ -86,7 +86,7 @@ fun EmailItemSkeleton(modifier: Modifier = Modifier) {
                     modifier = Modifier
                         .height(14.dp)
                         .weight(0.2f)
-                        .clip(RoundedCornerShape(4.dp))
+                        .clip(cornerShape(4.dp))
                         .shimmer()
                 )
             }
@@ -98,7 +98,7 @@ fun EmailItemSkeleton(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .height(16.dp)
                     .fillMaxWidth(0.85f)
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .shimmer()
             )
             
@@ -109,7 +109,7 @@ fun EmailItemSkeleton(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .height(14.dp)
                     .fillMaxWidth(0.95f)
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .shimmer()
             )
         }
@@ -128,7 +128,7 @@ fun DetailSkeleton(modifier: Modifier = Modifier) {
             modifier = Modifier
                 .height(32.dp)
                 .fillMaxWidth(0.9f)
-                .clip(RoundedCornerShape(8.dp))
+                .clip(cornerShape(8.dp))
                 .shimmer()
         )
         
@@ -150,7 +150,7 @@ fun DetailSkeleton(modifier: Modifier = Modifier) {
                     modifier = Modifier
                         .height(16.dp)
                         .fillMaxWidth(0.4f)
-                        .clip(RoundedCornerShape(4.dp))
+                        .clip(cornerShape(4.dp))
                         .shimmer()
                 )
                 Spacer(modifier = Modifier.height(6.dp))
@@ -158,7 +158,7 @@ fun DetailSkeleton(modifier: Modifier = Modifier) {
                     modifier = Modifier
                         .height(14.dp)
                         .fillMaxWidth(0.6f)
-                        .clip(RoundedCornerShape(4.dp))
+                        .clip(cornerShape(4.dp))
                         .shimmer()
                 )
             }
@@ -172,7 +172,7 @@ fun DetailSkeleton(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .height(16.dp)
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .shimmer()
             )
             Spacer(modifier = Modifier.height(8.dp))
@@ -180,7 +180,7 @@ fun DetailSkeleton(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .height(16.dp)
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .shimmer()
             )
             Spacer(modifier = Modifier.height(8.dp))
@@ -188,7 +188,7 @@ fun DetailSkeleton(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .height(16.dp)
                     .fillMaxWidth(if (i % 2 == 0) 0.8f else 0.6f)
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .shimmer()
             )
             Spacer(modifier = Modifier.height(24.dp))

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/SlideSheet.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/SlideSheet.kt
@@ -1,0 +1,116 @@
+package com.shrivatsav.monomail.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.shrivatsav.monomail.ui.theme.cornerShape
+
+/**
+ * Floating bottom "slide sheet": a full-width [Dialog] anchored to the bottom of the
+ * screen, with a drag handle, an optional title + divider header, an optional divider +
+ * action row footer, and a scrim that dismisses on tap.
+ *
+ * This encapsulates the scaffolding that was previously copy-pasted across the PGP,
+ * template, picker, provider and attachment sheets so the individual sheets only need to
+ * supply their own body [content].
+ */
+@Composable
+fun SlideSheet(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    contentPadding: PaddingValues = PaddingValues(vertical = 24.dp),
+    actions: (@Composable RowScope.() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(contentPadding),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(
+                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                CircleShape
+                            )
+                    )
+                    if (title != null) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                        )
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    }
+                    content()
+                    if (actions != null) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 4.dp),
+                            horizontalArrangement = Arrangement.End,
+                            content = actions
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/TooltipIconButton.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/TooltipIconButton.kt
@@ -1,0 +1,54 @@
+package com.shrivatsav.monomail.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+/**
+ * Icon-only tap target with a long-press tooltip for its label. Used for secondary
+ * support actions where the icon alone should carry the affordance.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TooltipIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+        tooltip = { PlainTooltip { Text(contentDescription) } },
+        state = rememberTooltipState()
+    ) {
+        IconButton(
+            onClick = onClick,
+            modifier = modifier
+                .size(44.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f))
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/theme/Theme.kt
@@ -88,6 +88,7 @@ object MonoMailTheme {
 fun MonoMailTheme(
     themeMode: String = "SYSTEM",
     useSystemFont: Boolean = false,
+    cornerStyle: String = "ROUNDED",
     content: @Composable () -> Unit
 ) {
     val darkTheme = when (themeMode) {
@@ -98,12 +99,16 @@ fun MonoMailTheme(
     val colorScheme = if (darkTheme) DarkColors else LightColors
     val extendedColors = if (darkTheme) DarkExtendedColors else LightExtendedColors
     val typography = if (useSystemFont) SystemTypography else AppTypography
+    val shapes = getMonoMailShapes(cornerStyle)
 
-    CompositionLocalProvider(LocalMonoMailExtendedColors provides extendedColors) {
+    CompositionLocalProvider(
+        LocalMonoMailExtendedColors provides extendedColors,
+        LocalCornerStyle provides cornerStyle
+    ) {
         MaterialExpressiveTheme(
             colorScheme  = colorScheme,
             typography   = typography,
-            shapes       = MonoMailShapes,
+            shapes       = shapes,
             motionScheme = MotionScheme.expressive(),
             content      = content
         )

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/theme/shape.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/theme/shape.kt
@@ -1,7 +1,33 @@
 package com.shrivatsav.monomail.ui.theme
+import androidx.compose.ui.unit.Dp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.dp
+
+val LocalCornerStyle = staticCompositionLocalOf { "ROUNDED" }
+
+@Composable
+fun cornerShape(baseDp: Dp): RoundedCornerShape {
+    return when (LocalCornerStyle.current.uppercase()) {
+        "SQUARE" -> when {
+            baseDp <= 8.dp -> RoundedCornerShape(0.dp)
+            baseDp <= 12.dp -> RoundedCornerShape(2.dp)
+            baseDp <= 16.dp -> RoundedCornerShape(4.dp)
+            baseDp <= 20.dp -> RoundedCornerShape(6.dp)
+            else -> RoundedCornerShape(8.dp)
+        }
+        "EXTRA_ROUNDED" -> when {
+            baseDp <= 8.dp -> RoundedCornerShape(12.dp)
+            baseDp <= 12.dp -> RoundedCornerShape(16.dp)
+            baseDp <= 16.dp -> RoundedCornerShape(20.dp)
+            baseDp <= 20.dp -> RoundedCornerShape(24.dp)
+            else -> RoundedCornerShape(28.dp)
+        }
+        else -> RoundedCornerShape(baseDp)
+    }
+}
 val MonoMailShapes = Shapes(
     extraSmall = RoundedCornerShape(8.dp),
     small      = RoundedCornerShape(12.dp),
@@ -9,3 +35,27 @@ val MonoMailShapes = Shapes(
     large      = RoundedCornerShape(24.dp),
     extraLarge = RoundedCornerShape(32.dp),
 )
+
+fun getMonoMailShapes(style: String): Shapes = when (style.uppercase()) {
+    "SQUARE" -> Shapes(
+        extraSmall = RoundedCornerShape(0.dp),
+        small      = RoundedCornerShape(2.dp),
+        medium     = RoundedCornerShape(4.dp),
+        large      = RoundedCornerShape(8.dp),
+        extraLarge = RoundedCornerShape(12.dp),
+    )
+    "EXTRA_ROUNDED" -> Shapes(
+        extraSmall = RoundedCornerShape(12.dp),
+        small      = RoundedCornerShape(16.dp),
+        medium     = RoundedCornerShape(24.dp),
+        large      = RoundedCornerShape(32.dp),
+        extraLarge = RoundedCornerShape(48.dp),
+    )
+    else -> Shapes(
+        extraSmall = RoundedCornerShape(8.dp),
+        small      = RoundedCornerShape(12.dp),
+        medium     = RoundedCornerShape(16.dp),
+        large      = RoundedCornerShape(24.dp),
+        extraLarge = RoundedCornerShape(32.dp),
+    )
+}

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/ImapSetupScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/ImapSetupScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material3.LinearProgressIndicator
 import com.shrivatsav.monomail.core.network.provider.imap.ImapAccountConfig
 import androidx.compose.material3.Surface
@@ -229,7 +229,7 @@ private fun SyncingOverlay() {
                 Text("Syncing emails...", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
                 LinearProgressIndicator(
                     progress = { progress.value },
-                    modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
+                    modifier = Modifier.fillMaxWidth().height(6.dp).clip(cornerShape(3.dp)),
                     color = MaterialTheme.colorScheme.primary,
                     trackColor = MaterialTheme.colorScheme.primaryContainer,
                     strokeCap = StrokeCap.Round

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/OnboardingScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/OnboardingScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.animation.core.*
 import androidx.compose.ui.graphics.graphicsLayer
 import com.shrivatsav.monomail.ui.components.IllustrationType
 import com.shrivatsav.monomail.ui.components.MonoIllustration
+import com.shrivatsav.monomail.ui.components.TooltipIconButton
 import com.shrivatsav.monomail.ui.theme.MonoOpacity
 import com.shrivatsav.monomail.ui.theme.MonoSpring
 import androidx.compose.ui.Alignment
@@ -76,7 +77,7 @@ private fun SupportPage(uriHandler: androidx.compose.ui.platform.UriHandler, con
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
         Spacer(modifier = Modifier.height(16.dp))
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-            OnboardingSupportIconAction(
+            TooltipIconButton(
                 icon = Icons.Rounded.Share,
                 contentDescription = "Share Monomail",
                 onClick = {
@@ -87,12 +88,12 @@ private fun SupportPage(uriHandler: androidx.compose.ui.platform.UriHandler, con
                     context.startActivity(Intent.createChooser(intent, "Share Monomail"))
                 }
             )
-            OnboardingSupportIconAction(
+            TooltipIconButton(
                 icon = Icons.Rounded.BugReport,
                 contentDescription = "Report Issue",
                 onClick = { uriHandler.openUri("https://github.com/shrivatsav-0/monomail/issues") }
             )
-            OnboardingSupportIconAction(
+            TooltipIconButton(
                 icon = Icons.Rounded.AccountBalanceWallet,
                 contentDescription = "Donate Crypto (BASE)",
                 onClick = {
@@ -389,31 +390,3 @@ private fun OnboardingSupportCard(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun OnboardingSupportIconAction(
-    icon: ImageVector,
-    contentDescription: String,
-    onClick: () -> Unit
-) {
-    TooltipBox(
-        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
-        tooltip = { PlainTooltip { Text(contentDescription) } },
-        state = rememberTooltipState()
-    ) {
-        IconButton(
-            onClick = onClick,
-            modifier = Modifier
-                .size(44.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f))
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = contentDescription,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-}

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/OnboardingScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/OnboardingScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
@@ -137,7 +137,7 @@ private fun PermissionButton(granted: Boolean, onClick: () -> Unit, grantedLabel
     Button(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(0.9f),
-        shape = RoundedCornerShape(16.dp),
+        shape = cornerShape(16.dp),
         colors = ButtonDefaults.buttonColors(containerColor = if (granted) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.primary)
     ) {
         Icon(imageVector = if (granted) grantedIcon else defaultIcon, contentDescription = null, modifier = Modifier.size(20.dp))
@@ -152,7 +152,7 @@ private fun PagerControls(currentPage: Int, onPrev: () -> Unit, onNext: () -> Un
         if (currentPage > 0) TextButton(onClick = onPrev) { Text("Back") }
         else Spacer(modifier = Modifier.width(64.dp))
 
-        if (currentPage < TOTAL_PAGES - 1) Button(onClick = onNext, shape = RoundedCornerShape(16.dp)) {
+        if (currentPage < TOTAL_PAGES - 1) Button(onClick = onNext, shape = cornerShape(16.dp)) {
             Text("Next", modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
         } else {
             val transition = rememberInfiniteTransition(label = "pulse_transition")
@@ -168,7 +168,7 @@ private fun PagerControls(currentPage: Int, onPrev: () -> Unit, onNext: () -> Un
             
             Button(
                 onClick = onFinish, 
-                shape = RoundedCornerShape(16.dp), 
+                shape = cornerShape(16.dp), 
                 enabled = enabled, 
                 modifier = Modifier.graphicsLayer { 
                     scaleX = scale 
@@ -364,9 +364,9 @@ private fun OnboardingSupportCard(
 ) {
     Surface(
         modifier = modifier
-            .clip(RoundedCornerShape(18.dp))
+            .clip(cornerShape(18.dp))
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(18.dp),
+        shape = cornerShape(18.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
         contentColor = MaterialTheme.colorScheme.onSurface
     ) {

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import com.shrivatsav.monomail.ui.theme.cornerShape
+import com.shrivatsav.monomail.ui.components.SlideSheet
 import androidx.compose.foundation.Image
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -300,54 +302,22 @@ private fun ProviderSheet(
     onMicrosoftSignIn: () -> Unit,
     onImapClick: () -> Unit,
 ) {
-    androidx.compose.ui.window.Dialog(
-        onDismissRequest = onDismiss,
-        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
+    SlideSheet(
+        onDismiss = onDismiss,
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            Surface(
-                shape = cornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = androidx.compose.foundation.layout.WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp, vertical = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
-                    )
-                    Spacer(modifier = Modifier.height(24.dp))
-                    Text(
-                        text = "Choose your provider",
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                    Spacer(modifier = Modifier.height(24.dp))
-                    ProviderButtons(
-                        state = state,
-                        onGoogleSignIn = onGoogleSignIn,
-                        onMicrosoftSignIn = onMicrosoftSignIn,
-                        onImapClick = onImapClick,
-                    )
-                }
-            }
-        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = "Choose your provider",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        ProviderButtons(
+            state = state,
+            onGoogleSignIn = onGoogleSignIn,
+            onMicrosoftSignIn = onMicrosoftSignIn,
+            onImapClick = onImapClick,
+        )
     }
 }
 

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -38,7 +40,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.foundation.Image
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -298,29 +300,53 @@ private fun ProviderSheet(
     onMicrosoftSignIn: () -> Unit,
     onImapClick: () -> Unit,
 ) {
-    ModalBottomSheet(
+    androidx.compose.ui.window.Dialog(
         onDismissRequest = onDismiss,
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Column(
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
         ) {
-            Text(
-                text = "Choose your provider",
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            ProviderButtons(
-                state = state,
-                onGoogleSignIn = onGoogleSignIn,
-                onMicrosoftSignIn = onMicrosoftSignIn,
-                onImapClick = onImapClick,
-            )
-            Spacer(modifier = Modifier.height(48.dp))
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = androidx.compose.foundation.layout.WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Text(
+                        text = "Choose your provider",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    ProviderButtons(
+                        state = state,
+                        onGoogleSignIn = onGoogleSignIn,
+                        onMicrosoftSignIn = onMicrosoftSignIn,
+                        onImapClick = onImapClick,
+                    )
+                }
+            }
         }
     }
 }
@@ -364,7 +390,7 @@ fun ProviderSelectionDialog(
 
     Surface(
         modifier = Modifier.fillMaxWidth(0.9f),
-        shape = RoundedCornerShape(28.dp),
+        shape = cornerShape(28.dp),
         color = MaterialTheme.colorScheme.background,
         contentColor = MaterialTheme.colorScheme.onBackground,
         shadowElevation = 32.dp,

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import com.shrivatsav.monomail.ui.theme.cornerShape
+import com.shrivatsav.monomail.ui.components.SlideSheet
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -136,8 +137,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.launch
@@ -161,68 +160,26 @@ private fun TemplatesModal(
     onDismiss: () -> Unit,
     onApply: (String, String) -> Unit
 ) {
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            Surface(
-                shape = cornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
-            ) {
-                Column(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+    SlideSheet(onDismiss = onDismiss, title = "Templates") {
+        if (templates.isEmpty()) {
+            com.shrivatsav.monomail.ui.components.EmptyStateView(
+                illustration = com.shrivatsav.monomail.ui.components.IllustrationType.SEARCH_EMPTY,
+                title = "No templates yet",
+                subtitle = "Add them in Settings",
+                modifier = Modifier.height(200.dp)
+            )
+        } else {
+            templates.forEach { template ->
+                Row(
+                    modifier = Modifier.fillMaxWidth()
+                        .clickable { onApply(template.subject, template.body); onDismiss() }
+                        .padding(horizontal = 24.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
-                    )
-                    Spacer(modifier = Modifier.height(24.dp))
-                    Text(
-                        text = "Templates",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-                    )
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    if (templates.isEmpty()) {
-                        com.shrivatsav.monomail.ui.components.EmptyStateView(
-                            illustration = com.shrivatsav.monomail.ui.components.IllustrationType.SEARCH_EMPTY,
-                            title = "No templates yet",
-                            subtitle = "Add them in Settings",
-                            modifier = Modifier.height(200.dp)
-                        )
-                    } else {
-                        templates.forEach { template ->
-                            Row(
-                                modifier = Modifier.fillMaxWidth()
-                                    .clickable { onApply(template.subject, template.body); onDismiss() }
-                                    .padding(horizontal = 24.dp, vertical = 14.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(text = template.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
-                                    if (template.subject.isNotEmpty()) {
-                                        Text(text = template.subject, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                                    }
-                                }
-                            }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(text = template.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
+                        if (template.subject.isNotEmpty()) {
+                            Text(text = template.subject, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
                 }
@@ -1319,76 +1276,41 @@ private fun AttachmentPickerSheet(
     onSelectImages: () -> Unit,
     onSelectFiles: () -> Unit
 ) {
-    androidx.compose.ui.window.Dialog(
-        onDismissRequest = onDismiss,
-        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
-    ) {
-        androidx.compose.foundation.layout.Box(
+    SlideSheet(onDismiss = onDismiss) {
+        Spacer(modifier = androidx.compose.ui.Modifier.height(24.dp))
+
+        Row(
             modifier = androidx.compose.ui.Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = androidx.compose.ui.Alignment.BottomCenter
+                .fillMaxWidth()
+                .clickable(onClick = onSelectImages)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
         ) {
-            androidx.compose.material3.Surface(
-                shape = cornerShape(24.dp),
-                color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
-                contentColor = androidx.compose.material3.MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
-                modifier = androidx.compose.ui.Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
-            ) {
-                androidx.compose.foundation.layout.Column(
-                    modifier = androidx.compose.ui.Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 24.dp),
-                    horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
-                ) {
-                    androidx.compose.foundation.layout.Box(
-                        modifier = androidx.compose.ui.Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), androidx.compose.foundation.shape.CircleShape)
-                    )
-                    Spacer(modifier = androidx.compose.ui.Modifier.height(24.dp))
-                    
-                    Row(
-                        modifier = androidx.compose.ui.Modifier
-                            .fillMaxWidth()
-                            .clickable(onClick = onSelectImages)
-                            .padding(horizontal = 24.dp, vertical = 16.dp),
-                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
-                    ) {
-                        androidx.compose.material3.Icon(
-                            imageVector = androidx.compose.material.icons.Icons.Rounded.Image,
-                            contentDescription = "Gallery",
-                            tint = androidx.compose.material3.MaterialTheme.colorScheme.primary,
-                            modifier = androidx.compose.ui.Modifier.size(24.dp)
-                        )
-                        Spacer(modifier = androidx.compose.ui.Modifier.width(16.dp))
-                        androidx.compose.material3.Text("Photos & Videos", style = androidx.compose.material3.MaterialTheme.typography.bodyLarge)
-                    }
-                    
-                    Row(
-                        modifier = androidx.compose.ui.Modifier
-                            .fillMaxWidth()
-                            .clickable(onClick = onSelectFiles)
-                            .padding(horizontal = 24.dp, vertical = 16.dp),
-                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
-                    ) {
-                        androidx.compose.material3.Icon(
-                            imageVector = androidx.compose.material.icons.Icons.Rounded.Folder,
-                            contentDescription = "Files",
-                            tint = androidx.compose.material3.MaterialTheme.colorScheme.primary,
-                            modifier = androidx.compose.ui.Modifier.size(24.dp)
-                        )
-                        Spacer(modifier = androidx.compose.ui.Modifier.width(16.dp))
-                        androidx.compose.material3.Text("Browse Files", style = androidx.compose.material3.MaterialTheme.typography.bodyLarge)
-                    }
-                }
-            }
+            androidx.compose.material3.Icon(
+                imageVector = androidx.compose.material.icons.Icons.Rounded.Image,
+                contentDescription = "Gallery",
+                tint = androidx.compose.material3.MaterialTheme.colorScheme.primary,
+                modifier = androidx.compose.ui.Modifier.size(24.dp)
+            )
+            Spacer(modifier = androidx.compose.ui.Modifier.width(16.dp))
+            androidx.compose.material3.Text("Photos & Videos", style = androidx.compose.material3.MaterialTheme.typography.bodyLarge)
+        }
+
+        Row(
+            modifier = androidx.compose.ui.Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onSelectFiles)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        ) {
+            androidx.compose.material3.Icon(
+                imageVector = androidx.compose.material.icons.Icons.Rounded.Folder,
+                contentDescription = "Files",
+                tint = androidx.compose.material3.MaterialTheme.colorScheme.primary,
+                modifier = androidx.compose.ui.Modifier.size(24.dp)
+            )
+            Spacer(modifier = androidx.compose.ui.Modifier.width(16.dp))
+            androidx.compose.material3.Text("Browse Files", style = androidx.compose.material3.MaterialTheme.typography.bodyLarge)
         }
     }
 }

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -77,7 +77,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
@@ -122,6 +121,9 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.icons.rounded.ArrowDropDown
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.material.icons.rounded.Image
+import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.animation.core.Animatable
@@ -134,6 +136,8 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.launch
@@ -151,40 +155,73 @@ private fun resolveAttachmentMimeType(contentResolver: android.content.ContentRe
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TemplatesModal(
     templates: List<com.shrivatsav.monomail.core.data.settings.EmailTemplate>,
     onDismiss: () -> Unit,
     onApply: (String, String) -> Unit
 ) {
-    ModalBottomSheet(
+    Dialog(
         onDismissRequest = onDismiss,
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+        properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)) {
-            Text(text = "Templates", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-            if (templates.isEmpty()) {
-                com.shrivatsav.monomail.ui.components.EmptyStateView(
-                    illustration = com.shrivatsav.monomail.ui.components.IllustrationType.SEARCH_EMPTY,
-                    title = "No templates yet",
-                    subtitle = "Add them in Settings",
-                    modifier = Modifier.height(200.dp)
-                )
-            } else {
-                templates.forEach { template ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth()
-                            .clickable { onApply(template.subject, template.body); onDismiss() }
-                            .padding(horizontal = 24.dp, vertical = 14.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(text = template.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
-                            if (template.subject.isNotEmpty()) {
-                                Text(text = template.subject, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Text(
+                        text = "Templates",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    if (templates.isEmpty()) {
+                        com.shrivatsav.monomail.ui.components.EmptyStateView(
+                            illustration = com.shrivatsav.monomail.ui.components.IllustrationType.SEARCH_EMPTY,
+                            title = "No templates yet",
+                            subtitle = "Add them in Settings",
+                            modifier = Modifier.height(200.dp)
+                        )
+                    } else {
+                        templates.forEach { template ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth()
+                                    .clickable { onApply(template.subject, template.body); onDismiss() }
+                                    .padding(horizontal = 24.dp, vertical = 14.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(text = template.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
+                                    if (template.subject.isNotEmpty()) {
+                                        Text(text = template.subject, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    }
+                                }
                             }
                         }
                     }
@@ -306,6 +343,7 @@ fun ComposeScreen(
     val canSend = state.to.isNotBlank()
     val showSentAnimation = remember { mutableStateOf(false) }
     val contentResolver = context.contentResolver
+    var showAttachmentPicker by remember { mutableStateOf(false) }
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetMultipleContents()
     ) { uris: List<Uri> ->
@@ -337,6 +375,19 @@ fun ComposeScreen(
         }
     }
     ComposeDialogs(state, viewModel)
+    if (showAttachmentPicker) {
+        AttachmentPickerSheet(
+            onDismiss = { showAttachmentPicker = false },
+            onSelectImages = { 
+                showAttachmentPicker = false
+                launcher.launch("image/*") 
+            },
+            onSelectFiles = { 
+                showAttachmentPicker = false
+                launcher.launch("*/*") 
+            }
+        )
+    }
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -376,7 +427,7 @@ fun ComposeScreen(
                 isSending = state.isSending,
                 isSent = state.isSent,
                 canSend = canSend,
-                onAttach = { launcher.launch("*/*") },
+                onAttach = { showAttachmentPicker = true },
                 onSend = { viewModel.send() }
             )
         },
@@ -1009,7 +1060,7 @@ private fun ComposeBottomBar(
             .padding(top = 8.dp, bottom = 28.dp)
     ) {
         Surface(
-            shape = RoundedCornerShape(28.dp),
+            shape = cornerShape(28.dp),
             tonalElevation = 6.dp,
             shadowElevation = 8.dp,
             color = MaterialTheme.colorScheme.surfaceContainerHigh
@@ -1095,7 +1146,7 @@ private fun SlideToSendControl(
         modifier = modifier
             .height(48.dp)
             .onGloballyPositioned { trackWidthPx = it.size.width.toFloat() }
-            .clip(RoundedCornerShape(24.dp))
+            .clip(cornerShape(24.dp))
             .background(
                 if (canSend) MaterialTheme.colorScheme.primaryContainer
                 else MaterialTheme.colorScheme.surfaceContainerHigh
@@ -1106,14 +1157,14 @@ private fun SlideToSendControl(
                     MaterialTheme.colorScheme.primary.copy(alpha = 0.25f)
                 else
                     MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                shape = RoundedCornerShape(24.dp)
+                shape = cornerShape(24.dp)
             )
     ) {
         Box(
             modifier = Modifier
                 .fillMaxHeight()
                 .width(with(density) { (thumbOffset.value + thumbSize.toPx() + thumbPadding.toPx()).toDp() })
-                .clip(RoundedCornerShape(24.dp))
+                .clip(cornerShape(24.dp))
                 .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f + 0.18f * progress))
         )
 
@@ -1210,7 +1261,7 @@ fun AttachmentPreview(
     Box(
         modifier = Modifier
             .size(100.dp)
-            .clip(RoundedCornerShape(12.dp))
+            .clip(cornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
     ) {
         if (isImage) {
@@ -1258,6 +1309,86 @@ fun AttachmentPreview(
                 modifier = Modifier.size(16.dp),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+    }
+}
+
+@Composable
+private fun AttachmentPickerSheet(
+    onDismiss: () -> Unit,
+    onSelectImages: () -> Unit,
+    onSelectFiles: () -> Unit
+) {
+    androidx.compose.ui.window.Dialog(
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        androidx.compose.foundation.layout.Box(
+            modifier = androidx.compose.ui.Modifier
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = androidx.compose.ui.Alignment.BottomCenter
+        ) {
+            androidx.compose.material3.Surface(
+                shape = cornerShape(24.dp),
+                color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
+                contentColor = androidx.compose.material3.MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = androidx.compose.ui.Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                androidx.compose.foundation.layout.Column(
+                    modifier = androidx.compose.ui.Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+                ) {
+                    androidx.compose.foundation.layout.Box(
+                        modifier = androidx.compose.ui.Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), androidx.compose.foundation.shape.CircleShape)
+                    )
+                    Spacer(modifier = androidx.compose.ui.Modifier.height(24.dp))
+                    
+                    Row(
+                        modifier = androidx.compose.ui.Modifier
+                            .fillMaxWidth()
+                            .clickable(onClick = onSelectImages)
+                            .padding(horizontal = 24.dp, vertical = 16.dp),
+                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                    ) {
+                        androidx.compose.material3.Icon(
+                            imageVector = androidx.compose.material.icons.Icons.Rounded.Image,
+                            contentDescription = "Gallery",
+                            tint = androidx.compose.material3.MaterialTheme.colorScheme.primary,
+                            modifier = androidx.compose.ui.Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = androidx.compose.ui.Modifier.width(16.dp))
+                        androidx.compose.material3.Text("Photos & Videos", style = androidx.compose.material3.MaterialTheme.typography.bodyLarge)
+                    }
+                    
+                    Row(
+                        modifier = androidx.compose.ui.Modifier
+                            .fillMaxWidth()
+                            .clickable(onClick = onSelectFiles)
+                            .padding(horizontal = 24.dp, vertical = 16.dp),
+                        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                    ) {
+                        androidx.compose.material3.Icon(
+                            imageVector = androidx.compose.material.icons.Icons.Rounded.Folder,
+                            contentDescription = "Files",
+                            tint = androidx.compose.material3.MaterialTheme.colorScheme.primary,
+                            modifier = androidx.compose.ui.Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = androidx.compose.ui.Modifier.width(16.dp))
+                        androidx.compose.material3.Text("Browse Files", style = androidx.compose.material3.MaterialTheme.typography.bodyLarge)
+                    }
+                }
+            }
         }
     }
 }

--- a/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
+++ b/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
@@ -565,22 +565,7 @@ private fun ConversationEmailItem(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = "to:",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = email.to,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
+                ToRow(email = email)
                 if (!isExpanded) {
                     val snippetText = remember(email.snippet) {
                         email.snippet
@@ -942,7 +927,7 @@ private fun SenderDetails(email: Email, isMsgUnread: Boolean) {
 }
 
 @Composable
-private fun ToRow(email: Email, onToggleCcBcc: () -> Unit) {
+private fun ToRow(email: Email, onToggleCcBcc: (() -> Unit)? = null) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = "to:",
@@ -956,8 +941,17 @@ private fun ToRow(email: Email, onToggleCcBcc: () -> Unit) {
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-                .clickable { if (email.cc.isNotBlank() || email.bcc.isNotBlank()) onToggleCcBcc() }
+            modifier = Modifier
+                .weight(1f)
+                .then(
+                    if (onToggleCcBcc != null) {
+                        Modifier.clickable {
+                            if (email.cc.isNotBlank() || email.bcc.isNotBlank()) onToggleCcBcc()
+                        }
+                    } else {
+                        Modifier
+                    }
+                )
         )
     }
 }

--- a/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
+++ b/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -124,6 +124,7 @@ data class EmailDisplayConfig(
     val fontScaleMultiplier: Float = 1f,
     val loadRemoteImages: Boolean = true,
     val emailTheme: EmailTheme = EmailTheme.AUTO,
+    val showInlineImages: Boolean = true,
     val showInlineAttachments: Boolean = true,
     val isDeveloperMode: Boolean = false,
     val currentUserEmail: String = ""
@@ -143,6 +144,7 @@ fun EmailDetailScreen(
     val fontScaleMultiplier by viewModel.fontScaleMultiplier.collectAsState()
     val loadRemoteImages by viewModel.loadRemoteImages.collectAsState()
     val emailTheme by viewModel.emailTheme.collectAsState()
+    val showInlineImages by viewModel.showInlineImages.collectAsState()
     val showInlineAttachments by viewModel.showInlineAttachments.collectAsState()
     val state by viewModel.state.collectAsState()
     val isStarred by viewModel.isStarred.collectAsState()
@@ -226,6 +228,7 @@ fun EmailDetailScreen(
                 fontScaleMultiplier = fontScaleMultiplier,
                 loadRemoteImages = loadRemoteImages,
                 emailTheme = emailTheme,
+                showInlineImages = showInlineImages,
                 showInlineAttachments = showInlineAttachments,
                 isDeveloperMode = isDeveloperMode,
                 currentUserEmail = viewModel.currentUserEmail
@@ -460,7 +463,7 @@ fun ThreadConversationContent(
                         modifier = Modifier
                             .weight(1f)
                             .height(52.dp),
-                        shape = RoundedCornerShape(16.dp),
+                        shape = cornerShape(16.dp),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.onBackground,
                             contentColor = MaterialTheme.colorScheme.background
@@ -479,7 +482,7 @@ fun ThreadConversationContent(
                         modifier = Modifier
                             .weight(1f)
                             .height(52.dp),
-                        shape = RoundedCornerShape(16.dp),
+                        shape = cornerShape(16.dp),
                         border = BorderStroke(
                             1.dp,
                             MaterialTheme.colorScheme.onBackground.copy(alpha = 0.2f)
@@ -652,7 +655,7 @@ private fun CcBccBlock(email: Email) {
                 .padding(start = 8.dp, end = 12.dp, top = 8.dp, bottom = 4.dp)
                 .background(
                     MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.4f),
-                    RoundedCornerShape(8.dp)
+                    cornerShape(8.dp)
                 )
                 .padding(horizontal = 12.dp, vertical = 8.dp)
         ) {
@@ -782,7 +785,7 @@ private fun MessageBodyContent(
         safeBodyText,
         config.fontScaleMultiplier,
         showQuotedText,
-        config.showInlineAttachments,
+        config.showInlineImages,
         config.loadRemoteImages,
         showRemoteImages,
         config.emailTheme,
@@ -797,7 +800,7 @@ private fun MessageBodyContent(
                 config.fontScaleMultiplier,
                 HtmlBuildParams(
                     showQuotedText,
-                    config.showInlineAttachments,
+                    config.showInlineImages,
                     config.loadRemoteImages,
                     showRemoteImages,
                     useOverviewScaling,
@@ -836,7 +839,7 @@ private fun EncryptionBadge(decryptedResult: PgpDecryptionResult?) {
     if (decryptedResult == null) return
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)
-            .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f), cornerShape(8.dp))
             .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -1011,7 +1014,7 @@ private fun RemoteImagesBanner(
     if (!loadRemoteImages && !showRemoteImages && bodyIsHtml) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 4.dp)
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f), cornerShape(8.dp))
                 .padding(horizontal = 12.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -1095,7 +1098,7 @@ private fun EmailWebViewCard(
     Column {
         AndroidView(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
-                .clip(RoundedCornerShape(16.dp)).background(cardBgColor, RoundedCornerShape(16.dp)).padding(12.dp)
+                .clip(cornerShape(16.dp)).background(cardBgColor, cornerShape(16.dp)).padding(12.dp)
                 .alpha(alpha),
             factory = { context ->
                 WebView(context).apply {
@@ -1202,7 +1205,7 @@ private fun createWebViewClient(context: android.content.Context, onPageFinished
 }
 
 private data class HtmlBuildParams(
-    val showQuotedText: Boolean, val showInlineAttachments: Boolean, val loadRemoteImages: Boolean,
+    val showQuotedText: Boolean, val showInlineImages: Boolean, val loadRemoteImages: Boolean,
     val showRemoteImages: Boolean, val useOverviewScaling: Boolean, val emailZoomFactor: Float,
     val textColor: String, val linkColor: String
 )
@@ -1211,9 +1214,9 @@ private fun buildEmailHtml(
     email: Email, safeBodyText: String, bodyIsHtml: Boolean, fontScaleMultiplier: Float,
     params: HtmlBuildParams
 ): String {
-    val (showQuotedText, showInlineAttachments, loadRemoteImages, showRemoteImages, useOverviewScaling, emailZoomFactor, textColor, linkColor) = params
+    val (showQuotedText, showInlineImages, loadRemoteImages, showRemoteImages, useOverviewScaling, emailZoomFactor, textColor, linkColor) = params
     val displayBody = if (bodyIsHtml) safeBodyText else TextUtils.htmlEncode(safeBodyText).replace("\n", "<br>")
-    val bodyWithCidPlaceholders = if (!showInlineAttachments && email.attachments.isNotEmpty()) {
+    val bodyWithCidPlaceholders = if (!showInlineImages && email.attachments.isNotEmpty()) {
         var b = displayBody
         for (att in email.attachments) {
             if (att.name.isBlank()) continue
@@ -1299,7 +1302,8 @@ private fun formatFileSize(bytes: Long): String {
     return when {
         bytes >= 1024 * 1024 -> String.format(Locale.getDefault(), "%.1f MB", bytes / (1024.0 * 1024.0))
         bytes >= 1024 -> "${bytes / 1024} KB"
-        else -> "$bytes B"
+        bytes > 0 -> "$bytes B"
+        else -> "Unknown size"
     }
 }
 
@@ -1334,21 +1338,23 @@ private fun AttachmentsSection(
                 val columnWidth = 200.dp
                 val availableWidth = maxWidth
                 val columns = maxOf(1, (availableWidth / columnWidth).toInt())
-                fileAttachments.chunked(columns).forEach { rowItems ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        rowItems.forEach { attachment ->
-                            FileAttachmentCard(
-                                attachment = attachment,
-                                onFetchAttachment = onFetchAttachment,
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-                        // Fill remaining slots with spacers for consistent sizing
-                        repeat(columns - rowItems.size) {
-                            Spacer(modifier = Modifier.weight(1f))
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    fileAttachments.chunked(columns).forEach { rowItems ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            rowItems.forEach { attachment ->
+                                FileAttachmentCard(
+                                    attachment = attachment,
+                                    onFetchAttachment = onFetchAttachment,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+                            // Fill remaining slots with spacers for consistent sizing
+                            repeat(columns - rowItems.size) {
+                                Spacer(modifier = Modifier.weight(1f))
+                            }
                         }
                     }
                 }
@@ -1465,7 +1471,7 @@ private fun FileAttachmentCard(
     val ext = attachment.name.substringAfterLast('.', "").uppercase()
     Row(
         modifier = modifier
-            .clip(RoundedCornerShape(12.dp))
+            .clip(cornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
             .clickable {
                 if (!isFetching) {
@@ -1483,7 +1489,7 @@ private fun FileAttachmentCard(
         Box(
             modifier = Modifier
                 .size(40.dp)
-                .clip(RoundedCornerShape(10.dp))
+                .clip(cornerShape(10.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh),
             contentAlignment = Alignment.Center
         ) {
@@ -1552,7 +1558,7 @@ private fun AttachmentToggleButton(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .clip(cornerShape(12.dp))
             .clickable(onClick = onClick)
             .background(MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.5f))
             .padding(horizontal = 16.dp, vertical = 14.dp),
@@ -1625,28 +1631,30 @@ private fun FileAttachmentsGrid(
     BoxWithConstraints {
         val columnWidth = 200.dp
         val columns = maxOf(1, (maxWidth / columnWidth).toInt())
-        fileAttachments.chunked(columns).forEach { rowItems ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                rowItems.forEach { (attachment, sender) ->
-                    Column(modifier = Modifier.weight(1f)) {
-                        FileAttachmentCard(
-                            attachment = attachment,
-                            onFetchAttachment = onFetchAttachment,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        Text(
-                            text = "from $sender",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
-                            modifier = Modifier.padding(start = 4.dp, top = 2.dp)
-                        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            fileAttachments.chunked(columns).forEach { rowItems ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    rowItems.forEach { (attachment, sender) ->
+                        Column(modifier = Modifier.weight(1f)) {
+                            FileAttachmentCard(
+                                attachment = attachment,
+                                onFetchAttachment = onFetchAttachment,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                            Text(
+                                text = "from $sender",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+                                modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+                            )
+                        }
                     }
-                }
-                repeat(columns - rowItems.size) {
-                    Spacer(modifier = Modifier.weight(1f))
+                    repeat(columns - rowItems.size) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
                 }
             }
         }

--- a/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailViewModel.kt
+++ b/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailViewModel.kt
@@ -76,6 +76,9 @@ class EmailDetailViewModel @Inject constructor(
         .map { it.isDeveloperMode }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
+    val showInlineImages: StateFlow<Boolean> = settingsDataStore.settingsFlow
+        .map { it.showInlineImages }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
     val showInlineAttachments: StateFlow<Boolean> = settingsDataStore.settingsFlow
         .map { it.showInlineAttachments }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.TextButton
 import com.shrivatsav.monomail.feature.inbox.components.*
 
 import com.shrivatsav.monomail.ui.components.AvatarCircle
+import com.shrivatsav.monomail.ui.components.TooltipIconButton
 import com.shrivatsav.monomail.model.InboxTab
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.*
@@ -843,7 +844,7 @@ fun InboxScreen(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
-                    SupportIconAction(
+                    TooltipIconButton(
                         icon = Icons.Rounded.Share,
                         contentDescription = "Share Monomail",
                         onClick = {
@@ -857,12 +858,12 @@ fun InboxScreen(
                             context.startActivity(android.content.Intent.createChooser(intent, "Share Monomail"))
                         }
                     )
-                    SupportIconAction(
+                    TooltipIconButton(
                         icon = Icons.Rounded.BugReport,
                         contentDescription = "Report Issue",
                         onClick = { uriHandler.openUri("https://github.com/shrivatsav-0/monomail/issues") }
                     )
-                    SupportIconAction(
+                    TooltipIconButton(
                         icon = Icons.Rounded.AccountBalanceWallet,
                         contentDescription = "Donate Crypto (BASE)",
                         onClick = {
@@ -1386,41 +1387,6 @@ private fun SupportCard(
         }
     }
 }
-
-/**
- * Secondary support action — icon-only tap target with a long-press
- * tooltip for the label. Lower visual priority than SupportCard.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SupportIconAction(
-    icon: ImageVector,
-    contentDescription: String,
-    onClick: () -> Unit
-) {
-    TooltipBox(
-        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
-        tooltip = { PlainTooltip { Text(contentDescription) } },
-        state = rememberTooltipState()
-    ) {
-        IconButton(
-            onClick = onClick,
-            modifier = Modifier
-                .size(44.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f))
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = contentDescription,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-}
-
-
 
 @Composable
 private fun LongPressAction(

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -1,5 +1,17 @@
 package com.shrivatsav.monomail.feature.inbox
 
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.asPaddingValues
+import com.shrivatsav.monomail.ui.theme.cornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.TextButton
 import com.shrivatsav.monomail.feature.inbox.components.*
 
 import com.shrivatsav.monomail.ui.components.AvatarCircle
@@ -34,6 +46,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -96,6 +109,7 @@ fun InboxScreen(
     val currentThreads = (state as? InboxState.Success)?.threads ?: emptyList()
     var longPressedThread by remember { mutableStateOf<EmailThread?>(null) }
     val hapticFeedback = LocalHapticFeedback.current
+    val focusManager = LocalFocusManager.current
     var activeModal by remember { mutableStateOf<ModalType?>(null) }
     var showSnoozePicker by remember { mutableStateOf(false) }
     var snoozeThreadId by remember { mutableStateOf<String?>(null) }
@@ -104,7 +118,13 @@ fun InboxScreen(
     val isBulkMode by viewModel.isBulkSelectMode.collectAsState()
     val selectedThreadIds by viewModel.selectedThreadIds.collectAsState()
     val selectedCount by viewModel.selectedCount.collectAsState()
-    if (isBulkMode) {
+    val isSearchActive = searchQuery.isNotEmpty()
+    if (isSearchActive) {
+        BackHandler {
+            searchQuery = ""
+            focusManager.clearFocus()
+        }
+    } else if (isBulkMode) {
         BackHandler { viewModel.exitBulkSelectMode() }
     } else if (immediateTab != InboxTab.INBOX) {
         BackHandler { viewModel.switchTab(InboxTab.INBOX) }
@@ -197,7 +217,6 @@ fun InboxScreen(
                             showMarkAllRead = appSettings.showMarkAllRead
                         ),
                         isRefreshing = isRefreshing,
-                        toastState = toastState,
                         bulkSelection = BulkSelectionState(
                             isBulkMode = isBulkMode,
                             selectedCount = selectedCount,
@@ -639,6 +658,14 @@ fun InboxScreen(
                 unifiedInboxEnabled = unifiedInboxEnabled
             )
         }
+            
+            val toastState by viewModel.toastState.collectAsState()
+            Box {
+                TopAlertBanner(
+                    toastState = toastState,
+                    onUndo = { viewModel.undoAction() }
+                )
+            }
     }
 
     // ── Welcome to Monomail modal ────────────────────────────────────
@@ -648,7 +675,7 @@ fun InboxScreen(
         onDismiss = { viewModel.dismissWelcomePrompt() }
     ) {
         Surface(
-            shape = RoundedCornerShape(28.dp),
+            shape = cornerShape(28.dp),
             color = MaterialTheme.colorScheme.background,
             contentColor = MaterialTheme.colorScheme.onBackground,
             shadowElevation = 32.dp,
@@ -695,7 +722,7 @@ fun InboxScreen(
 
                 // ── What's New ─────────────────────────────────────────
                 Surface(
-                    shape = RoundedCornerShape(16.dp),
+                    shape = cornerShape(16.dp),
                     color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f),
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -855,7 +882,7 @@ fun InboxScreen(
                 ) {
                     FilledTonalButton(
                         onClick = { viewModel.dismissWelcomePrompt() },
-                        shape = RoundedCornerShape(16.dp)
+                        shape = cornerShape(16.dp)
                     ) {
                         Text(
                             "Get Started",
@@ -905,7 +932,7 @@ fun InboxScreen(
         onDismiss = { threadToDelete = null }
     ) {
         Surface(
-            shape = RoundedCornerShape(28.dp),
+            shape = cornerShape(28.dp),
             color = MaterialTheme.colorScheme.background,
             contentColor = MaterialTheme.colorScheme.onBackground,
             shadowElevation = 32.dp,
@@ -1007,7 +1034,7 @@ private fun ClearCountdownDialog(
         }
     }
     Surface(
-        shape = RoundedCornerShape(28.dp),
+        shape = cornerShape(28.dp),
         color = MaterialTheme.colorScheme.background,
         contentColor = MaterialTheme.colorScheme.onBackground,
         shadowElevation = 32.dp,
@@ -1048,34 +1075,41 @@ private fun BottomFabArea(
     onEmptyBin: (isTrash: Boolean) -> Unit
 ) {
     val tabForDock = immediateTab
-    Row(
-        modifier = Modifier.padding(bottom = navBarHeight + 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalAlignment = Alignment.Bottom
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = navBarHeight + 8.dp)
     ) {
         BottomDockBar(
             currentTab = tabForDock,
             dockConfig = appSettings.dockConfig,
             unifiedInboxEnabled = unifiedInboxEnabled,
             appSettings = appSettings,
-            onTabClick = { viewModel.switchTab(it) }
+            onTabClick = { viewModel.switchTab(it) },
+            modifier = Modifier.align(Alignment.BottomCenter)
         )
-        AnimatedContent(
-            targetState = when (immediateTab) {
-                InboxTab.TRASH -> "trash"
-                InboxTab.SPAM -> "spam"
-                else -> "default"
-            },
-            label = "FabIconMorph",
-            transitionSpec = {
-                (fadeIn(tween(180)) + scaleIn(tween(180), initialScale = 0.85f)) togetherWith
-                        (fadeOut(tween(120)) + scaleOut(tween(120), targetScale = 0.85f))
-            }
-        ) { state ->
-            when (state) {
-                "trash" -> EmptyTrashFab(appSettings) { onEmptyBin(true) }
-                "spam" -> EmptySpamFab(appSettings) { onEmptyBin(false) }
-                "default" -> ComposeFab(appSettings, navActions.onCompose)
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 16.dp)
+        ) {
+            AnimatedContent(
+                targetState = when (immediateTab) {
+                    InboxTab.TRASH -> "trash"
+                    InboxTab.SPAM -> "spam"
+                    else -> "default"
+                },
+                label = "FabIconMorph",
+                transitionSpec = {
+                    (fadeIn(tween(180)) + scaleIn(tween(180), initialScale = 0.85f)) togetherWith
+                            (fadeOut(tween(120)) + scaleOut(tween(120), targetScale = 0.85f))
+                }
+            ) { state ->
+                when (state) {
+                    "trash" -> EmptyTrashFab(appSettings) { onEmptyBin(true) }
+                    "spam" -> EmptySpamFab(appSettings) { onEmptyBin(false) }
+                    "default" -> ComposeFab(appSettings, navActions.onCompose)
+                }
             }
         }
     }
@@ -1168,11 +1202,11 @@ private fun LongPressMenu(
             modifier = Modifier.fillMaxWidth(0.85f),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
+            Surface(shape = cornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
                 EmailItem(thread = thread, onClick = { onDismiss(); actions.onEmailClick() }, onLongClick = {}, modifier = Modifier)
             }
             Spacer(Modifier.height(8.dp))
-            Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
+            Surface(shape = cornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
                 LongPressActionRow(thread, tabForMenu, actions) { onDismiss() }
             }
         }
@@ -1285,7 +1319,7 @@ private fun SnoozePickerDialog(
         onDismiss = onDismiss
     ) {
         Surface(
-            shape = RoundedCornerShape(28.dp),
+            shape = cornerShape(28.dp),
             color = MaterialTheme.colorScheme.background,
             contentColor = MaterialTheme.colorScheme.onBackground,
             shadowElevation = 32.dp,
@@ -1303,7 +1337,7 @@ private fun SnoozePickerDialog(
                     TextButton(
                         onClick = { onSnooze(opt.timestamp) },
                         modifier = Modifier.fillMaxWidth().height(48.dp),
-                        shape = RoundedCornerShape(12.dp)
+                        shape = cornerShape(12.dp)
                     ) {
                         Text(opt.label, modifier = Modifier.fillMaxWidth())
                     }
@@ -1328,9 +1362,9 @@ private fun SupportCard(
 ) {
     Surface(
         modifier = modifier
-            .clip(RoundedCornerShape(18.dp))
+            .clip(cornerShape(18.dp))
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(18.dp),
+        shape = cornerShape(18.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
         contentColor = MaterialTheme.colorScheme.onSurface
     ) {
@@ -1398,7 +1432,7 @@ private fun LongPressAction(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
-            .clip(RoundedCornerShape(12.dp))
+            .clip(cornerShape(12.dp))
             .clickable(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 10.dp)
     ) {
@@ -1520,7 +1554,7 @@ private fun ShimmerEmailItem() {
                 modifier = Modifier
                     .fillMaxWidth(0.5f)
                     .height(14.dp)
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .background(color)
             )
             Spacer(Modifier.height(6.dp))
@@ -1528,7 +1562,7 @@ private fun ShimmerEmailItem() {
                 modifier = Modifier
                     .fillMaxWidth(0.85f)
                     .height(12.dp)
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .background(color.copy(alpha = 0.5f))
             )
             Spacer(Modifier.height(4.dp))
@@ -1536,7 +1570,7 @@ private fun ShimmerEmailItem() {
                 modifier = Modifier
                     .fillMaxWidth(0.6f)
                     .height(10.dp)
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(cornerShape(4.dp))
                     .background(color.copy(alpha = 0.3f))
             )
         }
@@ -1545,7 +1579,7 @@ private fun ShimmerEmailItem() {
             modifier = Modifier
                 .width(40.dp)
                 .height(12.dp)
-                .clip(RoundedCornerShape(4.dp))
+                .clip(cornerShape(4.dp))
                 .background(color.copy(alpha = 0.3f))
         )
     }
@@ -1563,7 +1597,7 @@ private fun WelcomeActionButton(
         modifier = modifier
             .fillMaxWidth()
             .height(52.dp),
-        shape = RoundedCornerShape(14.dp),
+        shape = cornerShape(14.dp),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         colors = ButtonDefaults.outlinedButtonColors(
             contentColor = MaterialTheme.colorScheme.onSurface
@@ -1637,6 +1671,14 @@ private data class ReleaseNotes(
 )
 
 private val allReleaseNotes = listOf(
+    ReleaseNotes(version = "1.7.38", changes = listOf(
+        "Optimized email detail loading with asynchronous parsing and pre-warmed instances",
+        "Completed a major architectural overhaul, modularizing the application",
+        "Abstracted authentication logic to support specific flavor builds",
+        "Fixed a critical crash on launch related to missing HiltWorker processing",
+        "Restored the custom Monomail notification icon",
+        "Settings screen now accurately displays the application version"
+    )),
     ReleaseNotes(version = "1.7.24", changes = listOf(
         "Optimized build times with configuration caching",
         "Fixed MSAL sign-in for release builds",
@@ -1651,3 +1693,63 @@ private val allReleaseNotes = listOf(
         "Enhanced tablet layout support"
     ))
 )
+
+@Composable
+private fun TopAlertBanner(
+    toastState: InboxViewModel.ToastState?,
+    onUndo: () -> Unit
+) {
+    androidx.compose.animation.AnimatedVisibility(
+        visible = toastState != null,
+        enter = fadeIn(tween(220)) + slideInVertically(
+            initialOffsetY = { -it },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        ),
+        exit = fadeOut(tween(180)) + slideOutVertically(
+            targetOffsetY = { -it },
+            animationSpec = tween(250)
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 8.dp)
+    ) {
+        if (toastState != null) {
+            Surface(
+                shape = cornerShape(16.dp),
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                shadowElevation = 8.dp,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                val icon = when (toastState.actionType) {
+                    InboxViewModel.ActionType.ARCHIVE -> Icons.Rounded.Archive
+                    InboxViewModel.ActionType.DELETE -> Icons.Rounded.Delete
+                    InboxViewModel.ActionType.EMPTY_TRASH -> Icons.Rounded.Delete
+                    InboxViewModel.ActionType.SEND -> Icons.Rounded.Send
+                    InboxViewModel.ActionType.SNOOZE -> Icons.Rounded.Schedule
+                    InboxViewModel.ActionType.UNARCHIVE -> Icons.Rounded.Unarchive
+                    InboxViewModel.ActionType.RESTORE -> Icons.Rounded.Restore
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(icon, null, modifier = Modifier.size(20.dp))
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        toastState.message, modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis
+                    )
+                    TextButton(
+                        onClick = onUndo,
+                        shape = cornerShape(24.dp),
+                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary),
+                        contentPadding = PaddingValues(horizontal = 12.dp)
+                    ) { Text("Undo", fontWeight = FontWeight.Bold) }
+                }
+            }
+        }
+    }
+}

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
@@ -269,12 +270,11 @@ class InboxViewModel @Inject constructor(
 
     private fun observeSentEvents() {
         viewModelScope.launch {
-            combine(sentEmailEvents, settingsDataStore.settingsFlow) { event, settings ->
-                Pair(event, settings)
-            }.collect { (event, settings) ->
-                val toastId = event.threadId ?: "send_${System.currentTimeMillis()}"
-                if (!settings.undoSendEnabled) return@collect
-                startUndoCountdown(toastId, settings.undoSendWindow.seconds)
+            sentEmailEvents.collect { event ->
+                val settings = settingsDataStore.settingsFlow.first()
+                if (settings.undoSendEnabled) {
+                    startUndoCountdown(event.threadId ?: "send_${System.currentTimeMillis()}", settings.undoSendWindow.seconds)
+                }
             }
         }
     }

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/BottomDockBar.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/BottomDockBar.kt
@@ -7,10 +7,8 @@ import com.shrivatsav.monomail.model.InboxTab
 import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.KeyboardArrowUp
@@ -20,12 +18,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import com.shrivatsav.monomail.core.data.settings.DockConfig
 import com.shrivatsav.monomail.core.data.settings.DockTabId
 import com.shrivatsav.monomail.core.data.settings.AppSettings
@@ -38,6 +35,7 @@ internal fun BottomDockBar(
     unifiedInboxEnabled: Boolean,
     appSettings: AppSettings,
     onTabClick: (InboxTab) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var showRemainingTabs by remember { mutableStateOf(false) }
     val allTabs = DockTabId.entries.filter { it != DockTabId.UNIFIED }
@@ -47,7 +45,7 @@ internal fun BottomDockBar(
     val density = LocalDensity.current
 
     Box(
-        modifier = Modifier.wrapContentSize()
+        modifier = modifier.wrapContentSize()
     ) {
         AnimatedVisibility(
             visible = showRemainingTabs && remainingIds.isNotEmpty(),
@@ -58,7 +56,7 @@ internal fun BottomDockBar(
                 .padding(bottom = (dockRowHeightPx / density.density).dp + 8.dp)
         ) {
             Surface(
-                shape = RoundedCornerShape(20.dp),
+                shape = cornerShape(20.dp),
                 color = MaterialTheme.colorScheme.surfaceContainer,
                 shadowElevation = 8.dp,
             ) {
@@ -121,7 +119,7 @@ private fun PrimaryDockRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Surface(
-            shape = CircleShape,
+            shape = cornerShape(24.dp),
             color = MaterialTheme.colorScheme.primaryContainer,
             shadowElevation = 4.dp
         ) {
@@ -153,14 +151,13 @@ private fun MoreTabsButton(
     onClick: () -> Unit,
 ) {
     Surface(
-        shape = CircleShape,
+        shape = cornerShape(24.dp),
         color = if (showRemainingTabs) MaterialTheme.colorScheme.secondaryContainer
                 else MaterialTheme.colorScheme.primaryContainer,
         shadowElevation = 4.dp,
+        onClick = onClick,
         modifier = Modifier
             .size((42 * navScale).dp)
-            .clip(CircleShape)
-            .clickable(onClick = onClick)
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
@@ -184,7 +181,7 @@ private fun RemainingTabItem(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        shape = RoundedCornerShape(14.dp),
+        shape = cornerShape(14.dp),
         color = if (isActive) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent,
         onClick = onClick,
         modifier = modifier

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/DockTab.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/DockTab.kt
@@ -5,7 +5,6 @@ import com.shrivatsav.monomail.feature.inbox.*
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -17,6 +16,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import com.shrivatsav.monomail.ui.theme.MonoMailTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -75,7 +75,7 @@ fun AnimatedDockTab(
     ) { active -> if (active) 1.1f else 1f }
 
     Surface(
-        shape = CircleShape,
+        shape = cornerShape(24.dp),
         color = bgColor,
         contentColor = iconColor,
         onClick = onClick,

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/EmailItem.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/EmailItem.kt
@@ -26,7 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.RadioButtonUnchecked
@@ -186,7 +186,7 @@ private fun EmailItemSenderInfo(thread: EmailThread, isUnread: Boolean) {
                     modifier = Modifier
                         .background(
                             color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                            shape = RoundedCornerShape(4.dp)
+                            shape = cornerShape(4.dp)
                         )
                         .padding(horizontal = 5.dp, vertical = 1.dp)
                 )

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/InboxSearchBar.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/InboxSearchBar.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.rounded.*
@@ -63,14 +63,13 @@ internal fun InboxSearchBar(
     onServerSearch: (String) -> Unit,
     actions: SearchBarActions,
     isRefreshing: Boolean,
-    toastState: InboxViewModel.ToastState?,
     bulkSelection: BulkSelectionState = BulkSelectionState(),
     unifiedInboxEnabled: Boolean = false,
 ) {
     val containerColor by animateColorAsState(
         targetValue = when {
             bulkSelection.isBulkMode -> MaterialTheme.colorScheme.secondaryContainer
-            toastState != null -> MaterialTheme.colorScheme.secondaryContainer
+            // toastState removed; handled as Top Sheet in InboxScreen
             else -> MaterialTheme.colorScheme.surfaceContainer
         },
         animationSpec = tween(300),
@@ -92,17 +91,8 @@ internal fun InboxSearchBar(
                     if (bulkSelection.isBulkMode) {
                         BulkSelectionContent(bulkSelection)
                     } else {
-                        AnimatedContent(
-                            targetState = toastState,
-                            label = "SearchBarToastMorph",
-                            transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(200)) }
-                        ) { toast ->
-                            if (toast != null) {
-                                ToastContent(toast, actions)
-                            } else {
-                                SearchInputContent(query, onQueryChange, onServerSearch, actions, SearchDisplayState(isRefreshing, unifiedInboxEnabled, accounts, userProfile))
-                            }
-                        }
+                        // No toast overlay; always show search input
+                        SearchInputContent(query, onQueryChange, onServerSearch, actions, SearchDisplayState(isRefreshing, unifiedInboxEnabled, accounts, userProfile))
                     }
                 }
             },
@@ -147,13 +137,13 @@ private fun BulkSelectionContent(bulkSelection: BulkSelectionState) {
             if (bulkSelection.selectedCount < bulkSelection.totalCount) {
                 TextButton(
                     onClick = bulkSelection.onSelectAll,
-                    shape = RoundedCornerShape(24.dp),
+                    shape = cornerShape(24.dp),
                     colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
                 ) { Text("Select all") }
             } else {
                 TextButton(
                     onClick = bulkSelection.onDeselectAll,
-                    shape = RoundedCornerShape(24.dp),
+                    shape = cornerShape(24.dp),
                     colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
                 ) { Text("Deselect all") }
             }
@@ -165,33 +155,6 @@ private fun BulkSelectionContent(bulkSelection: BulkSelectionState) {
     }
 }
 
-@Composable
-private fun ToastContent(toast: InboxViewModel.ToastState, actions: SearchBarActions) {
-    val icon = when (toast.actionType) {
-        InboxViewModel.ActionType.ARCHIVE -> Icons.Rounded.Archive
-        InboxViewModel.ActionType.DELETE -> Icons.Rounded.Delete
-        InboxViewModel.ActionType.EMPTY_TRASH -> Icons.Rounded.Delete
-        InboxViewModel.ActionType.SEND -> Icons.AutoMirrored.Rounded.Send
-        InboxViewModel.ActionType.SNOOZE -> Icons.Rounded.Schedule
-        InboxViewModel.ActionType.UNARCHIVE -> Icons.Rounded.Unarchive
-        InboxViewModel.ActionType.RESTORE -> Icons.Rounded.Restore
-    }
-    Row(modifier = Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
-        Spacer(Modifier.width(16.dp))
-        Icon(icon, null, tint = MaterialTheme.colorScheme.onSecondaryContainer, modifier = Modifier.size(20.dp))
-        Spacer(Modifier.width(10.dp))
-        Text(
-            toast.message, modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSecondaryContainer, maxLines = 1, overflow = TextOverflow.Ellipsis
-        )
-        TextButton(
-            onClick = actions.onUndo, shape = RoundedCornerShape(24.dp),
-            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
-        ) { Text("Undo") }
-        Spacer(Modifier.width(12.dp))
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/ModalOverlay.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/ModalOverlay.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -59,34 +59,35 @@ internal fun ModalOverlay(
 
     AnimatedVisibility(
         visible = activeModal != null,
-        enter = fadeIn(tween(220)),
-        exit = fadeOut(tween(180)),
+        enter = fadeIn(tween(220)) + slideInVertically(
+            initialOffsetY = { -it },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        ),
+        exit = fadeOut(tween(180)) + slideOutVertically(
+            targetOffsetY = { -it },
+            animationSpec = tween(250)
+        ),
     ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f))
+                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
                 .clickable(
                     indication = null,
                     interactionSource = remember { MutableInteractionSource() }
                 ) { callbacks.onDismiss() },
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.TopCenter
         ) {
             AnimatedContent(
                 targetState = displayed,
                 transitionSpec = {
-                    if (initialState == null) {
-                        EnterTransition.None togetherWith ExitTransition.None
-                    } else {
-                        (scaleIn(
-                            tween(200, easing = FastOutSlowInEasing),
-                            initialScale = 0.85f
-                        ) + fadeIn(tween(200))) togetherWith
-                                (scaleOut(tween(200), targetScale = 0.85f) +
-                                        fadeOut(tween(180)))
-                    }
+                    fadeIn(tween(200)) togetherWith fadeOut(tween(180))
                 },
-                label = "ModalContent"
+                label = "ModalContent",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 16.dp)
             ) { modal ->
                 ModalContentBody(
                     modal = modal,

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/ProfileCard.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/ProfileCard.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
@@ -50,7 +50,7 @@ internal fun ProfileCard(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(0.88f),
-        shape = RoundedCornerShape(28.dp),
+        shape = cornerShape(28.dp),
         color = MaterialTheme.colorScheme.background,
         shadowElevation = 32.dp,
     ) {
@@ -296,7 +296,7 @@ private fun ProfileCardButtons(callbacks: ProfileCardCallbacks) {
         OutlinedButton(
             onClick = callbacks.onSignOut,
             modifier = Modifier.weight(1f),
-            shape = RoundedCornerShape(14.dp),
+            shape = cornerShape(14.dp),
             colors = ButtonDefaults.outlinedButtonColors(
                 contentColor = MaterialTheme.colorScheme.onBackground
             ),
@@ -315,7 +315,7 @@ private fun ProfileCardButtons(callbacks: ProfileCardCallbacks) {
         Button(
             onClick = callbacks.onAddAccount,
             modifier = Modifier.weight(1f),
-            shape = RoundedCornerShape(14.dp),
+            shape = cornerShape(14.dp),
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.onBackground,
                 contentColor = MaterialTheme.colorScheme.background
@@ -342,7 +342,7 @@ private fun ProfileMenuItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp))
+            .clip(cornerShape(14.dp))
             .clickable(onClick = onClick)
             .padding(horizontal = 14.dp, vertical = 13.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SwitchAccountCard.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SwitchAccountCard.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Add
@@ -33,7 +33,7 @@ internal fun SwitchAccountCard(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(0.88f),
-        shape = RoundedCornerShape(28.dp),
+        shape = cornerShape(28.dp),
         color = MaterialTheme.colorScheme.background,
         shadowElevation = 32.dp,
     ) {
@@ -88,7 +88,7 @@ internal fun SwitchAccountCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 8.dp)
-                    .clip(RoundedCornerShape(16.dp))
+                    .clip(cornerShape(16.dp))
                     .clickable(onClick = onAddAccount)
                     .padding(horizontal = 12.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -132,7 +132,7 @@ private fun AccountRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
+            .clip(cornerShape(16.dp))
             .background(
                 if (isCurrent) MaterialTheme.colorScheme.onBackground.copy(alpha = 0.06f)
                 else Color.Transparent

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/scheduled/ScheduledMessagesScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/scheduled/ScheduledMessagesScreen.kt
@@ -3,7 +3,7 @@ package com.shrivatsav.monomail.feature.inbox.scheduled
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Send
@@ -78,7 +78,7 @@ fun ScheduledMessagesScreen(
                     Spacer(Modifier.height(24.dp))
                     FilledTonalButton(
                         onClick = onCompose,
-                        shape = RoundedCornerShape(20.dp)
+                        shape = cornerShape(20.dp)
                     ) {
                         Icon(Icons.Rounded.Add, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(Modifier.width(6.dp))
@@ -117,7 +117,7 @@ private fun ScheduledMessageItem(
 
     Surface(
         onClick = onEdit,
-        shape = RoundedCornerShape(12.dp),
+        shape = cornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 1.dp
     ) {

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AppearanceSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AppearanceSettingsScreen.kt
@@ -44,6 +44,14 @@ internal fun AppearanceSettingsScreen(
                 onCheckedChange = { viewModel.setUseSystemFont(it) }
             )
             CardDivider()
+            BottomSheetPickerRow(
+                icon = Icons.Rounded.RoundedCorner,
+                title = "Corner Style",
+                currentValue = settings.cornerStyle.name.lowercase().replace("_", " ").replaceFirstChar { it.titlecase() },
+                options = com.shrivatsav.monomail.core.data.settings.CornerStyle.entries.map { it.name.lowercase().replace("_", " ").replaceFirstChar { it.titlecase() } },
+                onSelected = { idx -> viewModel.setCornerStyle(com.shrivatsav.monomail.core.data.settings.CornerStyle.entries[idx]) }
+            )
+            CardDivider()
             EmailColorsRow(
                 currentTheme = settings.emailTheme,
                 onThemeSelected = { viewModel.setEmailTheme(it) }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/ReadingSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/ReadingSettingsScreen.kt
@@ -27,6 +27,14 @@ internal fun ReadingSettingsScreen(
             )
             CardDivider()
             SettingsToggleRow(
+                icon = Icons.Rounded.Image,
+                title = "Inline Images",
+                subtitle = "Render inline images embedded in the email body",
+                checked = settings.showInlineImages,
+                onCheckedChange = { viewModel.setShowInlineImages(it) }
+            )
+            CardDivider()
+            SettingsToggleRow(
                 icon = Icons.Rounded.AttachFile,
                 title = "Inline Attachments",
                 subtitle = "Show attachment cards within the email body, or as a collapsible summary above it",

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Reply
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.rounded.*
@@ -29,14 +30,29 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.unit.sp
 import com.shrivatsav.monomail.core.data.settings.*
+import com.shrivatsav.monomail.ui.components.SlideSheet
 import com.shrivatsav.monomail.ui.theme.MonoOpacity
 import com.shrivatsav.monomail.ui.theme.MonoSpring
 
 // ── Shared UI Primitives ────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SettingsDetailTopBar(title: String, onNavigateBack: () -> Unit) {
+    TopAppBar(
+        title = {
+            Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+        },
+        navigationIcon = {
+            IconButton(onClick = onNavigateBack) {
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back", tint = MaterialTheme.colorScheme.onSurface)
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+    )
+}
 
 @Composable
 internal fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
@@ -194,52 +210,52 @@ internal fun ThemeSelectorRow(
     currentTheme: ThemeMode,
     onThemeSelected: (ThemeMode) -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = Icons.Rounded.DarkMode,
-                contentDescription = "Theme",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp)
-            )
-            Spacer(modifier = Modifier.width(14.dp))
-            Text(
-                text = "Theme",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+    SelectorRow(
+        icon = Icons.Rounded.DarkMode,
+        iconDescription = "Theme",
+        title = "Theme",
+        labelPrefix = "theme",
+        entries = ThemeMode.entries.map { mode ->
+            SelectorEntry(mode.displayName(), currentTheme == mode) { onThemeSelected(mode) }
         }
-        Spacer(modifier = Modifier.height(12.dp))
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(cornerShape(14.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                .padding(4.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            ThemeMode.entries.forEach { mode ->
-                SelectorItem(
-                    modifier = Modifier.weight(1f),
-                    label = mode.displayName(),
-                    isSelected = currentTheme == mode,
-                    labelPrefix = "theme",
-                    onClick = { onThemeSelected(mode) }
-                )
-            }
-        }
-    }
+    )
 }
 
 @Composable
 internal fun EmailColorsRow(
     currentTheme: EmailTheme,
     onThemeSelected: (EmailTheme) -> Unit
+) {
+    SelectorRow(
+        icon = Icons.Rounded.Contrast,
+        iconDescription = "Email colors",
+        title = "Email Colors",
+        labelPrefix = "emailColor",
+        entries = EmailTheme.entries.map { mode ->
+            SelectorEntry(mode.displayName(), currentTheme == mode) { onThemeSelected(mode) }
+        },
+        description = currentTheme.description()
+    )
+}
+
+private data class SelectorEntry(
+    val label: String,
+    val isSelected: Boolean,
+    val onClick: () -> Unit,
+)
+
+/**
+ * Icon + title header above a segmented row of [SelectorItem]s, with an optional
+ * description line below. Shared by the theme and email-color pickers.
+ */
+@Composable
+private fun SelectorRow(
+    icon: ImageVector,
+    iconDescription: String,
+    title: String,
+    labelPrefix: String,
+    entries: List<SelectorEntry>,
+    description: String? = null,
 ) {
     Column(
         modifier = Modifier
@@ -248,14 +264,14 @@ internal fun EmailColorsRow(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
-                imageVector = Icons.Rounded.Contrast,
-                contentDescription = "Email colors",
+                imageVector = icon,
+                contentDescription = iconDescription,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(20.dp)
             )
             Spacer(modifier = Modifier.width(14.dp))
             Text(
-                text = "Email Colors",
+                text = title,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface
@@ -270,22 +286,24 @@ internal fun EmailColorsRow(
                 .padding(4.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            EmailTheme.entries.forEach { mode ->
+            entries.forEach { entry ->
                 SelectorItem(
                     modifier = Modifier.weight(1f),
-                    label = mode.displayName(),
-                    isSelected = currentTheme == mode,
-                    labelPrefix = "emailColor",
-                    onClick = { onThemeSelected(mode) }
+                    label = entry.label,
+                    isSelected = entry.isSelected,
+                    labelPrefix = labelPrefix,
+                    onClick = entry.onClick
                 )
             }
         }
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = currentTheme.description(),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        if (description != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 
@@ -606,78 +624,31 @@ private fun PickerBottomSheet(
     onSelected: (Int) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    androidx.compose.ui.window.Dialog(
-        onDismissRequest = onDismiss,
-        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            Surface(
-                shape = cornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
+    SlideSheet(onDismiss = onDismiss, title = title) {
+        options.forEachIndexed { index, option ->
+            val isSelected = option == currentValue
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
+                    .clickable { onSelected(index) }
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), androidx.compose.foundation.shape.CircleShape)
+                Text(
+                    text = option,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                    color = if (isSelected) MaterialTheme.colorScheme.onSurface
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f)
+                )
+                if (isSelected) {
+                    Icon(
+                        imageVector = Icons.Rounded.Check,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.size(20.dp)
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 8.dp)
-                    )
-                    HorizontalDivider(
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
-                        modifier = Modifier.padding(bottom = 8.dp)
-                    )
-                    options.forEachIndexed { index, option ->
-                        val isSelected = option == currentValue
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onSelected(index) }
-                                .padding(horizontal = 24.dp, vertical = 16.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = option,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                color = if (isSelected) MaterialTheme.colorScheme.onSurface
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.weight(1f)
-                            )
-                            if (isSelected) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Check,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSurface,
-                                    modifier = Modifier.size(20.dp)
-                                )
-                            }
-                        }
-                    }
                 }
             }
         }
@@ -922,89 +893,41 @@ private fun TemplateEditorDialog(
     onSave: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
+    SlideSheet(
+        onDismiss = onDismiss,
+        title = if (state.editingIndex >= 0) "Edit Template" else "New Template",
+        actions = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(onClick = onSave) { Text("Save") }
+        }
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.BottomCenter
+        Spacer(modifier = Modifier.height(8.dp))
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Surface(
-                shape = cornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = if (state.editingIndex >= 0) "Edit Template" else "New Template",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-                    )
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Column(
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        OutlinedTextField(
-                            value = state.nameInput,
-                            onValueChange = onNameChange,
-                            label = { Text("Name") },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        OutlinedTextField(
-                            value = state.subjectInput,
-                            onValueChange = onSubjectChange,
-                            label = { Text("Subject") },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        OutlinedTextField(
-                            value = state.bodyInput,
-                            onValueChange = onBodyChange,
-                            label = { Text("Body") },
-                            minLines = 3,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 4.dp),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        TextButton(onClick = onDismiss) { Text("Cancel") }
-                        Spacer(modifier = Modifier.width(8.dp))
-                        TextButton(onClick = onSave) { Text("Save") }
-                    }
-                }
-            }
+            OutlinedTextField(
+                value = state.nameInput,
+                onValueChange = onNameChange,
+                label = { Text("Name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = state.subjectInput,
+                onValueChange = onSubjectChange,
+                label = { Text("Subject") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = state.bodyInput,
+                onValueChange = onBodyChange,
+                label = { Text("Body") },
+                minLines = 3,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Reply
 import androidx.compose.material.icons.automirrored.rounded.Send
@@ -29,6 +29,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.unit.sp
 import com.shrivatsav.monomail.core.data.settings.*
 import com.shrivatsav.monomail.ui.theme.MonoOpacity
@@ -39,7 +41,7 @@ import com.shrivatsav.monomail.ui.theme.MonoSpring
 @Composable
 internal fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
     Surface(
-        shape = RoundedCornerShape(20.dp),
+        shape = cornerShape(20.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 0.dp,
         modifier = Modifier
@@ -216,7 +218,7 @@ internal fun ThemeSelectorRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(14.dp))
+                .clip(cornerShape(14.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 .padding(4.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp)
@@ -263,7 +265,7 @@ internal fun EmailColorsRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(14.dp))
+                .clip(cornerShape(14.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 .padding(4.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp)
@@ -316,7 +318,7 @@ private fun SelectorItem(
     Box(
         modifier = modifier
             .graphicsLayer(scaleX = scaleAnim, scaleY = scaleAnim)
-            .clip(RoundedCornerShape(10.dp))
+            .clip(cornerShape(10.dp))
             .background(bgColor)
             .clickable { onClick() }
             .padding(vertical = 10.dp),
@@ -375,7 +377,7 @@ internal fun FontSizeRow(
         }
         Spacer(modifier = Modifier.height(10.dp))
         Surface(
-            shape = RoundedCornerShape(10.dp),
+            shape = cornerShape(10.dp),
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
             modifier = Modifier.fillMaxWidth()
         ) {
@@ -604,51 +606,77 @@ private fun PickerBottomSheet(
     onSelected: (Int) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(
+    androidx.compose.ui.window.Dialog(
         onDismissRequest = onDismiss,
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Column(
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 32.dp)
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-            )
-            HorizontalDivider(
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
-            options.forEachIndexed { index, option ->
-                val isSelected = option == currentValue
-                Row(
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { onSelected(index) }
-                        .padding(horizontal = 24.dp, vertical = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text(
-                        text = option,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurface
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.weight(1f)
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), androidx.compose.foundation.shape.CircleShape)
                     )
-                    if (isSelected) {
-                        Icon(
-                            imageVector = Icons.Rounded.Check,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.size(20.dp)
-                        )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 8.dp)
+                    )
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                    options.forEachIndexed { index, option ->
+                        val isSelected = option == currentValue
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelected(index) }
+                                .padding(horizontal = 24.dp, vertical = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = option,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                                color = if (isSelected) MaterialTheme.colorScheme.onSurface
+                                else MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f)
+                            )
+                            if (isSelected) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Check,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -894,41 +922,91 @@ private fun TemplateEditorDialog(
     onSave: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    AlertDialog(
+    Dialog(
         onDismissRequest = onDismiss,
-        title = { Text(if (state.editingIndex >= 0) "Edit Template" else "New Template", fontWeight = FontWeight.SemiBold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = state.nameInput,
-                    onValueChange = onNameChange,
-                    label = { Text("Name") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                OutlinedTextField(
-                    value = state.subjectInput,
-                    onValueChange = onSubjectChange,
-                    label = { Text("Subject") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                OutlinedTextField(
-                    value = state.bodyInput,
-                    onValueChange = onBodyChange,
-                    label = { Text("Body") },
-                    minLines = 3,
-                    modifier = Modifier.fillMaxWidth()
-                )
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = if (state.editingIndex >= 0) "Edit Template" else "New Template",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Column(
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        OutlinedTextField(
+                            value = state.nameInput,
+                            onValueChange = onNameChange,
+                            label = { Text("Name") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        OutlinedTextField(
+                            value = state.subjectInput,
+                            onValueChange = onSubjectChange,
+                            label = { Text("Subject") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        OutlinedTextField(
+                            value = state.bodyInput,
+                            onValueChange = onBodyChange,
+                            label = { Text("Body") },
+                            minLines = 3,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = onDismiss) { Text("Cancel") }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        TextButton(onClick = onSave) { Text("Save") }
+                    }
+                }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onSave) { Text("Save") }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
         }
-    )
+    }
 }
 
 private data class TemplateEditorState(
@@ -1090,7 +1168,7 @@ internal fun SupportButton(
                 .fillMaxWidth()
                 .height(48.dp)
                 .graphicsLayer(scaleX = btnScale, scaleY = btnScale),
-            shape = RoundedCornerShape(14.dp),
+            shape = cornerShape(14.dp),
             colors = ButtonDefaults.filledTonalButtonColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer
@@ -1108,7 +1186,7 @@ internal fun SupportButton(
                 .fillMaxWidth()
                 .height(48.dp)
                 .graphicsLayer(scaleX = btnScale, scaleY = btnScale),
-            shape = RoundedCornerShape(14.dp),
+            shape = cornerShape(14.dp),
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onSurface)
         ) {

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.rememberScrollState
 import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
@@ -146,17 +145,7 @@ private fun SettingsHubScreen(
             bottom = 0.dp
         ),
         topBar = {
-            TopAppBar(
-                title = {
-                    Text("Settings", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back", tint = MaterialTheme.colorScheme.onSurface)
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
-            )
+            SettingsDetailTopBar(title = "Settings", onNavigateBack = onNavigateBack)
         }
     ) { padding ->
         Column(

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -286,6 +286,44 @@ internal fun DeveloperSettingsScreen(
                     modifier = Modifier.size(18.dp)
                 )
             }
+            CardDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = {
+                        throw RuntimeException("Intentional crash for testing purposes")
+                    })
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Warning,
+                    contentDescription = "Test Crash",
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(14.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Test App Crash",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    Text(
+                        "Intentionally crash the app to verify crash handler",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Rounded.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error.copy(alpha = 0.4f),
+                    modifier = Modifier.size(18.dp)
+                )
+            }
         }
     }
 }
@@ -308,7 +346,7 @@ private fun CategoryCard(
     Surface(
         onClick = onClick,
         interactionSource = interactionSource,
-        shape = RoundedCornerShape(16.dp),
+        shape = cornerShape(16.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 0.dp,
         modifier = Modifier

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
@@ -54,8 +54,10 @@ class SettingsViewModel @Inject constructor(
     fun setUndoSendWindow(window: UndoSendWindow) = viewModelScope.launch { settingsDataStore.setUndoSendWindow(window) }
     fun setDockConfig(config: DockConfig) = viewModelScope.launch { settingsDataStore.setDockConfig(config) }
     fun setDeveloperMode(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setDeveloperMode(enabled) }
+    fun setShowInlineImages(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowInlineImages(enabled) }
     fun setShowInlineAttachments(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowInlineAttachments(enabled) }
     fun setShowMarkAllRead(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowMarkAllRead(enabled) }
+    fun setCornerStyle(style: com.shrivatsav.monomail.core.data.settings.CornerStyle) = viewModelScope.launch { settingsDataStore.setCornerStyle(style) }
     fun resetWelcomePrompt() = viewModelScope.launch {
         settingsDataStore.setHasSeenWelcomePrompt(false)
     }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SupportSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SupportSettingsScreen.kt
@@ -1,7 +1,6 @@
 package com.shrivatsav.monomail.feature.settings
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
@@ -9,9 +8,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.addPathNodes
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -23,7 +23,20 @@ internal fun SupportSettingsScreen(
     val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
     val kofiIcon = remember { android.graphics.BitmapFactory.decodeStream(context.resources.openRawResource(com.shrivatsav.monomail.core.designsystem.R.raw.kofi))?.asImageBitmap()?.let { androidx.compose.ui.graphics.painter.BitmapPainter(it) } }
 
-    val discordIcon: Painter = painterResource(com.shrivatsav.monomail.core.designsystem.R.drawable.ic_discord)
+    val discordIcon = remember {
+        ImageVector.Builder(
+            name = "Discord",
+            defaultWidth = 22.dp,
+            defaultHeight = 22.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).addPath(
+            fill = SolidColor(Color.Black),
+            pathData = addPathNodes(
+                "M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"
+            )
+        ).build()
+    }
 
     ScrollableSettingsScaffold(title = "Support & Donate", onBack = onBack) {
         SettingsCard {
@@ -62,7 +75,7 @@ internal fun SupportSettingsScreen(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                         )
                     ) {
-                        Icon(painter = discordIcon, contentDescription = "Discord", tint = MaterialTheme.colorScheme.onSurface)
+                        Icon(imageVector = discordIcon, contentDescription = "Discord", tint = MaterialTheme.colorScheme.onSurface)
                     }
                     IconButton(
                         onClick = {

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/pgp/PgpKeyManagementScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/pgp/PgpKeyManagementScreen.kt
@@ -2,19 +2,13 @@ package com.shrivatsav.monomail.feature.settings.pgp
 
 import androidx.compose.animation.*
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import com.shrivatsav.monomail.ui.theme.cornerShape
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -28,6 +22,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.shrivatsav.monomail.data.pgp.PgpKeyInfo
+import com.shrivatsav.monomail.feature.settings.SettingsDetailTopBar
+import com.shrivatsav.monomail.ui.components.SlideSheet
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -51,17 +47,7 @@ fun PgpKeyManagementScreen(
             bottom = 0.dp
         ),
         topBar = {
-            TopAppBar(
-                title = {
-                    Text("PGP Keys", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back", tint = MaterialTheme.colorScheme.onSurface)
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
-            )
+            SettingsDetailTopBar(title = "PGP Keys", onNavigateBack = onNavigateBack)
         },
         floatingActionButton = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -247,82 +233,34 @@ private fun GenerateKeyDialog(
 ) {
     var userId by remember { mutableStateOf("") }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            Surface(
-                shape = cornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = "Generate PGP Key Pair",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-                    )
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Column(
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text(
-                            "Enter your name and email (e.g., \"Alice <alice@example.com>\")",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        OutlinedTextField(
-                            value = userId,
-                            onValueChange = { userId = it },
-                            label = { Text("User ID") },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 4.dp),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        TextButton(onClick = onDismiss) { Text("Cancel") }
-                        Spacer(modifier = Modifier.width(8.dp))
-                        TextButton(onClick = { onGenerate(userId) }, enabled = userId.isNotBlank()) {
-                            Text("Generate")
-                        }
-                    }
-                }
+    SlideSheet(
+        onDismiss = onDismiss,
+        title = "Generate PGP Key Pair",
+        actions = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(onClick = { onGenerate(userId) }, enabled = userId.isNotBlank()) {
+                Text("Generate")
             }
+        }
+    ) {
+        Spacer(modifier = Modifier.height(8.dp))
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                "Enter your name and email (e.g., \"Alice <alice@example.com>\")",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedTextField(
+                value = userId,
+                onValueChange = { userId = it },
+                label = { Text("User ID") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }
@@ -334,82 +272,34 @@ private fun ImportKeyDialog(
 ) {
     var armoredKey by remember { mutableStateOf("") }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            Surface(
-                shape = cornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = "Import PGP Key",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-                    )
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Column(
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text(
-                            "Paste the ASCII-armored PGP key below.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        OutlinedTextField(
-                            value = armoredKey,
-                            onValueChange = { armoredKey = it },
-                            label = { Text("Armored Key") },
-                            minLines = 6,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 4.dp),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        TextButton(onClick = onDismiss) { Text("Cancel") }
-                        Spacer(modifier = Modifier.width(8.dp))
-                        TextButton(onClick = { onImport(armoredKey) }, enabled = armoredKey.isNotBlank()) {
-                            Text("Import")
-                        }
-                    }
-                }
+    SlideSheet(
+        onDismiss = onDismiss,
+        title = "Import PGP Key",
+        actions = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(onClick = { onImport(armoredKey) }, enabled = armoredKey.isNotBlank()) {
+                Text("Import")
             }
+        }
+    ) {
+        Spacer(modifier = Modifier.height(8.dp))
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                "Paste the ASCII-armored PGP key below.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedTextField(
+                value = armoredKey,
+                onValueChange = { armoredKey = it },
+                label = { Text("Armored Key") },
+                minLines = 6,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }
@@ -422,93 +312,45 @@ private fun ExportKeyDialog(
 ) {
     val context = LocalContext.current
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
+    SlideSheet(
+        onDismiss = onDismiss,
+        title = "Public Key",
+        actions = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(onClick = {
+                val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                clipboard.setPrimaryClip(android.content.ClipData.newPlainText("PGP Public Key", armoredKey))
+                android.widget.Toast.makeText(context, "Copied to clipboard", android.widget.Toast.LENGTH_SHORT).show()
+                onCopied()
+            }) {
+                Text("Copy to Clipboard")
+            }
+        }
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.BottomCenter
+        Spacer(modifier = Modifier.height(8.dp))
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            Text(
+                "Copy this key to share with others.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             Surface(
-                shape = cornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                shadowElevation = 8.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
-                    .clickable(onClick = {})
+                shape = cornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = "Public Key",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-                    )
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Column(
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text(
-                            "Copy this key to share with others.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Surface(
-                            shape = cornerShape(12.dp),
-                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text(
-                                text = armoredKey,
-                                style = MaterialTheme.typography.bodySmall,
-                                fontFamily = FontFamily.Monospace,
-                                modifier = Modifier.padding(12.dp),
-                                maxLines = 10,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 4.dp),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        TextButton(onClick = onDismiss) { Text("Close") }
-                        Spacer(modifier = Modifier.width(8.dp))
-                        TextButton(onClick = {
-                            val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                            clipboard.setPrimaryClip(android.content.ClipData.newPlainText("PGP Public Key", armoredKey))
-                            android.widget.Toast.makeText(context, "Copied to clipboard", android.widget.Toast.LENGTH_SHORT).show()
-                            onCopied()
-                        }) {
-                            Text("Copy to Clipboard")
-                        }
-                    }
-                }
+                Text(
+                    text = armoredKey,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    modifier = Modifier.padding(12.dp),
+                    maxLines = 10,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/pgp/PgpKeyManagementScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/pgp/PgpKeyManagementScreen.kt
@@ -4,9 +4,15 @@ import androidx.compose.animation.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
+import com.shrivatsav.monomail.ui.theme.cornerShape
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.*
@@ -142,7 +148,7 @@ private fun KeyCard(
     var showMenu by remember { mutableStateOf(false) }
 
     Surface(
-        shape = RoundedCornerShape(16.dp),
+        shape = cornerShape(16.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         modifier = Modifier.fillMaxWidth()
     ) {
@@ -179,7 +185,7 @@ private fun KeyTypeIcon(key: PgpKeyInfo) {
     Box(
         modifier = Modifier
             .size(40.dp)
-            .clip(RoundedCornerShape(12.dp))
+            .clip(cornerShape(12.dp))
             .background(if (key.isPrivate) MaterialTheme.colorScheme.primary.copy(alpha = 0.15f) else MaterialTheme.colorScheme.tertiary.copy(alpha = 0.15f)),
         contentAlignment = Alignment.Center
     ) {
@@ -241,30 +247,84 @@ private fun GenerateKeyDialog(
 ) {
     var userId by remember { mutableStateOf("") }
 
-    AlertDialog(
+    Dialog(
         onDismissRequest = onDismiss,
-        title = { Text("Generate PGP Key Pair", fontWeight = FontWeight.SemiBold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Enter your name and email (e.g., \"Alice <alice@example.com>\")", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                OutlinedTextField(
-                    value = userId,
-                    onValueChange = { userId = it },
-                    label = { Text("User ID") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Generate PGP Key Pair",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Column(
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            "Enter your name and email (e.g., \"Alice <alice@example.com>\")",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        OutlinedTextField(
+                            value = userId,
+                            onValueChange = { userId = it },
+                            label = { Text("User ID") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = onDismiss) { Text("Cancel") }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        TextButton(onClick = { onGenerate(userId) }, enabled = userId.isNotBlank()) {
+                            Text("Generate")
+                        }
+                    }
+                }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = { onGenerate(userId) }, enabled = userId.isNotBlank()) {
-                Text("Generate")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
         }
-    )
+    }
 }
 
 @Composable
@@ -274,30 +334,84 @@ private fun ImportKeyDialog(
 ) {
     var armoredKey by remember { mutableStateOf("") }
 
-    AlertDialog(
+    Dialog(
         onDismissRequest = onDismiss,
-        title = { Text("Import PGP Key", fontWeight = FontWeight.SemiBold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Paste the ASCII-armored PGP key below.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                OutlinedTextField(
-                    value = armoredKey,
-                    onValueChange = { armoredKey = it },
-                    label = { Text("Armored Key") },
-                    minLines = 6,
-                    modifier = Modifier.fillMaxWidth()
-                )
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Import PGP Key",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Column(
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            "Paste the ASCII-armored PGP key below.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        OutlinedTextField(
+                            value = armoredKey,
+                            onValueChange = { armoredKey = it },
+                            label = { Text("Armored Key") },
+                            minLines = 6,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = onDismiss) { Text("Cancel") }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        TextButton(onClick = { onImport(armoredKey) }, enabled = armoredKey.isNotBlank()) {
+                            Text("Import")
+                        }
+                    }
+                }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = { onImport(armoredKey) }, enabled = armoredKey.isNotBlank()) {
-                Text("Import")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
         }
-    )
+    }
 }
 
 @Composable
@@ -308,40 +422,94 @@ private fun ExportKeyDialog(
 ) {
     val context = LocalContext.current
 
-    AlertDialog(
+    Dialog(
         onDismissRequest = onDismiss,
-        title = { Text("Public Key", fontWeight = FontWeight.SemiBold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Copy this key to share with others.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Surface(
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    modifier = Modifier.fillMaxWidth()
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Surface(
+                shape = cornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    .clickable(onClick = {})
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text(
-                        text = armoredKey,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = FontFamily.Monospace,
-                        modifier = Modifier.padding(12.dp),
-                        maxLines = 10,
-                        overflow = TextOverflow.Ellipsis
+                    Box(
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f), CircleShape)
                     )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Public Key",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Column(
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            "Copy this key to share with others.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Surface(
+                            shape = cornerShape(12.dp),
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                text = armoredKey,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontFamily = FontFamily.Monospace,
+                                modifier = Modifier.padding(12.dp),
+                                maxLines = 10,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = onDismiss) { Text("Close") }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        TextButton(onClick = {
+                            val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                            clipboard.setPrimaryClip(android.content.ClipData.newPlainText("PGP Public Key", armoredKey))
+                            android.widget.Toast.makeText(context, "Copied to clipboard", android.widget.Toast.LENGTH_SHORT).show()
+                            onCopied()
+                        }) {
+                            Text("Copy to Clipboard")
+                        }
+                    }
                 }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                clipboard.setPrimaryClip(android.content.ClipData.newPlainText("PGP Public Key", armoredKey))
-                android.widget.Toast.makeText(context, "Copied to clipboard", android.widget.Toast.LENGTH_SHORT).show()
-                onCopied()
-            }) {
-                Text("Copy to Clipboard")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
         }
-    )
+    }
 }

--- a/full_release_notes.md
+++ b/full_release_notes.md
@@ -1,0 +1,17 @@
+## What's Changed
+
+### Features & Improvements
+- **Email Loading:** Optimized email detail loading with asynchronous HTML parsing, WebView fade-in animations, and pre-warmed Chromium instances for smoother reading.
+- **Architecture:** Completed a major architectural overhaul, modularizing the application into distinct `core` and `feature` modules for better maintainability and optimized build times.
+- **Distribution:** Abstracted authentication logic to support specific builds (like GitHub vs. Play Store). 
+
+### Bug Fixes
+- **Launch Crash:** Fixed a critical crash on launch related to missing HiltWorker processing and incorrect resource identifiers.
+- **Notifications:** Restored the custom Monomail notification icon that was previously falling back to the generic Android icon.
+- **Settings:** The Settings screen now accurately displays the application version directly from the Android `PackageManager`.
+- **Release Build:** Fixed a resource linking failure that was preventing successful release builds in the `auth` feature module.
+- **Release Pipeline:** Fixed several automated release workflow issues, including the generation of accurate Play Store release notes directly from Pull Request descriptions and previous release context.
+
+### Maintenance
+- Removed deprecated `FORCE_DARK` and `FORCE_LIGHT` email theme options.
+- Updated Play Store automated deployment tracks and stripped unsupported language tags from release notes.

--- a/new_release_notes.md
+++ b/new_release_notes.md
@@ -1,0 +1,5 @@
+## What's Changed
+
+### Architecture & Distribution
+- Abstracted authentication logic to support flavor-specific implementations.
+- Fixed a resource linking failure affecting the `auth` module during release builds.


### PR DESCRIPTION
## Summary

Comprehensive UI overhaul across the app:

### New Features
- Added **Inline Images** setting (split from showInlineAttachments)
- **Corner Style** global setting (Square/Rounded/Extra Rounded) applied across 70+ locations
- Converted all PGP dialogs (Generate/Import/Export) to **SlideSheet** pattern

### Bug Fixes
- **Discord icon**: Replaced broken  with  SVG in SupportSettingsScreen
- **Search focus**: Fixed persistence by adding BackHandler + clearFocus
- **Undo Send**: Fixed countdown restart on settings change (SharedFlow replay 0)
- **MoreTabsButton shadow**: Removed redundant  that was clipping the elevation shadow
- **FAB shift**: Converted BottomFabArea from Row to Box layout so FAB is anchored to screen edge, not BottomDockBar width
- **Attachment list overlap**: Wrapped in Column inside BoxWithConstraints
- **formatFileSize**: Shows 'Unknown size' for 0/negative sizes

### Design Changes
- Redesigned ProviderSheet, ModalOverlay (top sheet), CrashScreen (humorous full-screen)
- AttachmentPickerSheet, PickerBottomSheet → floating SlideSheet pattern
- Templates modal + editor → SlideSheet
- Dock bar tabs/buttons now respect global corner style
- TopAlertBanner decoupled undo toast from search bar

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->