### PR TITLE
feat: attachment preview module with in-app viewer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,7 @@ dependencies {
     implementation(project(":feature:detail"))
     implementation(project(":feature:compose"))
     implementation(project(":feature:settings"))
+    implementation(project(":feature:attachment"))
 
     // Networking (now decoupled)
     implementation(project(":core:network"))

--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -57,6 +57,7 @@ import com.shrivatsav.monomail.feature.inbox.scheduled.ScheduledMessagesViewMode
 import com.shrivatsav.monomail.feature.settings.pgp.PgpKeyManagementScreen
 import com.shrivatsav.monomail.feature.settings.SettingsScreen
 import com.shrivatsav.monomail.feature.settings.SettingsViewModel
+import com.shrivatsav.monomail.feature.attachment.AttachmentViewerScreen
 
 sealed class Screen(val route: String) {
     object Onboarding   : Screen("onboarding")
@@ -86,6 +87,13 @@ sealed class Screen(val route: String) {
         fun createRoute(type: String) = "legal/$type"
     }
     object PgpKeys : Screen("pgp_keys")
+    object AttachmentViewer : Screen("attachment-viewer/{messageId}/{attachmentId}?mimeType={mimeType}&name={name}") {
+        fun createRoute(messageId: String, attachmentId: String, mimeType: String, name: String): String {
+            val enc = { s: String -> Uri.encode(s) }
+            return "attachment-viewer/${enc(messageId)}/${enc(attachmentId)}?mimeType=${enc(mimeType)}&name=${enc(name)}"
+        }
+    }
+    object SampleCompose : Screen("sample-compose")
 }
 
 private fun openLegalUrl(context: android.content.Context, type: String) {
@@ -339,6 +347,9 @@ fun NavGraph(
                     onNavigateToLegal = { type -> openLegalUrl(ctx, type) },
                     onNavigateToPgpKeys = {
                         navController.navigate(Screen.PgpKeys.route) { launchSingleTop = true }
+                    },
+                    onNavigateToSampleCompose = {
+                        navController.navigate(Screen.SampleCompose.route) { launchSingleTop = true }
                     }
                 )
             }
@@ -389,6 +400,11 @@ fun NavGraph(
                     },
                     onFetchAttachment = { messageId, attachmentId ->
                         vm.fetchAttachmentBytes(messageId, attachmentId)
+                    },
+                    onNavigateToAttachmentViewer = { messageId, attachmentId, mimeType, name ->
+                        navController.navigate(
+                            Screen.AttachmentViewer.createRoute(messageId, attachmentId, mimeType, name)
+                        )
                     }
                 )
             }
@@ -428,6 +444,55 @@ fun NavGraph(
                             )
                         )
                     }
+                )
+            }
+            composable(
+                route = Screen.AttachmentViewer.route,
+                arguments = listOf(
+                    navArgument("messageId") { type = NavType.StringType },
+                    navArgument("attachmentId") { type = NavType.StringType },
+                    navArgument("mimeType") { type = NavType.StringType; defaultValue = "application/octet-stream" },
+                    navArgument("name") { type = NavType.StringType; defaultValue = "attachment" }
+                )
+            ) {
+                AttachmentViewerScreen(
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            composable(Screen.SampleCompose.route) {
+                val vm: ComposeViewModel = hiltViewModel()
+                val packageName = LocalContext.current.packageName
+                val sampleUri = { res: String -> android.net.Uri.parse("android.resource://$packageName/drawable/$res") }
+                LaunchedEffect(Unit) {
+                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
+                        uri = sampleUri("ic_launcher_foreground"),
+                        name = "Sample Image.png",
+                        size = 24576,
+                        mimeType = "image/png"
+                    ))
+                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
+                        uri = sampleUri("ic_launcher_foreground"),
+                        name = "Report.pdf",
+                        size = 102400,
+                        mimeType = "application/pdf"
+                    ))
+                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
+                        uri = sampleUri("ic_launcher_foreground"),
+                        name = "Demo Video.mp4",
+                        size = 5242880,
+                        mimeType = "video/mp4"
+                    ))
+                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
+                        uri = sampleUri("ic_launcher_foreground"),
+                        name = "Document.docx",
+                        size = 48256,
+                        mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                    ))
+                }
+                ComposeScreen(
+                    viewModel = vm,
+                    onBack = { navController.popBackStack() },
+                    onSent = { navController.popBackStack() }
                 )
             }
         }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/attachment/AttachmentCacheManager.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/attachment/AttachmentCacheManager.kt
@@ -1,0 +1,103 @@
+package com.shrivatsav.monomail.core.data.attachment
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import androidx.core.net.toFile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Manages temporary cached attachment files on disk.
+ *
+ * Bytes are written to [cacheDir]/attachments/ and exposed via FileProvider
+ * so Media3, PdfRenderer, and other platform APIs can consume them from a Uri.
+ * Reuses the same [cacheDir]/attachments/ directory and FileProvider authority
+ * that the existing [openAttachment] flow in EmailDetailScreen already uses.
+ */
+@Singleton
+class AttachmentCacheManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val cacheDir: File
+        get() = File(context.cacheDir, "attachments").also { it.mkdirs() }
+
+    /**
+     * Write [bytes] to a temp file and return a content:// URI.
+     * Existing file for the same (messageId, attachmentId) is overwritten.
+     */
+    fun cacheBytes(
+        messageId: String,
+        attachmentId: String,
+        name: String,
+        bytes: ByteArray
+    ): Uri {
+        val file = resolveFile(messageId, attachmentId, name)
+        file.writeBytes(bytes)
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file
+        )
+    }
+
+    /**
+     * Return a cached URI if the file exists, or null.
+     */
+    fun getCachedUri(
+        messageId: String,
+        attachmentId: String,
+        name: String
+    ): Uri? {
+        val file = resolveFile(messageId, attachmentId, name)
+        if (!file.exists()) return null
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file
+        )
+    }
+
+    /**
+     * Write bytes and return the underlying [File].
+     * Useful for APIs that need a file path (PdfRenderer).
+     */
+    fun cacheFile(
+        messageId: String,
+        attachmentId: String,
+        name: String,
+        bytes: ByteArray
+    ): File {
+        val file = resolveFile(messageId, attachmentId, name)
+        file.writeBytes(bytes)
+        return file
+    }
+
+    /**
+     * Remove stale cached files whose ids are not in [keepIds].
+     * Called by the ViewModel when the viewer closes.
+     */
+    fun cleanExcept(keepIds: Set<String>) {
+        cacheDir.listFiles()?.forEach { file ->
+            val prefix = file.name.substringBeforeLast('_', "")
+            if (prefix.isNotEmpty() && prefix !in keepIds) {
+                file.delete()
+            }
+        }
+    }
+
+    /**
+     * Build a file with a short name to avoid ENAMETOOLONG on long email IDs.
+     * Pattern: <mid_short>_<aid_short>_<safe_name>
+     */
+    private fun resolveFile(messageId: String, attachmentId: String, name: String): File {
+        val safeName = name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+        val mid = messageId.take(12)
+        val aid = attachmentId.take(12)
+        val file = File(cacheDir, "${mid}_${aid}_$safeName")
+        return file
+    }
+
+}

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
@@ -25,6 +25,7 @@ import com.shrivatsav.monomail.core.network.provider.ProviderThreadListResult
 import com.shrivatsav.monomail.core.network.provider.ResourceNotFoundException
 import com.shrivatsav.monomail.core.network.provider.SendAsAlias
 import com.shrivatsav.monomail.core.network.provider.SendEmailOptions
+import com.shrivatsav.monomail.core.network.provider.SendEmailResult
 import com.shrivatsav.monomail.core.network.remote.RetrofitClient
 import com.shrivatsav.monomail.model.InboxTab
 import com.shrivatsav.monomail.util.cleanSubject
