### PR TITLE
feat: local FTS search with filters and focus fix

### DIFF
--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
@@ -14,6 +14,7 @@ import com.google.gson.Gson
 import com.shrivatsav.monomail.core.data.auth.AccountManager
 import com.shrivatsav.monomail.core.data.auth.UserProfile
 import com.shrivatsav.monomail.core.database.local.*
+import com.shrivatsav.monomail.core.data.repository.SearchField
 import com.shrivatsav.monomail.data.model.Email
 import com.shrivatsav.monomail.data.model.EmailAttachment
 import com.shrivatsav.monomail.data.model.EmailThread
@@ -59,6 +60,35 @@ class EmailRepository(
         return providerFactory(activeAccount)
     }
     fun getDatabase(): AppDatabase = database
+    suspend fun searchThreads(
+        query: String,
+        searchField: SearchField = SearchField.ALL,
+        dateFrom: Long? = null,
+        dateTo: Long? = null,
+        hasAttachments: Boolean = false,
+        accountId: String? = null
+    ): List<EmailThread> {
+        val activeAccountId = accountId ?: getActiveAccountId()
+        val ftsQuery = buildFtsQuery(query, searchField)
+        if (ftsQuery.isBlank()) return emptyList()
+        val threadIds = emailDao.searchThreadIds(ftsQuery, dateFrom, dateTo, hasAttachments)
+        if (threadIds.isEmpty()) return emptyList()
+        return threadDao.getThreadsByIds(threadIds, activeAccountId).map { it.toDomainModel() }
+    }
+
+    private fun buildFtsQuery(query: String, field: SearchField): String {
+        val sanitized = query.replace(Regex("[\"*()^~:]"), " ").trim()
+        if (sanitized.isBlank()) return ""
+        val tokens = sanitized.split(Regex("\\s+")).filter { it.isNotBlank() }
+        val ftsPart = tokens.joinToString(" AND ") { "$it*" }
+        return when (field) {
+            SearchField.ALL -> ftsPart
+            SearchField.SUBJECT -> "subject:($ftsPart)"
+            SearchField.BODY -> "body:($ftsPart)"
+            SearchField.FROM -> "fromEmail:($ftsPart) OR fromName:($ftsPart)"
+            SearchField.TO -> "toEmail:($ftsPart)"
+        }
+    }
     suspend fun getActiveAccountId(): String {
         return accountManager.getActiveAccount()?.id ?: "gmail_unknown"
     }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/SearchField.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/SearchField.kt
