### PR TITLE
Fix email caching, ghost drafts, and API duplicates

### DIFF
--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
@@ -513,9 +513,8 @@ class EmailRepository(
             threadDao.insertThreads(listOf(domainThread.toEntity(accountId, inInbox = false, inSent = false, inArchived = false, inTrash = false, inSpam = false, inDrafts = true)))
             emailDao.insertEmails(listOf(domainEmail.toEntity(accountId)))
         }
-        return actualThreadId
+        return actualMsgId
     }
-
     suspend fun emptySpam(isUnified: Boolean = false) {
         val activeAccountId = getActiveAccountId()
         val accountsToProcess = if (isUnified) {
@@ -560,6 +559,9 @@ class EmailRepository(
         insertPendingAction(PendingActionType.DELETE, accountId, threadId)
         threadDao.moveToTrash(threadId, accountId)
         emailDao.moveThreadEmailsToTrash(threadId, accountId)
+    }
+    suspend fun deleteDraft(draftId: String) {
+        emailDao.deleteDraftEmail(draftId)
     }
     suspend fun restoreThread(threadId: String) {
         val accountId = resolveAccountId(threadId)

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
@@ -359,7 +359,16 @@ class EmailRepository(
                     attachments = msg.attachments
                 )
             }
-            emailDao.insertEmails(emails.map { it.toEntity(accountId) })
+            val serverEmailIds = emails.map { it.id }
+            database.withTransaction {
+                if (serverEmailIds.isNotEmpty()) {
+                    emailDao.deleteOrphanedEmails(threadId, accountId, serverEmailIds)
+                } else {
+                    emailDao.deleteThreadEmails(threadId, accountId)
+                }
+                emailDao.insertEmails(emails.map { it.toEntity(accountId) })
+                threadDao.updateMessageCount(threadId, accountId, emails.size)
+            }
             Result.success(Unit)
         } catch (e: ResourceNotFoundException) {
             Log.w("EmailRepo", "Thread $threadId not found on server — removing stale local data")

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/AppDatabase.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/AppDatabase.kt
@@ -22,15 +22,30 @@ abstract class AppDatabase : RoomDatabase() {
     companion object {
         @Volatile
         private var INSTANCE: AppDatabase? = null
+        private fun migrateDbToCache(context: Context) {
+            val dbName = "monomail_database"
+            val defaultDb = context.getDatabasePath(dbName)
+            val cacheDb = java.io.File(context.cacheDir, dbName)
+            if (defaultDb.exists() && !cacheDb.exists()) {
+                defaultDb.renameTo(cacheDb)
+                for (suffix in listOf("-shm", "-wal", "-journal")) {
+                    val src = java.io.File(defaultDb.path + suffix)
+                    if (src.exists()) src.renameTo(java.io.File(cacheDb.path + suffix))
+                }
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             System.loadLibrary("sqlcipher")
             return INSTANCE ?: synchronized(this) {
+                migrateDbToCache(context.applicationContext)
                 val passphrase = String(SecurityUtil.getDatabasePassphrase(context)).toByteArray()
                 val factory = SupportOpenHelperFactory(passphrase)
+                val dbFile = java.io.File(context.applicationContext.cacheDir, "monomail_database")
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     AppDatabase::class.java,
-                    "monomail_database"
+                    dbFile.absolutePath
                 )
                 .openHelperFactory(factory)
                 .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18)

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailDao.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailDao.kt
@@ -27,6 +27,8 @@ interface EmailDao {
     suspend fun markThreadEmailsAsRead(threadIds: List<String>, accountId: String)
     @Query("DELETE FROM emails WHERE threadId = :threadId AND accountId = :accountId")
     suspend fun deleteThreadEmails(threadId: String, accountId: String)
+    @Query("DELETE FROM emails WHERE id = :emailId")
+    suspend fun deleteDraftEmail(emailId: String)
     @Query("DELETE FROM emails WHERE threadId = :threadId AND accountId = :accountId AND id NOT IN (:keepIds)")
     suspend fun deleteOrphanedEmails(threadId: String, accountId: String, keepIds: List<String>)
     @Query("DELETE FROM emails WHERE accountId = :accountId")

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailDao.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/EmailDao.kt
@@ -27,6 +27,8 @@ interface EmailDao {
     suspend fun markThreadEmailsAsRead(threadIds: List<String>, accountId: String)
     @Query("DELETE FROM emails WHERE threadId = :threadId AND accountId = :accountId")
     suspend fun deleteThreadEmails(threadId: String, accountId: String)
+    @Query("DELETE FROM emails WHERE threadId = :threadId AND accountId = :accountId AND id NOT IN (:keepIds)")
+    suspend fun deleteOrphanedEmails(threadId: String, accountId: String, keepIds: List<String>)
     @Query("DELETE FROM emails WHERE accountId = :accountId")
     suspend fun clearForAccount(accountId: String)
 

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/ThreadDao.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/ThreadDao.kt
@@ -38,6 +38,8 @@ interface ThreadDao {
     suspend fun unarchiveThread(threadId: String, accountId: String)
     @Query("UPDATE threads SET isRead = :isRead WHERE threadId = :threadId AND accountId = :accountId")
     suspend fun updateThreadReadStatus(threadId: String, accountId: String, isRead: Boolean)
+    @Query("UPDATE threads SET messageCount = :count WHERE threadId = :threadId AND accountId = :accountId")
+    suspend fun updateMessageCount(threadId: String, accountId: String, count: Int)
     @Query("UPDATE threads SET isRead = 1 WHERE accountId = :accountId AND threadId IN (:threadIds)")
     suspend fun markThreadsAsRead(threadIds: List<String>, accountId: String)
     @Query("DELETE FROM threads WHERE threadId = :threadId AND accountId = :accountId")

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeViewModel.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeViewModel.kt
@@ -318,7 +318,7 @@ class ComposeViewModel @Inject constructor(
 
     fun deleteDraft(draftId: String) {
         viewModelScope.launch {
-            repository.deleteThread(draftId)
+            repository.deleteDraft(draftId)
             if (_state.value.currentDraftId == draftId) {
                 _state.value = _state.value.copy(currentDraftId = null)
             }
@@ -391,7 +391,8 @@ class ComposeViewModel @Inject constructor(
                         isPendingSend = true
                     )
                 )
-                _state.value = current.copy(isSending = false, isSent = true)
+                current.currentDraftId?.let { repository.deleteDraft(it) }
+                _state.value = current.copy(isSending = false, isSent = true, currentDraftId = null)
             } else {
                 val result = repository.sendEmail(
                     from = current.from,
@@ -410,7 +411,10 @@ class ComposeViewModel @Inject constructor(
                     )
                 }
                 _state.value = result.fold(
-                    onSuccess = { current.copy(isSending = false, isSent = true) },
+                    onSuccess = { 
+                        current.currentDraftId?.let { repository.deleteDraft(it) }
+                        current.copy(isSending = false, isSent = true, currentDraftId = null) 
+                    },
                     onFailure = { current.copy(isSending = false, error = it.message ?: "Failed to send") }
                 )
             }
@@ -469,7 +473,8 @@ class ComposeViewModel @Inject constructor(
                     scheduledAt = scheduledAt
                 )
             )
-            _state.value = _state.value.copy(isSent = true)
+            current.currentDraftId?.let { repository.deleteDraft(it) }
+            _state.value = _state.value.copy(isSent = true, currentDraftId = null)
         }
     }
 

--- a/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailViewModel.kt
+++ b/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailViewModel.kt
@@ -106,8 +106,18 @@ class EmailDetailViewModel @Inject constructor(
             ) { emails, isLoading, error ->
                 when {
                     emails.isNotEmpty() -> {
-                        val needsBodyFetch = emails.any { it.body.isEmpty() }
-                        EmailDetailState.Success(emails, isRefreshing = isLoading && needsBodyFetch, refreshError = error)
+                        val deduplicated = emails.fold(mutableListOf<Email>()) { acc, email ->
+                            val isDuplicate = acc.any { existing -> 
+                                existing.fromEmail == email.fromEmail && 
+                                existing.snippet == email.snippet &&
+                                existing.body == email.body &&
+                                Math.abs(existing.date - email.date) < 60000 
+                            }
+                            if (!isDuplicate) acc.add(email)
+                            acc
+                        }
+                        val needsBodyFetch = deduplicated.any { it.body.isEmpty() }
+                        EmailDetailState.Success(deduplicated, isRefreshing = isLoading && needsBodyFetch, refreshError = error)
                     }
                     error != null -> EmailDetailState.Error(error)
                     !isLoading -> EmailDetailState.Error("Email thread not found.")


### PR DESCRIPTION
## Description
This PR addresses several critical issues with email storage and reconciliation:

1. **Storage Location Fix**: Migrates the Room database from userdata to `cacheDir` so the OS can manage it and the 'Clear Cache' button works as expected. A safe migration function handles the transition for existing users on startup.
2. **Ghost Drafts Fix**: Fixes a catastrophic bug where discarding a reply draft would delete the entire thread. `saveDraftLocally` now returns the correct message ID instead of the thread ID, and `ComposeViewModel` immediately deletes the draft when an email is successfully sent or scheduled.
3. **Orphan Deletion**: Inside `refreshThread`, local emails whose IDs are not in the server response are now correctly wiped, preventing older iterations of drafts from stacking infinitely.
4. **API Deduplication**: Added a fast deduplicator to `EmailDetailViewModel` that filters out identical API-level duplicate messages (e.g. from mailing lists or automated CCs) based on matching sender, snippet, body, and timeframe.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->