@@ -461,21 +462,21 @@ class EmailRepository(
         body: String,
         params: SendEmailParams = SendEmailParams(),
         explicitAccountId: String? = null
-    ): Result<String> {
+    ): Result<SendEmailResult> {
         return try {
             val targetAccountId = explicitAccountId ?: getActiveAccountId()
             val provider = (if (explicitAccountId != null) getProviderForAccount(explicitAccountId) else getActiveProvider()) ?: return Result.failure(Exception(NO_ACTIVE_PROVIDER))
-            val sentThreadId = provider.sendEmail(
+            val result = provider.sendEmail(
                 from = from,
                 to = to,
                 subject = subject,
                 body = body,
                 options = SendEmailOptions(cc = params.cc, bcc = params.bcc, threadId = params.threadId, inReplyToMessageId = params.inReplyToMessageId, references = params.references, attachments = params.attachments)
-            )
-            val actualThreadId = sentThreadId ?: UUID.randomUUID().toString()
+            ) ?: return Result.failure(Exception("Send returned null — email was not sent"))
+            val actualThreadId = result.threadId ?: UUID.randomUUID().toString()
+            val actualMsgId = result.messageId ?: UUID.randomUUID().toString()
             // ponytail: DB insert is best-effort — email already sent to server, don't report false failure
             try {
-                val msgId = UUID.randomUUID().toString()
                 val now = System.currentTimeMillis()
                 val domainThread = EmailThread(
                     threadId = actualThreadId,
@@ -487,11 +488,11 @@ class EmailRepository(
                     messageCount = 1,
                     isRead = true,
                     isStarred = false,
-                    latestMessageId = msgId,
+                    latestMessageId = actualMsgId,
                     participants = listOf(from, to)
                 )
                 val domainEmail = Email(
-                    id = msgId,
+                    id = actualMsgId,
                     threadId = actualThreadId,
                     subject = subject,
                     from = from,
@@ -505,7 +506,7 @@ class EmailRepository(
                     isRead = true,
                     isStarred = false,
                     labels = listOf(EmailFolder.SENT.name),
-                    attachments = params.attachments.map { com.shrivatsav.monomail.data.model.EmailAttachmentInfo(id = it.name, messageId = msgId, name = it.name, mimeType = it.mimeType, size = it.size.toInt()) }
+                    attachments = params.attachments.map { com.shrivatsav.monomail.data.model.EmailAttachmentInfo(id = it.name, messageId = actualMsgId, name = it.name, mimeType = it.mimeType, size = it.size.toInt()) }
                 )
                 database.withTransaction {
                     threadDao.insertThreads(listOf(domainThread.toEntity(targetAccountId, inInbox = false, inSent = true, inArchived = false, inTrash = false, inSpam = false)))
@@ -514,7 +515,7 @@ class EmailRepository(
             } catch (e: Exception) {
                 Log.w("EmailRepo", "DB insert after send failed (email was sent)", e)
             }
-            Result.success(actualThreadId)
+            Result.success(result)
         } catch (e: Exception) {
             Log.e("EmailRepo", "sendEmail failed", e)
             Result.failure(e)

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/AttachmentPreviewCard.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/AttachmentPreviewCard.kt
@@ -1,0 +1,310 @@
+package com.shrivatsav.monomail.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AttachFile
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.FolderZip
+import androidx.compose.material.icons.rounded.Image
+import androidx.compose.material.icons.rounded.PictureAsPdf
+import androidx.compose.material.icons.rounded.VideoFile
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.shrivatsav.monomail.ui.theme.cornerShape
+
+/**
+ * Shared preview card for attachments, used in both Compose-screen (THUMBNAIL mode)
+ * and Detail-screen (DETAIL / FILE_GRID modes).
+ *
+ * @param category classified attachment type — controls icon, color, thumbnail behavior
+ * @param mode THUMBNAIL = 100dp square for compose LazyRow; DETAIL = full-width card for detail screen
+ * @param thumbnailUri optional image URI for thumbnail preview (images, video frames)
+ * @param onRemove optional — shows X button (compose mode)
+ * @param onClick optional — tap action (detail mode preview or external open)
+ */
+@Composable
+fun AttachmentPreviewCard(
+    name: String,
+    mimeType: String,
+    size: Long,
+    category: AttachmentCategory = classifyAttachment(mimeType, name),
+    mode: PreviewMode = PreviewMode.THUMBNAIL,
+    thumbnailUri: Any? = null,
+    isFetching: Boolean = false,
+    onRemove: (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    when (mode) {
+        PreviewMode.THUMBNAIL -> ThumbnailPreview(
+            name = name,
+            category = category,
+            thumbnailUri = thumbnailUri,
+            isFetching = isFetching,
+            onRemove = onRemove,
+            onClick = onClick,
+            modifier = modifier
+        )
+
+        PreviewMode.DETAIL -> DetailPreview(
+            name = name,
+            size = size,
+            category = category,
+            isFetching = isFetching,
+            onClick = onClick,
+            modifier = modifier
+        )
+    }
+}
+
+enum class PreviewMode { THUMBNAIL, DETAIL }
+
+// ─── Thumbnail (100dp square for compose row) ─────────────────────────────────
+
+@Composable
+private fun ThumbnailPreview(
+    name: String,
+    category: AttachmentCategory,
+    thumbnailUri: Any?,
+    isFetching: Boolean,
+    onRemove: (() -> Unit)?,
+    onClick: (() -> Unit)?,
+    modifier: Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(100.dp)
+            .clip(cornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+    ) {
+        when {
+            category == AttachmentCategory.IMAGE && thumbnailUri != null -> {
+                AsyncImage(
+                    model = thumbnailUri,
+                    contentDescription = name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            category == AttachmentCategory.VIDEO -> {
+                if (thumbnailUri != null) {
+                    AsyncImage(
+                        model = thumbnailUri,
+                        contentDescription = name,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    CategoryIconTile(category = category, iconSize = 36.dp)
+                }
+                // Play icon overlay
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(Color.Black.copy(alpha = 0.5f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.AttachFile,
+                        contentDescription = "Play",
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+
+            else -> CategoryIconTile(category = category, iconSize = 36.dp)
+        }
+
+        // Filename label at bottom for non-image thumbnails
+        if (category != AttachmentCategory.IMAGE) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .padding(6.dp)
+            )
+        }
+
+        // Remove button
+        if (onRemove != null) {
+            IconButton(
+                onClick = onRemove,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .size(24.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f),
+                        CircleShape
+                    )
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = "Remove",
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Loading spinner
+        if (isFetching) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(22.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                )
+            }
+        }
+    }
+}
+
+// ─── Detail (full-width card for detail screen) ───────────────────────────────
+
+@Composable
+private fun DetailPreview(
+    name: String,
+    size: Long,
+    category: AttachmentCategory,
+    isFetching: Boolean,
+    onClick: (() -> Unit)?,
+    modifier: Modifier
+) {
+    val (icon, color) = categoryIconAndColor(category)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(cornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Category badge
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(cornerShape(10.dp))
+                .background(color),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = formatFileSize(size),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+            )
+        }
+
+        if (isFetching) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+            )
+        }
+    }
+}
+
+// ─── Category icon tile (for THUMBNAIL mode fallback) ────────────────────────
+
+@Composable
+private fun CategoryIconTile(
+    category: AttachmentCategory,
+    iconSize: Dp
+) {
+    val (icon, color) = categoryIconAndColor(category)
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(iconSize)
+            )
+        }
+    }
+}
+
+// ─── Icon + colour mapping ────────────────────────────────────────────────────
+
+private fun categoryIconAndColor(category: AttachmentCategory): Pair<ImageVector, Color> = when (category) {
+    AttachmentCategory.IMAGE -> Icons.Rounded.Image to Color(0xFF4CAF50)
+    AttachmentCategory.VIDEO -> Icons.Rounded.VideoFile to Color(0xFFE53935)
+    AttachmentCategory.PDF -> Icons.Rounded.PictureAsPdf to Color(0xFFE53935)
+    AttachmentCategory.ARCHIVE -> Icons.Rounded.FolderZip to Color(0xFFFF9800)
+    AttachmentCategory.CODE -> Icons.Rounded.Description to Color(0xFF2196F3)
+    AttachmentCategory.UNKNOWN -> Icons.Rounded.AttachFile to Color(0xFF9E9E9E)
+}

--- a/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/AttachmentType.kt
+++ b/core/designsystem/src/main/java/com/shrivatsav/monomail/ui/components/AttachmentType.kt
@@ -1,0 +1,76 @@
+package com.shrivatsav.monomail.ui.components
+
+import java.util.Locale
+
+enum class AttachmentCategory {
+    IMAGE,
+    VIDEO,
+    PDF,
+    ARCHIVE,
+    CODE,
+    UNKNOWN
+}
+
+fun classifyAttachment(mimeType: String, name: String): AttachmentCategory {
+    val mt = mimeType.lowercase()
+    val lower = name.lowercase()
+
+    if (mt.startsWith("image/") ||
+        lower.endsWith(".png") || lower.endsWith(".jpg") ||
+        lower.endsWith(".jpeg") || lower.endsWith(".gif") ||
+        lower.endsWith(".webp") || lower.endsWith(".bmp") ||
+        lower.endsWith(".svg")
+    ) return AttachmentCategory.IMAGE
+
+    if (mt.startsWith("video/") ||
+        lower.endsWith(".mp4") || lower.endsWith(".mov") ||
+        lower.endsWith(".avi") || lower.endsWith(".mkv") ||
+        lower.endsWith(".webm") || lower.endsWith(".3gp")
+    ) return AttachmentCategory.VIDEO
+
+    if (mt == "application/pdf" || lower.endsWith(".pdf")) return AttachmentCategory.PDF
+
+    if (mt.startsWith("application/") && (
+                mt.contains("zip") || mt.contains("rar") || mt.contains("tar") ||
+                mt.contains("gzip") || mt.contains("7z") || mt.contains("compress")
+                ) ||
+        lower.endsWith(".zip") || lower.endsWith(".rar") ||
+        lower.endsWith(".7z") || lower.endsWith(".tar") ||
+        lower.endsWith(".gz")
+    ) return AttachmentCategory.ARCHIVE
+
+    if (mt.startsWith("text/") ||
+        lower.endsWith(".kt") || lower.endsWith(".java") ||
+        lower.endsWith(".py") || lower.endsWith(".js") ||
+        lower.endsWith(".ts") || lower.endsWith(".xml") ||
+        lower.endsWith(".json") || lower.endsWith(".yml") ||
+        lower.endsWith(".yaml") || lower.endsWith(".html") ||
+        lower.endsWith(".css") || lower.endsWith(".sh") ||
+        lower.endsWith(".md") || lower.endsWith(".sql")
+    ) return AttachmentCategory.CODE
+
+    return AttachmentCategory.UNKNOWN
+}
+
+fun isPreviewableInApp(category: AttachmentCategory): Boolean = when (category) {
+    AttachmentCategory.IMAGE,
+    AttachmentCategory.VIDEO,
+    AttachmentCategory.PDF -> true
+    else -> false
+}
+
+fun isImageAttachment(mimeType: String, name: String): Boolean =
+    classifyAttachment(mimeType, name) == AttachmentCategory.IMAGE
+
+fun isVideoAttachment(mimeType: String, name: String): Boolean =
+    classifyAttachment(mimeType, name) == AttachmentCategory.VIDEO
+
+fun isPdfAttachment(mimeType: String, name: String): Boolean =
+    classifyAttachment(mimeType, name) == AttachmentCategory.PDF
+
+fun formatFileSize(bytes: Long): String = when {
+    bytes >= 1024 * 1024 -> String.format(Locale.getDefault(), "%.1f MB", bytes / (1024.0 * 1024.0))
+    bytes >= 1024 -> "${bytes / 1024} KB"
+    bytes > 0 -> "$bytes B"
+    else -> "Unknown size"
+}

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/EmailProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/EmailProvider.kt
@@ -10,6 +10,11 @@ data class SendEmailOptions(
     val attachments: List<EmailAttachment> = emptyList()
 )
 
+data class SendEmailResult(
+    val messageId: String?,
+    val threadId: String?
+)
+
 interface EmailProvider {
     val providerName: String  
     suspend fun listThreads(
@@ -31,7 +36,7 @@ interface EmailProvider {
     suspend fun sendEmail(
         from: String, to: String, subject: String, body: String,
         options: SendEmailOptions = SendEmailOptions()
-    ): String?
+    ): SendEmailResult?
 
     suspend fun getSendAsAliases(): List<SendAsAlias>
 }

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/GmailProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/GmailProvider.kt
@@ -280,7 +280,7 @@ class GmailProvider(
         subject: String,
         body: String,
         options: SendEmailOptions
-    ): String? = withContext(Dispatchers.IO) {
+    ): SendEmailResult? = withContext(Dispatchers.IO) {
         try {
             val session = Session.getInstance(Properties())
             val message = MimeMessage(session).apply {
@@ -317,7 +317,7 @@ class GmailProvider(
                 android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP
             )
             val response = api.sendMessage(SendMessageRequest(raw = raw, threadId = options.threadId))
-            response.threadId
+            SendEmailResult(messageId = response.id, threadId = response.threadId)
         } catch (e: HttpException) {
             val msg = when (e.code()) {
                 400 -> "Invalid message format"

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/OutlookProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/OutlookProvider.kt
@@ -307,7 +307,7 @@ class OutlookProvider(
         subject: String,
         body: String,
         options: SendEmailOptions
-    ): String? {
+    ): SendEmailResult? {
         val recipients = parseRecipients(to)
         val ccRecipients = options.cc.takeIf { it.isNotBlank() }?.let { parseRecipients(it) }
         val bccRecipients = options.bcc.takeIf { it.isNotBlank() }?.let { parseRecipients(it) }
@@ -322,7 +322,8 @@ class OutlookProvider(
             attachments = draftAttachments.takeIf { it.isNotEmpty() }
         )
         api.sendMail(OutlookSendMailRequest(msg))
-        return options.threadId ?: UUID.randomUUID().toString()
+        val threadId = options.threadId ?: UUID.randomUUID().toString()
+        return SendEmailResult(messageId = null, threadId = threadId)
     }
 
     private fun parseRecipients(csv: String): List<OutlookRecipient> {

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
@@ -10,6 +10,7 @@ import com.shrivatsav.monomail.core.network.provider.SendEmailOptions
 import com.shrivatsav.monomail.core.network.provider.ProviderThread
 import com.shrivatsav.monomail.core.network.provider.ProviderThreadListResult
 import com.shrivatsav.monomail.core.network.provider.SendAsAlias
+import com.shrivatsav.monomail.core.network.provider.SendEmailResult
 import jakarta.mail.Flags
 import jakarta.mail.Folder
 import jakarta.mail.Message
@@ -536,17 +537,16 @@ class ImapProvider(
         subject: String,
         body: String,
         options: SendEmailOptions
-    ): String? = withContext(Dispatchers.IO) {
+    ): SendEmailResult? = withContext(Dispatchers.IO) {
         val props = buildSmtpProps(from)
         val session = Session.getInstance(props, object : jakarta.mail.Authenticator() {
             override fun getPasswordAuthentication() = jakarta.mail.PasswordAuthentication(config.username, password)
         })
 
         val message = buildMimeMessage(session, from, to, subject, body, options)
-
         Transport.send(message)
         saveToSentFolder(message)
-        message.messageID
+        SendEmailResult(messageId = message.messageID, threadId = message.messageID)
     }
 
     private fun buildMimeMessage(

--- a/feature/attachment/build.gradle.kts
+++ b/feature/attachment/build.gradle.kts
@@ -1,0 +1,74 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+}
+
+android {
+    namespace = "com.shrivatsav.monomail.feature.attachment"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    flavorDimensions += "distribution"
+
+    productFlavors {
+        create("github") {
+            dimension = "distribution"
+        }
+        create("playstore") {
+            dimension = "distribution"
+        }
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+dependencies {
+    implementation(project(":core:model"))
+    implementation(project(":core:data"))
+    implementation(project(":core:designsystem"))
+
+    implementation(libs.androidx.core.ktx)
+
+    // Compose
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material.icons)
+
+    // Media3 (ExoPlayer)
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.ui)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.hilt.navigation.compose)
+
+    // Coil
+    implementation(libs.coil.compose)
+}

--- a/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/AttachmentViewerScreen.kt
+++ b/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/AttachmentViewerScreen.kt
@@ -1,0 +1,130 @@
+package com.shrivatsav.monomail.feature.attachment
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.shrivatsav.monomail.ui.components.AttachmentCategory
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AttachmentViewerScreen(
+    viewModel: AttachmentViewerViewModel = hiltViewModel(),
+    onBack: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+
+    when (val s = state) {
+        is AttachmentViewerState.Loading -> {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { },
+                        navigationIcon = {
+                            androidx.compose.material3.IconButton(onClick = onBack) {
+                                androidx.compose.material3.Icon(
+                                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                                    contentDescription = "Back"
+                                )
+                            }
+                        },
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.surface
+                        )
+                    )
+                }
+            ) { padding ->
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+
+        is AttachmentViewerState.Ready -> {
+            when (s.category) {
+                AttachmentCategory.IMAGE -> PhotoViewerScreen(
+                    uri = s.uri,
+                    name = s.name,
+                    onBack = onBack
+                )
+
+                AttachmentCategory.VIDEO -> VideoPlayerScreen(
+                    uri = s.uri,
+                    name = s.name,
+                    onBack = onBack
+                )
+
+                AttachmentCategory.PDF -> PdfViewerScreen(
+                    file = s.file,
+                    name = s.name,
+                    onBack = onBack
+                )
+
+                else -> FallbackScreen(
+                    name = s.name,
+                    mimeType = "",
+                    size = 0,
+                    bytes = null,
+                    onBack = onBack
+                )
+            }
+        }
+
+        is AttachmentViewerState.Fallback -> FallbackScreen(
+            name = s.name,
+            mimeType = s.mimeType,
+            size = s.size,
+            bytes = s.bytes,
+            onBack = onBack
+        )
+
+        is AttachmentViewerState.Error -> {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { Text("Attachment") },
+                        navigationIcon = {
+                            androidx.compose.material3.IconButton(onClick = onBack) {
+                                androidx.compose.material3.Icon(
+                                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                                    contentDescription = "Back"
+                                )
+                            }
+                        },
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.surface
+                        )
+                    )
+                }
+            ) { padding ->
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = s.message,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/AttachmentViewerViewModel.kt
+++ b/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/AttachmentViewerViewModel.kt
@@ -1,0 +1,108 @@
+package com.shrivatsav.monomail.feature.attachment
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shrivatsav.monomail.core.data.attachment.AttachmentCacheManager
+import com.shrivatsav.monomail.core.data.repository.EmailRepository
+import com.shrivatsav.monomail.ui.components.AttachmentCategory
+import com.shrivatsav.monomail.ui.components.classifyAttachment
+import com.shrivatsav.monomail.ui.components.isPreviewableInApp
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+
+sealed class AttachmentViewerState {
+    data object Loading : AttachmentViewerState()
+    data class Ready(
+        val category: AttachmentCategory,
+        val uri: android.net.Uri,
+        val file: File,
+        val name: String
+    ) : AttachmentViewerState()
+
+    data class Fallback(
+        val name: String,
+        val mimeType: String,
+        val size: Long,
+        val bytes: ByteArray?
+    ) : AttachmentViewerState()
+
+    data class Error(val message: String) : AttachmentViewerState()
+}
+
+@HiltViewModel
+class AttachmentViewerViewModel @Inject constructor(
+    private val repository: EmailRepository,
+    private val cacheManager: AttachmentCacheManager,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val messageId: String = savedStateHandle["messageId"] ?: ""
+    private val attachmentId: String = savedStateHandle["attachmentId"] ?: ""
+    private val mimeType: String = savedStateHandle["mimeType"] ?: "application/octet-stream"
+    private val name: String = savedStateHandle["name"] ?: "attachment"
+
+    private val _state = MutableStateFlow<AttachmentViewerState>(AttachmentViewerState.Loading)
+    val state: StateFlow<AttachmentViewerState> = _state.asStateFlow()
+
+    init {
+        loadAttachment()
+    }
+
+    private fun loadAttachment() {
+        viewModelScope.launch {
+            _state.value = AttachmentViewerState.Loading
+            try {
+                val category = classifyAttachment(mimeType, name)
+                val bytes = withContext(Dispatchers.IO) {
+                    repository.getAttachmentBytes(messageId, attachmentId)
+                }
+
+                if (bytes == null || bytes.isEmpty()) {
+                    _state.value = AttachmentViewerState.Error("Failed to load attachment")
+                    return@launch
+                }
+
+                if (isPreviewableInApp(category)) {
+                    val file = withContext(Dispatchers.IO) {
+                        cacheManager.cacheFile(messageId, attachmentId, name, bytes)
+                    }
+                    val uri = withContext(Dispatchers.IO) {
+                        cacheManager.cacheBytes(messageId, attachmentId, name, bytes)
+                    }
+                    _state.value = AttachmentViewerState.Ready(
+                        category = category,
+                        uri = uri,
+                        file = file,
+                        name = name
+                    )
+                } else {
+                    _state.value = AttachmentViewerState.Fallback(
+                        name = name,
+                        mimeType = mimeType,
+                        size = bytes.size.toLong(),
+                        bytes = bytes
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e("AttachmentViewerVM", "Failed to load attachment", e)
+                _state.value = AttachmentViewerState.Error(
+                    e.message ?: "Unknown error loading attachment"
+                )
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        cacheManager.cleanExcept(emptySet())
+    }
+}

--- a/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/FallbackScreen.kt
+++ b/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/FallbackScreen.kt
@@ -1,0 +1,179 @@
+package com.shrivatsav.monomail.feature.attachment
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.rounded.AttachFile
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.OpenInNew
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import com.shrivatsav.monomail.ui.components.formatFileSize
+import java.io.File
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FallbackScreen(
+    name: String,
+    mimeType: String,
+    size: Long,
+    bytes: ByteArray?,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.AttachFile,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                modifier = Modifier.size(64.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            if (size > 0) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = formatFileSize(size),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Preview not available for this file type.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Open in app
+            if (bytes != null) {
+                Button(
+                    onClick = {
+                        val safeName = name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+                        val dir = File(context.cacheDir, "attachments")
+                        dir.mkdirs()
+                        val file = File(dir, safeName)
+                        file.writeBytes(bytes)
+                        val uri = FileProvider.getUriForFile(
+                            context,
+                            "${context.packageName}.fileprovider",
+                            file
+                        )
+                        val intent = Intent(Intent.ACTION_VIEW).apply {
+                            setDataAndType(uri, mimeType)
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        context.startActivity(Intent.createChooser(intent, "Open with..."))
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.OpenInNew,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text("Open in App")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Download
+            OutlinedButton(onClick = {
+                // Trigger download via ACTION_VIEW with no target — saves to cache
+                if (bytes != null) {
+                    val safeName = name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+                    val dir = File(context.cacheDir, "attachments")
+                    dir.mkdirs()
+                    val file = File(dir, safeName)
+                    file.writeBytes(bytes)
+                }
+            }) {
+                Icon(
+                    imageVector = Icons.Rounded.Download,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text("Saved to device")
+            }
+        }
+    }
+}

--- a/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/PdfViewerScreen.kt
+++ b/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/PdfViewerScreen.kt
@@ -1,0 +1,199 @@
+package com.shrivatsav.monomail.feature.attachment
+
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Size
+import java.io.File
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PdfViewerScreen(
+    file: File,
+    name: String,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    val renderer = remember(file) {
+        try {
+            val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            PdfRenderer(fd)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    val pageCount = renderer?.pageCount ?: 0
+
+    DisposableEffect(Unit) {
+        onDispose {
+            renderer?.close()
+        }
+    }
+
+    if (renderer == null || pageCount == 0) {
+        // Fallback — render PDF pages as images via Coil
+        PdfImageFallback(file = file, name = name, onBack = onBack)
+        return
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(Color(0xFF424242))
+        ) {
+            // Page indicator
+            Text(
+                text = "$pageCount page${if (pageCount != 1) "s" else ""}",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.7f),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                itemsIndexed(List(pageCount) { it }) { index, _ ->
+                    val pageBitmap = remember(index) {
+                        renderer.openPage(index).use { page ->
+                            val w = page.width.coerceAtMost(1200)
+                            val h = (page.height.toFloat() * (w.toFloat() / page.width.toFloat())).toInt()
+                            val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+                            page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                            bitmap
+                        }
+                    }
+
+                    pageBitmap?.let { bmp ->
+                        androidx.compose.foundation.Image(
+                            bitmap = bmp.asImageBitmap(),
+                            contentDescription = "Page ${index + 1}",
+                            contentScale = androidx.compose.ui.layout.ContentScale.FillWidth,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 8.dp, vertical = 4.dp)
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Fallback PDF rendering via Coil's built-in PDF decoder.
+ * Used when PdfRenderer is unavailable (e.g. very large file).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PdfImageFallback(
+    file: File,
+    name: String,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(Color(0xFF424242))
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(file)
+                    .size(Size.ORIGINAL)
+                    .build(),
+                contentDescription = name,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+}

--- a/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/PhotoViewerScreen.kt
+++ b/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/PhotoViewerScreen.kt
@@ -1,0 +1,103 @@
+package com.shrivatsav.monomail.feature.attachment
+
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import coil.compose.AsyncImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PhotoViewerScreen(
+    uri: Uri,
+    name: String,
+    onBack: () -> Unit
+) {
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+        // Image — zoomable & pannable
+        AsyncImage(
+            model = uri,
+            contentDescription = name,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offset.x,
+                    translationY = offset.y
+                )
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        scale = (scale * zoom).coerceIn(0.5f, 5f)
+                        offset = if (scale > 1f) {
+                            offset + pan
+                        } else {
+                            Offset.Zero
+                        }
+                    }
+                }
+                .pointerInput(Unit) {
+                    detectTapGestures(onDoubleTap = {
+                        scale = if (scale > 1.5f) 1f else 2.5f
+                        offset = Offset.Zero
+                    })
+                }
+        )
+
+        // Top bar overlay
+        TopAppBar(
+            title = {
+                Text(
+                    text = name,
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = Color.White
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color.Black.copy(alpha = 0.4f)
+            ),
+            modifier = Modifier.zIndex(1f)
+        )
+    }
+}

--- a/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/VideoPlayerScreen.kt
+++ b/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/VideoPlayerScreen.kt
@@ -1,0 +1,102 @@
+package com.shrivatsav.monomail.feature.attachment
+
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VideoPlayerScreen(
+    uri: Uri,
+    name: String,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val player = remember {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(MediaItem.fromUri(uri))
+            prepare()
+            playWhenReady = true
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            player.run {
+                playWhenReady = false
+                stop()
+                release()
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        player.playWhenReady = false
+                        onBack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(Color.Black)
+        ) {
+            AndroidView(
+                factory = { ctx ->
+                    PlayerView(ctx).apply {
+                        this.player = player
+                        useController = true
+                        setShowNextButton(false)
+                        setShowPreviousButton(false)
+                        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+}

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
@@ -169,7 +169,7 @@ fun SignInScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter),
         ) {
-            Snackbar(snackbarData = it)
+            Snackbar(snackbarData = it, shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp))
         }
 
         if (showProviderSheet) {

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
@@ -107,6 +107,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.toArgb
+import android.app.Activity
+import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.AlertDialog
@@ -152,6 +154,24 @@ private fun resolveAttachmentMimeType(contentResolver: android.content.ContentRe
         lower.endsWith(".webp") -> "image/webp"
         else -> mimeType
     }
+}
+
+private fun addPickedAttachment(
+    contentResolver: android.content.ContentResolver,
+    uri: Uri,
+    onResult: (name: String, size: Long, mimeType: String) -> Unit
+) {
+    var name = "attachment"
+    var size = 0L
+    contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+        if (cursor.moveToFirst()) {
+            val nameIdx = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+            val sizeIdx = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE)
+            if (nameIdx != -1) name = cursor.getString(nameIdx)
+            if (sizeIdx != -1) size = cursor.getLong(sizeIdx)
+        }
+    }
+    onResult(name, size, resolveAttachmentMimeType(contentResolver, uri, name))
 }
 
 @Composable
@@ -301,22 +321,35 @@ fun ComposeScreen(
     val showSentAnimation = remember { mutableStateOf(false) }
     val contentResolver = context.contentResolver
     var showAttachmentPicker by remember { mutableStateOf(false) }
-    val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetMultipleContents()
-    ) { uris: List<Uri> ->
-        uris.forEach { uri ->
-            var name = "attachment"
-            var size = 0L
-            contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                if (cursor.moveToFirst()) {
-                    val nameIdx = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                    val sizeIdx = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE)
-                    if (nameIdx != -1) name = cursor.getString(nameIdx)
-                    if (sizeIdx != -1) size = cursor.getLong(sizeIdx)
+    val photoVideoLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            result.data?.let { intentData ->
+                val clipData = intentData.clipData
+                if (clipData != null) {
+                    for (i in 0 until clipData.itemCount) {
+                        val uri = clipData.getItemAt(i).uri
+                        addPickedAttachment(contentResolver, uri) { name, size, mimeType ->
+                            viewModel.addAttachment(EmailAttachment(uri, name, size, mimeType))
+                        }
+                    }
+                } else {
+                    intentData.data?.let { uri ->
+                        addPickedAttachment(contentResolver, uri) { name, size, mimeType ->
+                            viewModel.addAttachment(EmailAttachment(uri, name, size, mimeType))
+                        }
+                    }
                 }
             }
-            viewModel.addAttachment(EmailAttachment(uri, name, size, resolveAttachmentMimeType(contentResolver, uri, name)))
         }
+    }
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris: List<Uri> ->
+        uris.forEach { uri -> addPickedAttachment(contentResolver, uri) { name, size, mimeType ->
+            viewModel.addAttachment(EmailAttachment(uri, name, size, mimeType))
+        } }
     }
     LaunchedEffect(state.isSent) {
         if (state.isSent) {
@@ -335,13 +368,19 @@ fun ComposeScreen(
     if (showAttachmentPicker) {
         AttachmentPickerSheet(
             onDismiss = { showAttachmentPicker = false },
-            onSelectImages = { 
+            onSelectImages = {
                 showAttachmentPicker = false
-                launcher.launch("image/*") 
+                val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    type = "image/*"
+                    putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("image/*", "video/*"))
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                }
+                photoVideoLauncher.launch(intent)
             },
-            onSelectFiles = { 
+            onSelectFiles = {
                 showAttachmentPicker = false
-                launcher.launch("*/*") 
+                filePickerLauncher.launch(arrayOf("*/*"))
             }
         )
     }
@@ -390,7 +429,7 @@ fun ComposeScreen(
         },
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) {
-                Snackbar(snackbarData = it)
+                Snackbar(snackbarData = it, shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp))
             }
         }
     ) { padding ->
@@ -1214,60 +1253,14 @@ fun AttachmentPreview(
     attachment: EmailAttachment,
     onRemove: () -> Unit
 ) {
-    val isImage = attachment.mimeType.startsWith("image/")
-    Box(
-        modifier = Modifier
-            .size(100.dp)
-            .clip(cornerShape(12.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-    ) {
-        if (isImage) {
-            AsyncImage(
-                model = attachment.uri,
-                contentDescription = attachment.name,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize()
-            )
-        } else {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(8.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Description,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(32.dp)
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = attachment.name,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
-                )
-            }
-        }
-        IconButton(
-            onClick = onRemove,
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(4.dp)
-                .size(24.dp)
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f), CircleShape)
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.Close,
-                contentDescription = "Remove",
-                modifier = Modifier.size(16.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
+    com.shrivatsav.monomail.ui.components.AttachmentPreviewCard(
+        name = attachment.name,
+        mimeType = attachment.mimeType,
+        size = attachment.size,
+        thumbnailUri = attachment.uri,
+        onRemove = onRemove,
+        mode = com.shrivatsav.monomail.ui.components.PreviewMode.THUMBNAIL
+    )
 }
 
 @Composable

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeViewModel.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeViewModel.kt
@@ -311,10 +311,10 @@ class ComposeViewModel @Inject constructor(
                 body = finalBody,
                 params = SendEmailParams(cc = current.cc, bcc = current.bcc, threadId = current.threadId, inReplyToMessageId = current.inReplyToMessageId, references = current.references, attachments = current.attachments)
             )
-            result.onSuccess { sentThreadId ->
+            result.onSuccess { sendResult ->
                 sentEmailEvents.tryEmit(
                     SentEmailEvent(
-                        threadId = sentThreadId,
+                        threadId = sendResult.threadId ?: "",
                         to = current.to,
                         subject = current.subject
                     )

--- a/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
+++ b/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
@@ -137,7 +137,8 @@ fun EmailDetailScreen(
     onBack: () -> Unit,
     onReply: (to: String, subject: String, body: String, threadId: String, messageId: String) -> Unit = { _, _, _, _, _ -> },
     onForward: (subject: String, body: String, threadId: String, messageId: String) -> Unit = { _, _, _, _ -> },
-    onFetchAttachment: suspend (String, String) -> ByteArray? = { _, _ -> null }
+    onFetchAttachment: suspend (String, String) -> ByteArray? = { _, _ -> null },
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit = { _, _, _, _ -> }
 ) {
     // Read settings from ViewModel (consolidated — no direct DataStore collection)
     val isConversationView by viewModel.isConversationView.collectAsState()
@@ -236,7 +237,8 @@ fun EmailDetailScreen(
             decryptedBodies = decryptedBodies,
             onReply = onReply,
             onForward = onForward,
-            onFetchAttachment = onFetchAttachment
+            onFetchAttachment = onFetchAttachment,
+            onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
         )
     }
 
@@ -250,7 +252,8 @@ private fun DetailContent(
     decryptedBodies: Map<String, PgpDecryptionResult>,
     onReply: (to: String, subject: String, body: String, threadId: String, messageId: String) -> Unit,
     onForward: (subject: String, body: String, threadId: String, messageId: String) -> Unit,
-    onFetchAttachment: suspend (String, String) -> ByteArray?
+    onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit
 ) {
     when (val s = state) {
         is EmailDetailState.Error -> {
@@ -349,7 +352,8 @@ private fun DetailContent(
                                     latestEmail.id
                                 )
                             },
-                            onFetchAttachment = onFetchAttachment
+                            onFetchAttachment = onFetchAttachment,
+                            onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
                         )
                     }
                 }
@@ -367,7 +371,8 @@ fun ThreadConversationContent(
     config: EmailDisplayConfig = EmailDisplayConfig(),
     onReply: () -> Unit = {},
     onForward: () -> Unit = {},
-    onFetchAttachment: suspend (String, String) -> ByteArray? = { _, _ -> null }
+    onFetchAttachment: suspend (String, String) -> ByteArray? = { _, _ -> null },
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit = { _, _, _, _ -> }
 ) {
     val expandedMap = remember(emails) {
         if (config.isConversationView) {
@@ -423,7 +428,8 @@ fun ThreadConversationContent(
                     onToggleExpand = { expandedMap[email.id] = !isExpanded },
                     config = config,
                     decryptedBodies = decryptedBodies,
-                    onFetchAttachment = onFetchAttachment
+                    onFetchAttachment = onFetchAttachment,
+                    onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
                 )
             } else {
                 MessageBody(
@@ -431,6 +437,7 @@ fun ThreadConversationContent(
                     decryptedResult = decryptedBodies[email.id],
                     config = config,
                     onFetchAttachment = onFetchAttachment,
+                    onNavigateToAttachmentViewer = onNavigateToAttachmentViewer,
                     showSender = true,
                     messageCount = emails.size
                 )
@@ -510,7 +517,8 @@ private fun ConversationEmailItem(
     onToggleExpand: () -> Unit,
     config: EmailDisplayConfig,
     decryptedBodies: Map<String, PgpDecryptionResult>,
-    onFetchAttachment: suspend (String, String) -> ByteArray?
+    onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit
 ) {
     Column {
         Row(
@@ -589,7 +597,8 @@ private fun ConversationEmailItem(
             val perEmailAttachments = email.attachments.map { it to displayName(email.from) }
             ThreadAttachmentsSummary(
                 attachmentsWithSender = perEmailAttachments,
-                onFetchAttachment = onFetchAttachment
+                onFetchAttachment = onFetchAttachment,
+                onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
             )
         }
         AnimatedVisibility(
@@ -597,16 +606,16 @@ private fun ConversationEmailItem(
             enter = fadeIn(tween(200)) + expandVertically(tween(200)),
             exit = fadeOut(tween(150)) + shrinkVertically(tween(150))
         ) {
-            ConversationEmailBody(email, index, config, decryptedBodies, onFetchAttachment)
+            ConversationEmailBody(email, index, config, decryptedBodies, onFetchAttachment, onNavigateToAttachmentViewer)
         }
     }
 }
-
 @Composable
 private fun ConversationEmailBody(
     email: Email, index: Int, config: EmailDisplayConfig,
     decryptedBodies: Map<String, PgpDecryptionResult>,
-    onFetchAttachment: suspend (String, String) -> ByteArray?
+    onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().background(
@@ -625,6 +634,7 @@ private fun ConversationEmailBody(
                 decryptedResult = decryptedBodies[email.id],
                 config = config,
                 onFetchAttachment = onFetchAttachment,
+                onNavigateToAttachmentViewer = onNavigateToAttachmentViewer,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -694,6 +704,7 @@ private fun MessageBody(
     decryptedResult: PgpDecryptionResult? = null,
     config: EmailDisplayConfig,
     onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit = { _, _, _, _ -> },
     showSender: Boolean = false,
     messageCount: Int = 0,
     modifier: Modifier = Modifier
@@ -719,7 +730,7 @@ private fun MessageBody(
             }
             return
         }
-        MessageBodyContent(email, safeBodyText, bodyIsHtml, config, showSender, messageCount, onFetchAttachment)
+        MessageBodyContent(email, safeBodyText, bodyIsHtml, config, showSender, messageCount, onFetchAttachment, onNavigateToAttachmentViewer)
     }
 }
 
@@ -727,7 +738,6 @@ private fun isEncryptedBlob(email: Email): Boolean =
     email.body.startsWith("-----BEGIN PGP MESSAGE-----") ||
             email.body.contains("multipart/encrypted;") ||
             email.body.contains("multipart/encrypted\r\n")
-
 @Composable
 private fun MessageBodyContent(
     email: Email,
@@ -736,7 +746,8 @@ private fun MessageBodyContent(
     config: EmailDisplayConfig,
     showSender: Boolean,
     messageCount: Int,
-    onFetchAttachment: suspend (String, String) -> ByteArray?
+    onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit
 ) {
     var showQuotedText by remember { mutableStateOf(false) }
     val hasQuotedText = remember(safeBodyText) { hasQuotedTextBlock(safeBodyText) }
@@ -747,7 +758,8 @@ private fun MessageBodyContent(
         Spacer(modifier = Modifier.height(8.dp))
         ThreadAttachmentsSummary(
             attachmentsWithSender = email.attachments.map { it to displayName(email.from) },
-            onFetchAttachment = onFetchAttachment
+            onFetchAttachment = onFetchAttachment,
+            onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
         )
         Spacer(modifier = Modifier.height(8.dp))
     }
@@ -805,7 +817,7 @@ private fun MessageBodyContent(
     }
     if (config.showInlineAttachments && email.attachments.isNotEmpty()) {
         Spacer(modifier = Modifier.height(16.dp))
-        AttachmentsSection(attachments = email.attachments, onFetchAttachment = onFetchAttachment)
+        AttachmentsSection(attachments = email.attachments, onFetchAttachment = onFetchAttachment, onNavigateToAttachmentViewer = onNavigateToAttachmentViewer)
     }
 }
 
@@ -1284,27 +1296,12 @@ private fun openAttachment(context: android.content.Context, attachment: EmailAt
     }
 }
 
-private fun isImageAttachment(attachment: EmailAttachmentInfo): Boolean {
-    val lowerName = attachment.name.lowercase()
-    return attachment.mimeType.startsWith("image/") ||
-            lowerName.endsWith(".png") || lowerName.endsWith(".jpg") ||
-            lowerName.endsWith(".jpeg") || lowerName.endsWith(".gif") ||
-            lowerName.endsWith(".webp")
-}
-
-private fun formatFileSize(bytes: Long): String {
-    return when {
-        bytes >= 1024 * 1024 -> String.format(Locale.getDefault(), "%.1f MB", bytes / (1024.0 * 1024.0))
-        bytes >= 1024 -> "${bytes / 1024} KB"
-        bytes > 0 -> "$bytes B"
-        else -> "Unknown size"
-    }
-}
 
 @Composable
 private fun AttachmentsSection(
     attachments: List<EmailAttachmentInfo>,
-    onFetchAttachment: suspend (String, String) -> ByteArray?
+    onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit = { _, _, _, _ -> }
 ) {
     Column(
         modifier = Modifier
@@ -1319,15 +1316,17 @@ private fun AttachmentsSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = 4.dp)
         )
-        val (imageAttachments, fileAttachments) = attachments.partition { isImageAttachment(it) }
+        val (imageAttachments, fileAttachments) = attachments.partition {
+            com.shrivatsav.monomail.ui.components.isImageAttachment(it.mimeType, it.name)
+        }
         imageAttachments.forEach { attachment ->
             ImageAttachmentCard(
                 attachment = attachment,
-                onFetchAttachment = onFetchAttachment
+                onFetchAttachment = onFetchAttachment,
+                onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
             )
         }
         if (fileAttachments.isNotEmpty()) {
-            // Responsive column count — each card minimum ~200dp
             BoxWithConstraints {
                 val columnWidth = 200.dp
                 val availableWidth = maxWidth
@@ -1342,10 +1341,10 @@ private fun AttachmentsSection(
                                 FileAttachmentCard(
                                     attachment = attachment,
                                     onFetchAttachment = onFetchAttachment,
+                                    onNavigateToAttachmentViewer = onNavigateToAttachmentViewer,
                                     modifier = Modifier.weight(1f)
                                 )
                             }
-                            // Fill remaining slots with spacers for consistent sizing
                             repeat(columns - rowItems.size) {
                                 Spacer(modifier = Modifier.weight(1f))
                             }
@@ -1360,9 +1359,9 @@ private fun AttachmentsSection(
 @Composable
 private fun ImageAttachmentCard(
     attachment: EmailAttachmentInfo,
-    onFetchAttachment: suspend (String, String) -> ByteArray?
+    onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit = { _, _, _, _ -> }
 ) {
-    val context = androidx.compose.ui.platform.LocalContext.current
     var imageBytes by remember { androidx.compose.runtime.mutableStateOf<ByteArray?>(null) }
     androidx.compose.runtime.LaunchedEffect(attachment.id) {
         imageBytes = onFetchAttachment(attachment.messageId, attachment.id)
@@ -1374,7 +1373,7 @@ private fun ImageAttachmentCard(
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
             .clickable {
                 if (imageBytes != null) {
-                    openAttachment(context, attachment, imageBytes)
+                    onNavigateToAttachmentViewer(attachment.messageId, attachment.id, attachment.mimeType, attachment.name)
                 }
             }
     ) {
@@ -1445,7 +1444,7 @@ private fun ImageAttachmentCard(
                 modifier = Modifier.weight(1f)
             )
             Text(
-                text = formatFileSize(attachment.size.toLong()),
+                text = com.shrivatsav.monomail.ui.components.formatFileSize(attachment.size.toLong()),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
             )
@@ -1457,70 +1456,54 @@ private fun ImageAttachmentCard(
 private fun FileAttachmentCard(
     attachment: EmailAttachmentInfo,
     onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit = { _, _, _, _ -> },
     modifier: Modifier = Modifier
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
     var isFetching by remember { androidx.compose.runtime.mutableStateOf(false) }
     val scope = androidx.compose.runtime.rememberCoroutineScope()
-    val ext = attachment.name.substringAfterLast('.', "").uppercase()
     Row(
         modifier = modifier
             .clip(cornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
             .clickable {
                 if (!isFetching) {
-                    isFetching = true
-                    scope.launch {
-                        val bytes = onFetchAttachment(attachment.messageId, attachment.id)
-                        openAttachment(context, attachment, bytes)
-                        isFetching = false
+                    val category = com.shrivatsav.monomail.ui.components.classifyAttachment(attachment.mimeType, attachment.name)
+                    if (com.shrivatsav.monomail.ui.components.isPreviewableInApp(category)) {
+                        onNavigateToAttachmentViewer(attachment.messageId, attachment.id, attachment.mimeType, attachment.name)
+                    } else {
+                        isFetching = true
+                        scope.launch {
+                            val bytes = onFetchAttachment(attachment.messageId, attachment.id)
+                            openAttachment(context, attachment, bytes)
+                            isFetching = false
+                        }
                     }
                 }
             }
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(cornerShape(10.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = if (ext.length in 1..4) ext else "FILE",
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
-            )
-        }
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = attachment.name,
-                style = MaterialTheme.typography.bodySmall,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onBackground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = formatFileSize(attachment.size.toLong()),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-            )
-        }
+        com.shrivatsav.monomail.ui.components.AttachmentPreviewCard(
+            name = attachment.name,
+            mimeType = attachment.mimeType,
+            size = attachment.size.toLong(),
+            isFetching = isFetching,
+            mode = com.shrivatsav.monomail.ui.components.PreviewMode.DETAIL,
+            onClick = null
+        )
     }
 }
 
 @Composable
 private fun ThreadAttachmentsSummary(
     attachmentsWithSender: List<Pair<EmailAttachmentInfo, String>>,
-    onFetchAttachment: suspend (String, String) -> ByteArray?
+    onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val imageAttachments = attachmentsWithSender.filter { isImageAttachment(it.first) }
-    val fileAttachments = attachmentsWithSender.filter { !isImageAttachment(it.first) }
+    val imageAttachments = attachmentsWithSender.filter { com.shrivatsav.monomail.ui.components.isImageAttachment(it.first.mimeType, it.first.name) }
+    val fileAttachments = attachmentsWithSender.filter { !com.shrivatsav.monomail.ui.components.isImageAttachment(it.first.mimeType, it.first.name) }
     val totalCount = attachmentsWithSender.size
     val imageCount = imageAttachments.size
 
@@ -1536,7 +1519,8 @@ private fun ThreadAttachmentsSummary(
             ExpandedAttachmentList(
                 imageAttachments = imageAttachments,
                 fileAttachments = fileAttachments,
-                onFetchAttachment = onFetchAttachment
+                onFetchAttachment = onFetchAttachment,
+                onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
             )
         }
     }
@@ -1586,6 +1570,7 @@ private fun ExpandedAttachmentList(
     imageAttachments: List<Pair<EmailAttachmentInfo, String>>,
     fileAttachments: List<Pair<EmailAttachmentInfo, String>>,
     onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
@@ -1595,7 +1580,8 @@ private fun ExpandedAttachmentList(
             Column {
                 ImageAttachmentCard(
                     attachment = attachment,
-                    onFetchAttachment = onFetchAttachment
+                    onFetchAttachment = onFetchAttachment,
+                    onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
                 )
                 Text(
                     text = "from $sender",
@@ -1609,7 +1595,8 @@ private fun ExpandedAttachmentList(
         if (fileAttachments.isNotEmpty()) {
             FileAttachmentsGrid(
                 fileAttachments = fileAttachments,
-                onFetchAttachment = onFetchAttachment
+                onFetchAttachment = onFetchAttachment,
+                onNavigateToAttachmentViewer = onNavigateToAttachmentViewer
             )
         }
 
@@ -1621,6 +1608,7 @@ private fun ExpandedAttachmentList(
 private fun FileAttachmentsGrid(
     fileAttachments: List<Pair<EmailAttachmentInfo, String>>,
     onFetchAttachment: suspend (String, String) -> ByteArray?,
+    onNavigateToAttachmentViewer: (messageId: String, attachmentId: String, mimeType: String, name: String) -> Unit,
 ) {
     BoxWithConstraints {
         val columnWidth = 200.dp
@@ -1636,6 +1624,7 @@ private fun FileAttachmentsGrid(
                             FileAttachmentCard(
                                 attachment = attachment,
                                 onFetchAttachment = onFetchAttachment,
+                                onNavigateToAttachmentViewer = onNavigateToAttachmentViewer,
                                 modifier = Modifier.fillMaxWidth()
                             )
                             Text(

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -176,7 +176,7 @@ fun InboxScreen(
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
-        snackbarHost = { SnackbarHost(snackbarHostState) },
+        snackbarHost = { SnackbarHost(snackbarHostState) { Snackbar(snackbarData = it, shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp)) } },
         contentWindowInsets = WindowInsets(
             top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding(),
             bottom = 0.dp
@@ -1087,7 +1087,9 @@ private fun BottomFabArea(
             unifiedInboxEnabled = unifiedInboxEnabled,
             appSettings = appSettings,
             onTabClick = { viewModel.switchTab(it) },
-            modifier = Modifier.align(Alignment.BottomCenter)
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(end = 72.dp)
         )
         Box(
             modifier = Modifier

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
@@ -48,7 +48,8 @@ fun SettingsScreen(
     authManager: com.shrivatsav.monomail.core.data.auth.AuthManager,
     onNavigateBack: () -> Unit,
     onNavigateToLegal: (String) -> Unit,
-    onNavigateToPgpKeys: () -> Unit = {}
+    onNavigateToPgpKeys: () -> Unit = {},
+    onNavigateToSampleCompose: () -> Unit = {}
 ) {
     var currentSection by remember { mutableStateOf<SettingsSection?>(null) }
     BackHandler(currentSection != null) { currentSection = null }
@@ -105,7 +106,8 @@ fun SettingsScreen(
             )
             SettingsSection.DEVELOPER -> DeveloperSettingsScreen(
                 viewModel = viewModel,
-                onBack = { currentSection = null }
+                onBack = { currentSection = null },
+                onNavigateToSampleCompose = onNavigateToSampleCompose
             )
             SettingsSection.NOTIFICATIONS -> NotificationSettingsScreen(
                 authManager = authManager,
@@ -213,7 +215,8 @@ private fun SettingsHubScreen(
 @Composable
 internal fun DeveloperSettingsScreen(
     viewModel: SettingsViewModel,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onNavigateToSampleCompose: () -> Unit = {}
 ) {
     val settings by viewModel.settings.collectAsState()
     val context = LocalContext.current
@@ -232,6 +235,43 @@ internal fun DeveloperSettingsScreen(
         }
         Spacer(Modifier.height(8.dp))
         SettingsCard {
+            // Sample Attachments
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onNavigateToSampleCompose)
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.AttachFile,
+                    contentDescription = "Sample Attachments",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(14.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Sample Attachments",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        "Open compose with sample attachments for testing",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Rounded.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            CardDivider()
             // Preview Welcome button
             Row(
                 modifier = Modifier

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ googleServices = "4.4.2"
 firebaseMessaging = "24.1.0"
 pgpainless = "2.0.3"
 webkit = "1.12.1"
+media3 = "1.5.1"
 
 [libraries]
 # Core
@@ -88,6 +89,10 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 
 # WebKit
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
+
+# Media3
+androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+androidx-media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
 
 # Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,4 +30,4 @@ rootProject.name = "Mono mail"
 include(":app")
 include(":core:model")
 include(":core:network")
-include(":core:designsystem", ":core:database", ":core:pgp", ":core:data", ":feature:auth", ":feature:inbox", ":feature:detail", ":feature:compose", ":feature:settings")
+include(":core:designsystem", ":core:database", ":core:pgp", ":core:data", ":feature:auth", ":feature:inbox", ":feature:detail", ":feature:compose", ":feature:settings", ":feature:attachment")


### PR DESCRIPTION
## Summary

Adds an in-app attachment preview system with photo viewer, video player, and PDF renderer. Fixes several bugs discovered during implementation.

### New: Attachment Preview Module (`:feature:attachment`)
- **PhotoViewerScreen** — zoomable image viewer with Coil
- **VideoPlayerScreen** — ExoPlayer-based video playback
- **PdfViewerScreen** — PdfRenderer (SDK built-in) with Coil fallback
- **FallbackScreen** — office docs (DOCX/XLSX/PPT) open externally via ACTION_VIEW
- Wired through NavGraph with URL-encoded params

### New: Shared Components
- `AttachmentPreviewCard` — THUMBNAIL and DETAIL variants
- `AttachmentType` — MIME classification enum with icons and color mapping

### Bug Fixes
- **ENAMETOOLONG** — AttachmentCacheManager truncates IDs to 12 chars
- **Duplicate threads** — SendEmailResult propagates real Gmail messageId for Room REPLACE dedup
- **HTTP 400** — URL-encoded messageId/attachmentId in nav routes
- **Snackbar roundedness** — explicit cornerShape(12.dp) on all instances
- **Photo/video picker** — ACTION_GET_CONTENT with dual MIME types (opens gallery)
- **Dock/FAB overlap** — 72dp end padding on BottomDockBar

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->