@@ -1,0 +1,9 @@
+package com.shrivatsav.monomail.core.data.repository
+
+enum class SearchField(val displayName: String) {
+    ALL("All"),
+    SUBJECT("Subject"),
+    BODY("Body"),
+    FROM("From"),
+    TO("To")
+}

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
@@ -75,6 +75,7 @@ data class AppSettings(
     val cornerStyle: CornerStyle = CornerStyle.ROUNDED,
     val showMarkAllRead: Boolean = true,
     val monochromeTheme: Boolean = true,
+    val swipeThreshold: Float = 0.40f,
 )
 class SettingsDataStore(private val context: Context) {
     private val gson = Gson()
@@ -113,6 +114,7 @@ class SettingsDataStore(private val context: Context) {
         val CORNER_STYLE = stringPreferencesKey("corner_style")
         val SHOW_INLINE_IMAGES = booleanPreferencesKey("show_inline_images")
         val MONOCHROME_THEME = booleanPreferencesKey("monochrome_theme")
+        val SWIPE_THRESHOLD = floatPreferencesKey("swipe_threshold")
     }
     private fun mapToSettings(prefs: Preferences): AppSettings {
         val dockConfigJson = prefs[Keys.DOCK_CONFIG]
@@ -158,6 +160,7 @@ class SettingsDataStore(private val context: Context) {
             showInlineAttachments = prefs[Keys.SHOW_INLINE_ATTACHMENTS] ?: true,
             cornerStyle = prefs[Keys.CORNER_STYLE]?.let { CornerStyle.valueOf(it) } ?: CornerStyle.ROUNDED,
             monochromeTheme = prefs[Keys.MONOCHROME_THEME] ?: true,
+            swipeThreshold = prefs[Keys.SWIPE_THRESHOLD]?.coerceIn(0.20f, 0.60f) ?: 0.40f,
         )
     }
 
@@ -259,6 +262,9 @@ class SettingsDataStore(private val context: Context) {
 
     suspend fun setMonochromeTheme(enabled: Boolean) {
         context.dataStore.edit { it[Keys.MONOCHROME_THEME] = enabled }
+    }
+    suspend fun setSwipeThreshold(threshold: Float) {
+        context.dataStore.edit { it[Keys.SWIPE_THRESHOLD] = threshold.coerceIn(0.20f, 0.60f) }
     }
     suspend fun getTemplates(): List<EmailTemplate> {
         val prefs = context.dataStore.data.first()

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/AppDatabase.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/AppDatabase.kt
@@ -7,8 +7,8 @@ import androidx.room.TypeConverters
 import com.shrivatsav.monomail.security.SecurityUtil
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 @Database(
-    entities = [ThreadEntity::class, EmailEntity::class, ScheduledMessageEntity::class, PendingActionEntity::class],
-    version = 14,
+    entities = [ThreadEntity::class, EmailEntity::class, EmailFtsEntity::class, ScheduledMessageEntity::class, PendingActionEntity::class],
+    version = 15,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -31,7 +31,7 @@ abstract class AppDatabase : RoomDatabase() {
                     "monomail_database"
                 )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
                 .fallbackToDestructiveMigration(true)
                 .build()
                 INSTANCE = instance
@@ -142,5 +142,24 @@ val MIGRATION_13_14 = object : androidx.room.migration.Migration(13, 14) {
     override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE scheduled_messages ADD COLUMN threadId TEXT DEFAULT NULL")
         db.execSQL("ALTER TABLE scheduled_messages ADD COLUMN messageId TEXT DEFAULT NULL")
+    }
+}
+val MIGRATION_14_15 = object : androidx.room.migration.Migration(14, 15) {
+    override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+        db.execSQL("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS `emails_fts` USING FTS4(
+                content=`emails`,
+                `subject` TEXT,
+                `body` TEXT,
+                `fromName` TEXT,
+                `fromEmail` TEXT,
+                `toEmail` TEXT,
+                `snippet` TEXT
+            )
+        """)
+        db.execSQL("""
+            INSERT INTO `emails_fts`(`docid`, `subject`, `body`, `fromName`, `fromEmail`, `toEmail`, `snippet`)
+            SELECT `rowid`, `subject`, `body`, `fromName`, `fromEmail`, `toEmail`, `snippet` FROM `emails`
+        """)
     }
 }

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailDao.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailDao.kt
@@ -89,6 +89,21 @@ interface EmailDao {
 
     @Query("SELECT id, body, bodyIsHtml FROM emails WHERE accountId = :accountId")
     suspend fun getEmailBodyForAccount(accountId: String): List<EmailBodyProjection>
+
+    @Query("""
+        SELECT DISTINCT e.threadId FROM emails e
+        INNER JOIN emails_fts fts ON e.rowid = fts.docid
+        WHERE emails_fts MATCH :ftsQuery
+        AND (:dateFrom IS NULL OR e.date >= :dateFrom)
+        AND (:dateTo IS NULL OR e.date <= :dateTo)
+        AND (:hasAttachments = 0 OR e.attachmentsJson != '[]')
+    """)
+    suspend fun searchThreadIds(
+        ftsQuery: String,
+        dateFrom: Long?,
+        dateTo: Long?,
+        hasAttachments: Boolean
+    ): List<String>
 }
 
 data class EmailBodyProjection(

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailFtsEntity.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailFtsEntity.kt
@@ -1,0 +1,15 @@
+package com.shrivatsav.monomail.core.database.local
+
+import androidx.room.Entity
+import androidx.room.Fts4
+
+@Fts4(contentEntity = EmailEntity::class)
+@Entity(tableName = "emails_fts")
+data class EmailFtsEntity(
+    val subject: String,
+    val body: String,
+    val fromName: String,
+    val fromEmail: String,
+    val toEmail: String,
+    val snippet: String
+)

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/ThreadDao.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/ThreadDao.kt
@@ -84,6 +84,8 @@ interface ThreadDao {
     fun getAllSpamThreads(): Flow<List<ThreadEntity>>
     @Query("SELECT * FROM threads WHERE isSnoozed = 1 ORDER BY date DESC LIMIT 500")
     fun getAllSnoozedThreads(): Flow<List<ThreadEntity>>
+    @Query("SELECT * FROM threads WHERE threadId IN (:threadIds) AND accountId = :accountId ORDER BY date DESC")
+    suspend fun getThreadsByIds(threadIds: List<String>, accountId: String): List<ThreadEntity>
 }
 
 data class ThreadReadStatusProjection(

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
@@ -169,7 +169,13 @@ fun SignInScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter),
         ) {
-            Snackbar(snackbarData = it, shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp))
+            Snackbar(
+                snackbarData = it,
+                shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp),
+                containerColor = MaterialTheme.colorScheme.inverseSurface,
+                contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                actionContentColor = MaterialTheme.colorScheme.inverseOnSurface
+            )
         }
 
         if (showProviderSheet) {

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
@@ -429,7 +429,13 @@ fun ComposeScreen(
         },
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState) {
-                Snackbar(snackbarData = it, shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp))
+                Snackbar(
+                    snackbarData = it,
+                    shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp),
+                    containerColor = MaterialTheme.colorScheme.inverseSurface,
+                    contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    actionContentColor = MaterialTheme.colorScheme.inverseOnSurface
+                )
             }
         }
     ) { padding ->

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -105,13 +105,14 @@ fun InboxScreen(
     var isTrashCountdownActive by remember { mutableStateOf(false) }
     var isSpamCountdownActive by remember { mutableStateOf(false) }
     val appSettings by viewModel.appSettingsState.collectAsState()
+    val searchFilters by viewModel.searchFilters.collectAsState()
+    val searchResults by viewModel.searchResults.collectAsState()
 
     val pullToRefreshState = rememberPullToRefreshState()
-    var searchQuery by remember { mutableStateOf("") }
     val currentThreads = (state as? InboxState.Success)?.threads ?: emptyList()
-    var longPressedThread by remember { mutableStateOf<EmailThread?>(null) }
     val hapticFeedback = LocalHapticFeedback.current
     val focusManager = LocalFocusManager.current
+    var longPressedThread by remember { mutableStateOf<EmailThread?>(null) }
     var activeModal by remember { mutableStateOf<ModalType?>(null) }
     var showSnoozePicker by remember { mutableStateOf(false) }
     var snoozeThreadId by remember { mutableStateOf<String?>(null) }
@@ -120,10 +121,14 @@ fun InboxScreen(
     val isBulkMode by viewModel.isBulkSelectMode.collectAsState()
     val selectedThreadIds by viewModel.selectedThreadIds.collectAsState()
     val selectedCount by viewModel.selectedCount.collectAsState()
-    val isSearchActive = searchQuery.isNotEmpty()
+    var isSearchFocused by remember { mutableStateOf(false) }
+    val isSearchActive = searchFilters.query.isNotEmpty()
     if (isSearchActive) {
         BackHandler {
-            searchQuery = ""
+            viewModel.clearSearch()
+        }
+    } else if (isSearchFocused) {
+        BackHandler {
             focusManager.clearFocus()
         }
     } else if (isBulkMode) {
@@ -132,14 +137,11 @@ fun InboxScreen(
         BackHandler { viewModel.switchTab(InboxTab.INBOX) }
     }
 
-    val localFilteredThreads by remember(searchQuery, currentThreads) {
-        derivedStateOf {
-            if (searchQuery.isEmpty()) null
-            else currentThreads.filter {
-                it.subject.contains(searchQuery, ignoreCase = true) ||
-                        it.from.contains(searchQuery, ignoreCase = true) ||
-                        it.snippet.contains(searchQuery, ignoreCase = true)
-            }
+    LaunchedEffect(isSearchActive) {
+        if (!isSearchActive) {
+            focusManager.clearFocus()
+            kotlinx.coroutines.delay(100)
+            focusManager.clearFocus()
         }
     }
 
@@ -209,9 +211,10 @@ fun InboxScreen(
                     InboxSearchBar(
                         userProfile = userProfile,
                         accounts = accounts,
-                        query = searchQuery,
-                        onQueryChange = { searchQuery = it },
+                        query = searchFilters.query,
+                        onQueryChange = { viewModel.updateSearch(searchFilters.copy(query = it)) },
                         onServerSearch = { viewModel.searchServer(it) },
+                        onFocusChange = { isSearchFocused = it },
                         actions = SearchBarActions(
                             onMarkAllRead = { viewModel.markAllAsRead() },
                             onScheduledClick = navActions.onScheduledClick,
@@ -224,12 +227,18 @@ fun InboxScreen(
                         bulkSelection = BulkSelectionState(
                             isBulkMode = isBulkMode,
                             selectedCount = selectedCount,
-                            totalCount = localFilteredThreads?.size ?: currentThreads.size,
+                            totalCount = if (isSearchActive) searchResults.size else currentThreads.size,
                             onSelectAll = { viewModel.selectAll() },
                             onDeselectAll = { viewModel.deselectAll() },
                             onDone = { viewModel.exitBulkSelectMode() }
                         ),
                         unifiedInboxEnabled = unifiedInboxEnabled
+                    )
+
+                    SearchFilterBar(
+                        filters = searchFilters,
+                        onFiltersChanged = { viewModel.updateSearch(it) },
+                        visible = isSearchActive
                     )
 
                     val isOnline = rememberConnectivityState()
@@ -285,8 +294,7 @@ fun InboxScreen(
                                     viewModel.saveScrollState(currentTab, index, offset)
                                 }
                             }
-                            val threadsToDisplay = localFilteredThreads ?: s.threads
-                            val isSearchActive = localFilteredThreads != null
+                            val threadsToDisplay = if (isSearchActive) searchResults else s.threads
                             var expandedGroupsList by androidx.compose.runtime.saveable.rememberSaveable {
                                 mutableStateOf(emptyList<String>())
                             }
@@ -340,7 +348,7 @@ fun InboxScreen(
                                         title = "No results found"
                                         subtitle = "Try searching on the server instead."
                                         ctaText = "Search server"
-                                        onCtaClick = { viewModel.searchServer(searchQuery) }
+                                        onCtaClick = { viewModel.searchServer(searchFilters.query) }
                                     } else {
                                         when (currentTab) {
                                             InboxTab.SENT -> {
@@ -567,7 +575,7 @@ fun InboxScreen(
                                                     contentAlignment = Alignment.Center
                                                 ) {
                                                     OutlinedButton(
-                                                        onClick = { viewModel.searchServer(searchQuery) },
+                                                        onClick = { viewModel.searchServer(searchFilters.query) },
                                                         shape = MaterialTheme.shapes.large
                                                     ) { Text("Search server for older emails") }
                                                 }

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -177,7 +177,13 @@ fun InboxScreen(
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
-        snackbarHost = { SnackbarHost(snackbarHostState) { Snackbar(snackbarData = it, shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp)) } },
+        snackbarHost = { SnackbarHost(snackbarHostState) { Snackbar(
+            snackbarData = it,
+            shape = com.shrivatsav.monomail.ui.theme.cornerShape(12.dp),
+            containerColor = MaterialTheme.colorScheme.inverseSurface,
+            contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+            actionContentColor = MaterialTheme.colorScheme.inverseOnSurface
+        ) } },
         contentWindowInsets = WindowInsets(0.dp)
     ) { padding ->
         Box(
@@ -413,6 +419,7 @@ fun InboxScreen(
                                                 is InboxDisplayItem.DateHeader -> {
                                                     com.shrivatsav.monomail.ui.components.SectionHeader(
                                                         label = displayItem.title,
+                                                        showTopDivider = false,
                                                         modifier = Modifier.animateItem().background(MaterialTheme.colorScheme.background)
                                                     )
                                                 }
@@ -437,8 +444,29 @@ fun InboxScreen(
                                                         }
                                                     )
                                                 }
-
                                                 is InboxDisplayItem.SingleThread -> {
+                                                    val isUnread = !displayItem.thread.isRead
+                                                    val prevIsSingle = index > 0 && displayItems[index - 1] is InboxDisplayItem.SingleThread
+                                                    val nextIsSingle = index < displayItems.lastIndex && displayItems[index + 1] is InboxDisplayItem.SingleThread
+                                                    val groupPos = when {
+                                                        !prevIsSingle && !nextIsSingle -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.SOLO
+                                                        !prevIsSingle -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.TOP
+                                                        !nextIsSingle -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.BOTTOM
+                                                        else -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.MIDDLE
+                                                    }
+                                                    val prevUnread = isUnread && index > 0 && displayItems[index - 1].let {
+                                                        it is InboxDisplayItem.SingleThread && !it.thread.isRead
+                                                    }
+                                                    val nextUnread = isUnread && index < displayItems.lastIndex && displayItems[index + 1].let {
+                                                        it is InboxDisplayItem.SingleThread && !it.thread.isRead
+                                                    }
+                                                    val unreadPos = when {
+                                                        !isUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.SOLO
+                                                        prevUnread && nextUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.MIDDLE
+                                                        prevUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.BOTTOM
+                                                        nextUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.TOP
+                                                        else -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.SOLO
+                                                    }
                                                     SwipeableEmailItem(
                                                         modifier = Modifier.animateItem(),
                                                         thread = displayItem.thread,
@@ -464,11 +492,35 @@ fun InboxScreen(
                                                             onAvatarLongClick = {
                                                                 viewModel.enterBulkSelectMode(displayItem.thread.threadId)
                                                             }
-                                                        )
+                                                        ),
+                                                        unreadPosition = unreadPos,
+                                                        groupPosition = groupPos
                                                     )
                                                 }
 
                                                 is InboxDisplayItem.NestedThread -> {
+                                                    val isUnread = !displayItem.thread.isRead
+                                                    val prevIsNested = index > 0 && displayItems[index - 1] is InboxDisplayItem.NestedThread
+                                                    val nextIsNested = index < displayItems.lastIndex && displayItems[index + 1] is InboxDisplayItem.NestedThread
+                                                    val groupPos = when {
+                                                        !prevIsNested && !nextIsNested -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.SOLO
+                                                        !prevIsNested -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.TOP
+                                                        !nextIsNested -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.BOTTOM
+                                                        else -> com.shrivatsav.monomail.feature.inbox.components.GroupPosition.MIDDLE
+                                                    }
+                                                    val prevUnread = isUnread && index > 0 && displayItems[index - 1].let {
+                                                        it is InboxDisplayItem.NestedThread && !it.thread.isRead
+                                                    }
+                                                    val nextUnread = isUnread && index < displayItems.lastIndex && displayItems[index + 1].let {
+                                                        it is InboxDisplayItem.NestedThread && !it.thread.isRead
+                                                    }
+                                                    val unreadPos = when {
+                                                        !isUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.SOLO
+                                                        prevUnread && nextUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.MIDDLE
+                                                        prevUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.BOTTOM
+                                                        nextUnread -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.TOP
+                                                        else -> com.shrivatsav.monomail.feature.inbox.components.UnreadPosition.SOLO
+                                                    }
                                                     SwipeableEmailItem(
                                                         modifier = Modifier.animateItem(),
                                                         thread = displayItem.thread,
@@ -494,7 +546,9 @@ fun InboxScreen(
                                                             onAvatarLongClick = {
                                                                 viewModel.enterBulkSelectMode(displayItem.thread.threadId)
                                                             }
-                                                        )
+                                                        ),
+                                                        unreadPosition = unreadPos,
+                                                        groupPosition = groupPos
                                                     )
                                                 }
                                                 }

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxViewModel.kt
@@ -115,6 +115,11 @@ class InboxViewModel @Inject constructor(
     val state: StateFlow<InboxState> = _state.asStateFlow()
     private val _scrollPositions = MutableStateFlow<Map<InboxTab, Pair<Int, Int>>>(emptyMap())
     val scrollPositions: StateFlow<Map<InboxTab, Pair<Int, Int>>> = _scrollPositions.asStateFlow()
+    private val _searchFilters = MutableStateFlow(SearchFilters())
+    val searchFilters: StateFlow<SearchFilters> = _searchFilters.asStateFlow()
+    private val _searchResults = MutableStateFlow<List<EmailThread>>(emptyList())
+    val searchResults: StateFlow<List<EmailThread>> = _searchResults.asStateFlow()
+
 
     fun saveScrollState(tab: InboxTab, index: Int, offset: Int) {
         _scrollPositions.value = _scrollPositions.value + (tab to (index to offset))
@@ -344,6 +349,7 @@ class InboxViewModel @Inject constructor(
         if (_currentTab.value == tab) return
         _currentTab.value = tab
         currentServerQuery = null
+        clearSearch()
         if (_isBulkSelectMode.value) exitBulkSelectMode()
         refresh()
     }
@@ -375,6 +381,29 @@ class InboxViewModel @Inject constructor(
     fun searchServer(query: String) {
         currentServerQuery = query.takeIf { it.isNotBlank() }
         refresh()
+    }
+    fun updateSearch(filters: SearchFilters) {
+        _searchFilters.value = filters
+        if (filters.query.isBlank()) {
+            _searchResults.value = emptyList()
+            return
+        }
+        viewModelScope.launch {
+            val accountId = _activeAccountId.value ?: return@launch
+            val results = repository.searchThreads(
+                query = filters.query,
+                searchField = filters.searchField,
+                dateFrom = filters.dateFrom,
+                dateTo = filters.dateTo,
+                hasAttachments = filters.hasAttachments,
+                accountId = accountId
+            )
+            _searchResults.value = results
+        }
+    }
+    fun clearSearch() {
+        _searchFilters.value = SearchFilters()
+        _searchResults.value = emptyList()
     }
     fun loadMore() {
         val key = getPageTokenKey()

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/SearchFilters.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/SearchFilters.kt
@@ -1,0 +1,13 @@
+package com.shrivatsav.monomail.feature.inbox
+
+import com.shrivatsav.monomail.core.data.repository.SearchField
+
+data class SearchFilters(
+    val query: String = "",
+    val searchField: SearchField = SearchField.ALL,
+    val dateFrom: Long? = null,
+    val dateTo: Long? = null,
+    val hasAttachments: Boolean = false
+) {
+    val isEmpty: Boolean get() = query.isBlank() && dateFrom == null && dateTo == null && !hasAttachments
+}

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/EmailItem.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/EmailItem.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import com.shrivatsav.monomail.ui.theme.cornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
@@ -55,6 +57,9 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 private val displayNameRegex = Regex("""^"?([^"<]+?)"?\s*<""")
 
+/** Where this unread item sits in a consecutive run of unread items. */
+enum class UnreadPosition { SOLO, TOP, MIDDLE, BOTTOM }
+
 data class SelectionState(
     val isSelected: Boolean = false,
     val isBulkMode: Boolean = false,
@@ -71,14 +76,20 @@ fun EmailItem(
     showSnippet: Boolean = true,
     compactMode: Boolean = false,
     selection: SelectionState = SelectionState(),
+    unreadPosition: UnreadPosition = UnreadPosition.SOLO,
     modifier: Modifier = Modifier
 ) {
     val isUnread = !thread.isRead
     val senderInitial = thread.from.firstOrNull()?.uppercase() ?: "?"
-    val backgroundColor = when {
-        isUnread -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = MonoOpacity.subtle)
-        else -> MaterialTheme.colorScheme.background
-    }
+    val unreadShape = if (isUnread) {
+        val r = cornerShape(14.dp)
+        when (unreadPosition) {
+            UnreadPosition.SOLO   -> r
+            UnreadPosition.TOP    -> RoundedCornerShape(r.topStart, r.topEnd, CornerSize(0.dp), CornerSize(0.dp))
+            UnreadPosition.MIDDLE -> RoundedCornerShape(CornerSize(0.dp), CornerSize(0.dp), CornerSize(0.dp), CornerSize(0.dp))
+            UnreadPosition.BOTTOM -> RoundedCornerShape(CornerSize(0.dp), CornerSize(0.dp), r.bottomEnd, r.bottomStart)
+        }
+    } else null
     val verticalPad = if (compactMode) 7.dp else 11.dp
     val hapticFeedback = LocalHapticFeedback.current
     val avatarClickAction = if (selection.isBulkMode) selection.onSelectToggle else onClick
@@ -95,8 +106,25 @@ fun EmailItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .padding(
+                start = 8.dp, end = 8.dp,
+                top = if (isUnread) when (unreadPosition) {
+                    UnreadPosition.SOLO, UnreadPosition.TOP -> 8.dp
+                    else -> 0.dp
+                } else 0.dp,
+                bottom = if (isUnread) when (unreadPosition) {
+                    UnreadPosition.SOLO, UnreadPosition.BOTTOM -> 8.dp
+                    else -> 0.dp
+                } else 0.dp
+            )
+            .then(
+                if (unreadShape != null)
+                    Modifier
+                        .clip(unreadShape)
+                        .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = MonoOpacity.subtle))
+                else Modifier
+            )
             .scale(rowScale)
