### PR TITLE
fix: add account modal blocked by performance warning and stale SignInViewModel state

### DIFF
--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInScreen.kt
@@ -8,6 +8,7 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
+import kotlinx.coroutines.flow.drop
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
@@ -349,14 +350,19 @@ fun ProviderSelectionDialog(
             viewModel.onConsentResult(context)
         }
     }
-
-    LaunchedEffect(state) {
-        when (state) {
-            is SignInState.Success -> onSuccess()
-            is SignInState.NeedsConsent -> {
-                consentLauncher.launch((state as SignInState.NeedsConsent).intent)
+    // Reset any stale state from a previous sign-in (e.g. leftover Success)
+    // to prevent immediate dismissal of this dialog. We collect the raw flow
+    // with drop(1) so the reset emission itself doesn't trigger a reaction.
+    LaunchedEffect(Unit) {
+        viewModel.resetState()
+        viewModel.state.drop(1).collect { s ->
+            when (s) {
+                is SignInState.Success -> onSuccess()
+                is SignInState.NeedsConsent -> {
+                    consentLauncher.launch(s.intent)
+                }
+                else -> {}
             }
-            else -> {}
         }
     }
 

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInViewModel.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/SignInViewModel.kt
@@ -29,6 +29,7 @@ class SignInViewModel @Inject constructor(
 ) : ViewModel() {
     private val _state = MutableStateFlow<SignInState>(SignInState.Idle)
     val state: StateFlow<SignInState> = _state.asStateFlow()
+    fun resetState() { _state.value = SignInState.Idle }
     init {
         viewModelScope.launch {
             authManager.microsoftAuthManager.initialize()

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -704,7 +704,7 @@ fun InboxScreen(
                             accounts.size >= 10 -> coroutineScope.launch {
                                 snackbarHostState.showSnackbar("Maximum limit of 10 accounts reached.")
                             }
-                            accounts.size >= 3 -> showPerformanceWarningDialog = true
+                            accounts.size >= 3 && com.shrivatsav.monomail.feature.inbox.BuildConfig.IS_GITHUB_BUILD -> showPerformanceWarningDialog = true
                             else -> activeModal = ModalType.ADD_ACCOUNT
                         }
                     },
@@ -954,7 +954,7 @@ fun InboxScreen(
     }
 
 
-    // Performance warning dialog for adding 4th+ account
+    // Performance warning dialog for adding 4th+ account (github/polling builds only — playstore uses push)
     if (showPerformanceWarningDialog) {
         AlertDialog(
             onDismissRequest = { showPerformanceWarningDialog = false },


### PR DESCRIPTION
Two issues when pressing Add Account with 3+ accounts:

**1. Performance warning blocking modal (InboxScreen)**
`accounts.size >= 3` showed a `Heads up` dialog instead of opening the add-account provider selection. On playstore builds (push-based, no polling), the performance concern doesn't apply — gated behind `IS_GITHUB_BUILD`.

**2. Stale SignInViewModel state (SignInScreen + SignInViewModel)**
After adding an account, `SignInViewModel` retains `SignInState.Success`. Next time the dialog opens, `hiltViewModel()` returns the same instance with stale state, and `LaunchedEffect(state)` instantly fires `onSuccess()` → `callbacks.onDismiss()` → modal slams shut.

Fix: reset state to `Idle` on dialog entry, then collect the raw flow with `drop(1)` so only new sign-in attempts trigger reactions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->