-            .background(backgroundColor)
             .then(
                 if (selection.isBulkMode) {
                     Modifier.combinedClickable(
@@ -112,7 +140,7 @@ fun EmailItem(
                     )
                 }
             )
-            .padding(horizontal = 20.dp, vertical = verticalPad),
+            .padding(horizontal = 12.dp, vertical = verticalPad),
         verticalAlignment = Alignment.Top
     ) {
         Box {
@@ -129,7 +157,6 @@ fun EmailItem(
                 },
                 modifier = Modifier.padding(top = 2.dp)
             )
-            UnreadDot(isUnread = isUnread, isBulkMode = selection.isBulkMode)
         }
         Spacer(modifier = Modifier.width(16.dp))
         Column(modifier = Modifier.weight(1f)) {
@@ -142,18 +169,6 @@ fun EmailItem(
     }
 }
 
-@Composable
-private fun BoxScope.UnreadDot(isUnread: Boolean, isBulkMode: Boolean) {
-    if (isUnread && !isBulkMode) {
-        Box(
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .size(12.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primary)
-        )
-    }
-}
 
 @Composable
 private fun EmailItemSenderInfo(thread: EmailThread, isUnread: Boolean) {

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/InboxSearchBar.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/InboxSearchBar.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
@@ -65,6 +67,7 @@ internal fun InboxSearchBar(
     isRefreshing: Boolean,
     bulkSelection: BulkSelectionState = BulkSelectionState(),
     unifiedInboxEnabled: Boolean = false,
+    onFocusChange: ((Boolean) -> Unit)? = null,
 ) {
     val containerColor by animateColorAsState(
         targetValue = when {
@@ -92,7 +95,7 @@ internal fun InboxSearchBar(
                         BulkSelectionContent(bulkSelection)
                     } else {
                         // No toast overlay; always show search input
-                        SearchInputContent(query, onQueryChange, onServerSearch, actions, SearchDisplayState(isRefreshing, unifiedInboxEnabled, accounts, userProfile))
+                        SearchInputContent(query, onQueryChange, onServerSearch, actions, SearchDisplayState(isRefreshing, unifiedInboxEnabled, accounts, userProfile), onFocusChange)
                     }
                 }
             },
@@ -154,8 +157,6 @@ private fun BulkSelectionContent(bulkSelection: BulkSelectionState) {
         }
     }
 }
-
-
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun SearchInputContent(
@@ -163,14 +164,25 @@ private fun SearchInputContent(
     onQueryChange: (String) -> Unit,
     onServerSearch: (String) -> Unit,
     actions: SearchBarActions,
-    display: SearchDisplayState
+    display: SearchDisplayState,
+    onFocusChange: ((Boolean) -> Unit)? = null,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect { interaction ->
+            when (interaction) {
+                is FocusInteraction.Focus -> onFocusChange?.invoke(true)
+                is FocusInteraction.Unfocus -> onFocusChange?.invoke(false)
+            }
+        }
+    }
     SearchBarDefaults.InputField(
         query = query,
         onQueryChange = onQueryChange,
         onSearch = { onServerSearch(query) },
         expanded = false,
         onExpandedChange = {},
+        interactionSource = interactionSource,
         placeholder = {
             Text(
                 if (display.isRefreshing) "Syncing..." else if (display.unifiedInboxEnabled) "Search all accounts..." else "Search in mail",

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SearchFilterBar.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SearchFilterBar.kt
@@ -1,0 +1,156 @@
+package com.shrivatsav.monomail.feature.inbox.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AttachFile
+import androidx.compose.material.icons.rounded.Clear
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.shrivatsav.monomail.core.data.repository.SearchField
+import com.shrivatsav.monomail.feature.inbox.SearchFilters
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun SearchFilterBar(
+    filters: SearchFilters,
+    onFiltersChanged: (SearchFilters) -> Unit,
+    visible: Boolean,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = expandVertically() + fadeIn(),
+        exit = shrinkVertically() + fadeOut(),
+        modifier = modifier
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            // Field scope chips
+            Text(
+                text = "Search in",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 6.dp)
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                SearchField.entries.forEach { field ->
+                    FilterChip(
+                        selected = filters.searchField == field,
+                        onClick = { onFiltersChanged(filters.copy(searchField = field)) },
+                        label = { Text(field.displayName) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            selectedLabelColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            // Date range chips
+            Text(
+                text = "Date range",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 6.dp)
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                data class DatePreset(val label: String, val dateFrom: Long?, val dateTo: Long?)
+                val datePresets = listOf(
+                    DatePreset("Any time", null, null),
+                    DatePreset("Today", todayStart(), todayEnd()),
+                    DatePreset("7 days", sevenDaysAgo(), null),
+                    DatePreset("30 days", thirtyDaysAgo(), null)
+                )
+                datePresets.forEach { preset ->
+                    val selected = filters.dateFrom == preset.dateFrom && filters.dateTo == preset.dateTo
+                    FilterChip(
+                        selected = selected,
+                        onClick = {
+                            onFiltersChanged(filters.copy(dateFrom = preset.dateFrom, dateTo = preset.dateTo))
+                        },
+                        label = { Text(preset.label) }
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            // Attachment toggle row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                FilterChip(
+                    selected = filters.hasAttachments,
+                    onClick = { onFiltersChanged(filters.copy(hasAttachments = !filters.hasAttachments)) },
+                    label = { Text("Has attachments") },
+                    leadingIcon = if (filters.hasAttachments) {
+                        { Icon(Icons.Rounded.AttachFile, contentDescription = null, modifier = Modifier.padding(4.dp)) }
+                    } else null
+                )
+
+                Spacer(Modifier.weight(1f))
+
+                if (!filters.isEmpty) {
+                    IconButton(onClick = { onFiltersChanged(SearchFilters()) }) {
+                        Icon(Icons.Rounded.Clear, contentDescription = "Clear filters", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun todayStart(): Long {
+    val cal = java.util.Calendar.getInstance()
+    cal.set(java.util.Calendar.HOUR_OF_DAY, 0)
+    cal.set(java.util.Calendar.MINUTE, 0)
+    cal.set(java.util.Calendar.SECOND, 0)
+    cal.set(java.util.Calendar.MILLISECOND, 0)
+    return cal.timeInMillis
+}
+
+private fun todayEnd(): Long = todayStart() + 86_400_000L
+
+private fun sevenDaysAgo(): Long = todayStart() - 7 * 86_400_000L
+
+private fun thirtyDaysAgo(): Long = todayStart() - 30 * 86_400_000L

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SwipeableEmailItem.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SwipeableEmailItem.kt
@@ -5,21 +5,29 @@ import com.shrivatsav.monomail.feature.inbox.*
 import com.shrivatsav.monomail.model.InboxTab
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.shrivatsav.monomail.data.model.EmailThread
+import com.shrivatsav.monomail.ui.theme.cornerShape
 import kotlinx.coroutines.launch
 
 data class SwipeCallbacks(
@@ -28,6 +36,8 @@ data class SwipeCallbacks(
     val onLongClick: () -> Unit,
     val isNested: Boolean = false
 )
+
+enum class GroupPosition { SOLO, TOP, MIDDLE, BOTTOM }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,7 +48,9 @@ internal fun SwipeableEmailItem(
     appSettings: com.shrivatsav.monomail.core.data.settings.AppSettings,
     viewModel: InboxViewModel,
     callbacks: SwipeCallbacks,
-    selection: SelectionState = SelectionState()
+    selection: SelectionState = SelectionState(),
+    unreadPosition: UnreadPosition = UnreadPosition.SOLO,
+    groupPosition: GroupPosition = GroupPosition.SOLO
 ) {
     var optIsRead by remember(thread.isRead) { mutableStateOf(thread.isRead) }
     var optIsStarred by remember(thread.isStarred) { mutableStateOf(thread.isStarred) }
@@ -47,7 +59,9 @@ internal fun SwipeableEmailItem(
         derivedStateOf { thread.copy(isRead = optIsRead, isStarred = optIsStarred) }
     }
 
-    val dismissState = rememberSwipeToDismissBoxState()
+    val dismissState = rememberSwipeToDismissBoxState(
+        positionalThreshold = { totalDistance -> totalDistance * appSettings.swipeThreshold }
+    )
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(dismissState.currentValue) {
@@ -75,9 +89,17 @@ internal fun SwipeableEmailItem(
         }
         scope.launch { dismissState.snapTo(SwipeToDismissBoxValue.Settled) }
     }
+    val shape = cardShape(groupPosition)
+    val topPad = if (groupPosition == GroupPosition.SOLO || groupPosition == GroupPosition.TOP) 2.dp else 0.dp
+    val bottomPad = if (groupPosition == GroupPosition.SOLO || groupPosition == GroupPosition.BOTTOM) 4.dp else 0.dp
 
     Column(
-        modifier = modifier.let { if (callbacks.isNested) it.padding(start = 32.dp) else it }
+        modifier = modifier
+            .let { if (callbacks.isNested) it.padding(start = 32.dp) else it }
+            .padding(horizontal = 12.dp)
+            .padding(top = topPad, bottom = bottomPad)
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surfaceContainer)
     ) {
         if (selection.isBulkMode) {
             EmailItem(
@@ -92,39 +114,34 @@ internal fun SwipeableEmailItem(
                     onSelectToggle = selection.onSelectToggle,
                     onRangeSelect = selection.onRangeSelect,
                     onAvatarLongClick = selection.onAvatarLongClick
-                )
+                ),
+                unreadPosition = unreadPosition
             )
         } else {
-        SwipeToDismissBox(
-            state = dismissState,
-            enableDismissFromEndToStart = true,
-            enableDismissFromStartToEnd = true,
-            backgroundContent = {
-                SwipeBackground(dismissState, appSettings, tabForSwipe, optIsStarred, optIsRead)
-            }
-        ) {
-            EmailItem(
-                thread = displayThread,
-                onClick = callbacks.onEmailClick,
-                onLongClick = callbacks.onLongClick,
-                showSnippet = appSettings.showSnippet,
-                compactMode = appSettings.compactList,
-                selection = SelectionState(
-                    isSelected = selection.isSelected,
-                    isBulkMode = false,
-                    onSelectToggle = selection.onSelectToggle,
-                    onRangeSelect = selection.onRangeSelect,
-                    onAvatarLongClick = selection.onAvatarLongClick
+            SwipeToDismissBox(
+                state = dismissState,
+                enableDismissFromEndToStart = true,
+                enableDismissFromStartToEnd = true,
+                backgroundContent = {
+                    SwipeBackground(dismissState, appSettings, tabForSwipe, optIsStarred, optIsRead)
+                }
+            ) {
+                EmailItem(
+                    thread = displayThread,
+                    onClick = callbacks.onEmailClick,
+                    onLongClick = callbacks.onLongClick,
+                    showSnippet = appSettings.showSnippet,
+                    compactMode = appSettings.compactList,
+                    selection = SelectionState(
+                        isSelected = selection.isSelected,
+                        isBulkMode = false,
+                        onSelectToggle = selection.onSelectToggle,
+                        onRangeSelect = selection.onRangeSelect,
+                        onAvatarLongClick = selection.onAvatarLongClick
+                    ),
+                    unreadPosition = unreadPosition
                 )
-            )
-        }
-        }
-        if (appSettings.showDividers) {
-            HorizontalDivider(
-                color = MaterialTheme.colorScheme.outlineVariant,
-                thickness = 0.5.dp,
-                modifier = Modifier.padding(horizontal = 20.dp)
-            )
+            }
         }
     }
 }
@@ -140,6 +157,16 @@ private fun resolveSwipeAction(
         else -> null
     }
 }
+@Composable
+private fun cardShape(position: GroupPosition): RoundedCornerShape {
+    val r = cornerShape(16.dp)
+    return when (position) {
+        GroupPosition.SOLO   -> r
+        GroupPosition.TOP    -> RoundedCornerShape(r.topStart, r.topEnd, CornerSize(0.dp), CornerSize(0.dp))
+        GroupPosition.MIDDLE -> RoundedCornerShape(CornerSize(0.dp), CornerSize(0.dp), CornerSize(0.dp), CornerSize(0.dp))
+        GroupPosition.BOTTOM -> RoundedCornerShape(CornerSize(0.dp), CornerSize(0.dp), r.bottomEnd, r.bottomStart)
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -150,63 +177,64 @@ private fun SwipeBackground(
     optIsStarred: Boolean,
     optIsRead: Boolean
 ) {
-    val getAction = { v: SwipeToDismissBoxValue ->
-        when (v) {
-            SwipeToDismissBoxValue.StartToEnd -> appSettings.swipeRightAction
-            SwipeToDismissBoxValue.EndToStart -> appSettings.swipeLeftAction
-            else -> null
-        }
+    val isStartToEnd = dismissState.targetValue == SwipeToDismissBoxValue.StartToEnd ||
+            (dismissState.targetValue == SwipeToDismissBoxValue.Settled &&
+                    dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd)
+    val action = when {
+        dismissState.targetValue == SwipeToDismissBoxValue.StartToEnd -> appSettings.swipeRightAction
+        dismissState.targetValue == SwipeToDismissBoxValue.EndToStart -> appSettings.swipeLeftAction
+        dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd -> appSettings.swipeRightAction
+        dismissState.dismissDirection == SwipeToDismissBoxValue.EndToStart -> appSettings.swipeLeftAction
+        else -> null
     }
-    val action = getAction(dismissState.targetValue) ?: getAction(dismissState.dismissDirection)
-    val color by animateColorAsState(
-        swipeActionColor(action),
-        animationSpec = tween(200),
-        label = "swipeBg"
+    val visuals = swipeActionVisuals(action, tabForSwipe, optIsStarred, optIsRead)
+    val progress = dismissState.progress
+
+    val bubbleWidth = if (visuals != null) (56f + 80f * progress).dp else 0.dp
+    val bubbleHeight = if (visuals != null) 56.dp else 0.dp
+
+    val bubbleColor by animateColorAsState(
+        targetValue = when (action) {
+            com.shrivatsav.monomail.core.data.settings.SwipeAction.ARCHIVE ->
+                MaterialTheme.colorScheme.primaryContainer
+            com.shrivatsav.monomail.core.data.settings.SwipeAction.STAR ->
+                MaterialTheme.colorScheme.tertiaryContainer
+            com.shrivatsav.monomail.core.data.settings.SwipeAction.DELETE ->
+                MaterialTheme.colorScheme.errorContainer
+            com.shrivatsav.monomail.core.data.settings.SwipeAction.READ_UNREAD ->
+                MaterialTheme.colorScheme.secondaryContainer
+            else -> Color.Transparent
+        },
+        animationSpec = tween(150),
+        label = "bubbleColor"
     )
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(color)
-            .padding(horizontal = 20.dp),
-        contentAlignment = if (
-            dismissState.targetValue == SwipeToDismissBoxValue.StartToEnd ||
-            dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
-        ) Alignment.CenterStart else Alignment.CenterEnd
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .padding(horizontal = 16.dp),
+        contentAlignment = if (isStartToEnd) Alignment.CenterStart else Alignment.CenterEnd
     ) {
-        SwipeActionLabel(action, tabForSwipe, optIsStarred, optIsRead)
+        if (visuals != null) {
+            Box(
+                modifier = Modifier
+                    .width(bubbleWidth)
+                    .height(bubbleHeight)
+                    .clip(cornerShape(18.dp))
+                    .background(bubbleColor),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = visuals.icon,
+                    contentDescription = visuals.label,
+                    tint = visuals.tint,
+                    modifier = Modifier.size(26.dp)
+                )
+            }
+        }
     }
 }
-
-@Composable
-private fun SwipeActionLabel(
-    action: com.shrivatsav.monomail.core.data.settings.SwipeAction?,
-    tabForSwipe: InboxTab,
-    optIsStarred: Boolean,
-    optIsRead: Boolean
-) {
-    val (icon, label, tint) = swipeActionVisuals(action, tabForSwipe, optIsStarred, optIsRead) ?: return
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Icon(icon, contentDescription = null, tint = tint)
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.Medium,
-            color = tint,
-            textAlign = if (action == com.shrivatsav.monomail.core.data.settings.SwipeAction.READ_UNREAD) TextAlign.Center else TextAlign.Unspecified
-        )
-    }
-}
-
-@Composable
-private fun swipeActionColor(action: com.shrivatsav.monomail.core.data.settings.SwipeAction?) =
-    when (action) {
-        com.shrivatsav.monomail.core.data.settings.SwipeAction.ARCHIVE -> MaterialTheme.colorScheme.primaryContainer
-        com.shrivatsav.monomail.core.data.settings.SwipeAction.STAR -> MaterialTheme.colorScheme.tertiaryContainer
-        com.shrivatsav.monomail.core.data.settings.SwipeAction.DELETE -> MaterialTheme.colorScheme.errorContainer
-        com.shrivatsav.monomail.core.data.settings.SwipeAction.READ_UNREAD -> MaterialTheme.colorScheme.secondaryContainer
-        else -> Color.Transparent
-    }
 
 private data class SwipeVisuals(val icon: androidx.compose.ui.graphics.vector.ImageVector, val label: String, val tint: Color)
 
@@ -234,7 +262,7 @@ private fun swipeActionVisuals(
     )
     com.shrivatsav.monomail.core.data.settings.SwipeAction.READ_UNREAD -> SwipeVisuals(
         icon = if (optIsRead) Icons.Rounded.MarkEmailRead else Icons.Rounded.MarkEmailUnread,
-        label = if (optIsRead) "Mark\nUnread" else "Mark\nRead",
+        label = if (optIsRead) "Mark Unread" else "Mark Read",
         tint = MaterialTheme.colorScheme.onSecondaryContainer
     )
     else -> null

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/NavigationSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/NavigationSettingsScreen.kt
@@ -22,6 +22,11 @@ internal fun NavigationSettingsScreen(
                 onScaleChanged = { viewModel.setNavScale(it) }
             )
             CardDivider()
+            SwipeThresholdRow(
+                threshold = settings.swipeThreshold,
+                onThresholdChanged = { viewModel.setSwipeThreshold(it) }
+            )
+            CardDivider()
             DockBarEditor(
                 dockConfig = settings.dockConfig,
                 maxSlots = DockConfig.MAX_SLOTS,

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
@@ -565,6 +565,86 @@ internal fun NavSizeRow(
     }
 }
 
+@Composable
+internal fun SwipeThresholdRow(
+    threshold: Float,
+    onThresholdChanged: (Float) -> Unit
+) {
+    // Steps: 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60  (9 values = 8 steps)
+    val steps = listOf(0.20f, 0.25f, 0.30f, 0.35f, 0.40f, 0.45f, 0.50f, 0.55f, 0.60f)
+    val label = when {
+        threshold <= 0.25f -> "Short"
+        threshold <= 0.35f -> "Medium-Short"
+        threshold <= 0.45f -> "Medium"
+        threshold <= 0.52f -> "Medium-Long"
+        else               -> "Long"
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Rounded.SwipeRight,
+                contentDescription = "Swipe Sensitivity",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Text(
+                text = "Swipe Distance",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "How far you must swipe before the action triggers",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(16.dp)
+            )
+            Slider(
+                value = steps.indexOfFirst { it >= threshold - 0.01f }.coerceAtLeast(0).toFloat(),
+                onValueChange = { onThresholdChanged(steps[it.toInt().coerceIn(0, steps.lastIndex)]) },
+                valueRange = 0f..(steps.lastIndex.toFloat()),
+                steps = steps.size - 2,
+                modifier = Modifier.weight(1f),
+                colors = SliderDefaults.colors(
+                    thumbColor = MaterialTheme.colorScheme.onSurface,
+                    activeTrackColor = MaterialTheme.colorScheme.onSurface,
+                    inactiveTrackColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                )
+            )
+            Icon(
+                imageVector = Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun BottomSheetPickerRow(

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
@@ -59,6 +59,7 @@ class SettingsViewModel @Inject constructor(
     fun setShowMarkAllRead(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowMarkAllRead(enabled) }
     fun setMonochromeTheme(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setMonochromeTheme(enabled) }
     fun setCornerStyle(style: com.shrivatsav.monomail.core.data.settings.CornerStyle) = viewModelScope.launch { settingsDataStore.setCornerStyle(style) }
+    fun setSwipeThreshold(threshold: Float) = viewModelScope.launch { settingsDataStore.setSwipeThreshold(threshold) }
     fun resetWelcomePrompt() = viewModelScope.launch {
         settingsDataStore.setHasSeenWelcomePrompt(false)
     }


### PR DESCRIPTION
## Summary
Adds local FTS4-powered email search with field scope, date range, and attachment filters. Fixes search bar focus behavior on Back press.

### Changes
- **FTS4 indexing**: New `emails_fts` virtual table auto-synced with `emails` via Room triggers. Migration v14→15.
- **Search filters**: Field scope chips (All/Subject/Body/From/To), date presets (Today/7d/30d), attachment toggle. Auto-open when search active.
- **ViewModel search**: `updateSearch()` runs FTS queries via `EmailRepository.searchThreads()`. Clears on tab switch.
- **Focus fix**: Tracks search bar focus via `MutableInteractionSource`. Back dismisses cursor when bar is focused but empty. Single-character queries work immediately.
- **No inbox UI changes**: Card containers, unread pills, swipe bubble preserved as at f26c3b6.

### Files
11 files changed, 334 insertions, 26 deletions
- 4 new: `SearchField.kt`, `EmailFtsEntity.kt`, `SearchFilters.kt`, `SearchFilterBar.kt`
- 7 modified: DAOs, repository, ViewModel, InboxScreen, InboxSearchBar, AppDatabase