### PR TITLE
Per-account notification customisation + remove placeholder data

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -102,7 +102,6 @@ sealed class Screen(val route: String) {
             return "attachment-viewer/${enc(messageId)}/${enc(attachmentId)}?mimeType=${enc(mimeType)}&name=${enc(name)}"
         }
     }
-    object SampleCompose : Screen("sample-compose")
 }
 
 private fun openLegalUrl(context: android.content.Context, type: String) {
@@ -460,9 +459,6 @@ fun NavGraph(
                     onNavigateToPgpKeys = {
                         navController.navigate(Screen.PgpKeys.route) { launchSingleTop = true }
                     },
-                    onNavigateToSampleCompose = {
-                        navController.navigate(Screen.SampleCompose.route) { launchSingleTop = true }
-                    },
                 )
             }
 
@@ -573,42 +569,6 @@ fun NavGraph(
             ) {
                 AttachmentViewerScreen(
                     onBack = { navController.popBackStack() }
-                )
-            }
-            composable(Screen.SampleCompose.route) {
-                val vm: ComposeViewModel = hiltViewModel()
-                val packageName = LocalContext.current.packageName
-                val sampleUri = { res: String -> android.net.Uri.parse("android.resource://$packageName/drawable/$res") }
-                LaunchedEffect(Unit) {
-                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
-                        uri = sampleUri("ic_launcher_foreground"),
-                        name = "Sample Image.png",
-                        size = 24576,
-                        mimeType = "image/png"
-                    ))
-                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
-                        uri = sampleUri("ic_launcher_foreground"),
-                        name = "Report.pdf",
-                        size = 102400,
-                        mimeType = "application/pdf"
-                    ))
-                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
-                        uri = sampleUri("ic_launcher_foreground"),
-                        name = "Demo Video.mp4",
-                        size = 5242880,
-                        mimeType = "video/mp4"
-                    ))
-                    vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(
-                        uri = sampleUri("ic_launcher_foreground"),
-                        name = "Document.docx",
-                        size = 48256,
-                        mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-                    ))
-                }
-                ComposeScreen(
-                    viewModel = vm,
-                    onBack = { navController.popBackStack() },
-                    onSent = { navController.popBackStack() }
                 )
             }
         }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AuthManager.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AuthManager.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import com.shrivatsav.monomail.core.data.worker.NotificationChannelManager
 import com.shrivatsav.monomail.core.data.push.PushNotificationManager
 
 data class ReauthInfo(val email: String, val provider: String, val intent: android.content.Intent? = null)
@@ -240,6 +241,7 @@ class AuthManager(
         }
         accountManager.removeAccount(accountId)
         try { pushNotificationManager.unregisterForPushNotifications(target.id) } catch (e: Exception) { android.util.Log.w(TAG, "push unregister failed during removeAccount for ${target.id}", e) }
+        try { NotificationChannelManager.deleteChannel(context, target.id) } catch (e: Exception) { android.util.Log.w(TAG, "notification channel delete failed during removeAccount for ${target.id}", e) }
         try {
             database.emailDao().clearForAccount(accountId)
             database.threadDao().clearForAccount(accountId)
@@ -279,6 +281,9 @@ class AuthManager(
         accountManager.removeAccount(active.id)
         try { pushNotificationManager.unregisterForPushNotifications(active.id) } catch (e: Exception) {
             android.util.Log.w("AuthManager", "push unregister failed during signOut for ${active.id}", e)
+        }
+        try { NotificationChannelManager.deleteChannel(context, active.id) } catch (e: Exception) {
+            android.util.Log.w(TAG, "notification channel delete failed during signOut for ${active.id}", e)
         }
         try {
             database.emailDao().clearForAccount(active.id)

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
@@ -28,6 +28,30 @@ enum class SwipeAction { ARCHIVE, STAR, DELETE, READ_UNREAD }
 enum class DefaultReply { REPLY, REPLY_ALL }
 enum class SyncFrequency { MIN_15, MIN_30, HOUR_1, MANUAL }
 enum class UndoSendWindow(val seconds: Int) { SEC_5(5), SEC_10(10), SEC_20(20), SEC_30(30) }
+/** Sound behavior for a per-account notification channel. */
+enum class NotificationSound { DEFAULT, SILENT }
+/** Alert level for a per-account notification channel (maps to channel importance). */
+enum class NotificationImportance { DEFAULT, URGENT, SILENT }
+/** How much email content appears on the lock screen (maps to Notification visibility). */
+enum class NotificationPreview { FULL, PRIVATE, NONE }
+/**
+ * Per-account notification behavior. Stored as one Gson JSON string per account
+ * under a `notification_profile_<accountId>` preference key.
+ *
+ * Defaults preserve the pre-customization behavior: system sound + vibration,
+ * default importance, full content preview, badge shown.
+ */
+data class NotificationProfile(
+    val sound: NotificationSound = NotificationSound.DEFAULT,
+    val vibrate: Boolean = true,
+    val importance: NotificationImportance = NotificationImportance.DEFAULT,
+    val preview: NotificationPreview = NotificationPreview.FULL,
+    val badge: Boolean = true,
+) {
+    companion object {
+        fun defaults() = NotificationProfile()
+    }
+}
 enum class DockTabId { UNIFIED, INBOX, SENT, ARCHIVED, SNOOZED, STARRED, TRASH, SPAM }
 data class DockConfig(
     val primaryTabs: List<DockTabId> = listOf(
@@ -77,7 +101,6 @@ data class AppSettings(
     val showMarkAllRead: Boolean = true,
     val monochromeTheme: Boolean = false,
     val swipeThreshold: Float = 0.40f,
-    val demoSmartFolders: Boolean = false,
     val addSignature: Boolean = true,
 )
 class SettingsDataStore(private val context: Context) {
@@ -116,11 +139,12 @@ class SettingsDataStore(private val context: Context) {
         val SHOW_INLINE_ATTACHMENTS = booleanPreferencesKey("show_inline_attachments")
         val SHOW_MARK_ALL_READ = booleanPreferencesKey("show_mark_all_read")
         val CORNER_STYLE = stringPreferencesKey("corner_style")
-        val DEMO_SMART_FOLDERS = booleanPreferencesKey("demo_smart_folders")
         val SHOW_INLINE_IMAGES = booleanPreferencesKey("show_inline_images")
         val MONOCHROME_THEME = booleanPreferencesKey("monochrome_theme")
         val SWIPE_THRESHOLD = floatPreferencesKey("swipe_threshold")
         val ADD_SIGNATURE = booleanPreferencesKey("add_signature")
+        fun notificationProfileKey(accountId: String) =
+            stringPreferencesKey("notification_profile_$accountId")
     }
     private fun mapToSettings(prefs: Preferences): AppSettings {
         val dockConfigJson = prefs[Keys.DOCK_CONFIG]
@@ -163,7 +187,6 @@ class SettingsDataStore(private val context: Context) {
                 } catch (e: Exception) { DockConfig.defaults() }
             } ?: DockConfig.defaults(),
             isDeveloperMode = prefs[Keys.IS_DEVELOPER_MODE] ?: false,
-            demoSmartFolders = prefs[Keys.DEMO_SMART_FOLDERS] ?: false,
             showInlineImages = prefs[Keys.SHOW_INLINE_IMAGES] ?: true,
             showInlineAttachments = prefs[Keys.SHOW_INLINE_ATTACHMENTS] ?: true,
             cornerStyle = prefs[Keys.CORNER_STYLE]?.let { CornerStyle.valueOf(it) } ?: CornerStyle.ROUNDED,
@@ -171,6 +194,38 @@ class SettingsDataStore(private val context: Context) {
             swipeThreshold = prefs[Keys.SWIPE_THRESHOLD]?.coerceIn(0.20f, 0.60f) ?: 0.40f,
             addSignature = prefs[Keys.ADD_SIGNATURE] ?: true,
         )
+    }
+    private fun parseNotificationProfile(json: String?): NotificationProfile {
+        if (json == null) return NotificationProfile.defaults()
+        return try {
+            val raw = gson.fromJson(json, NotificationProfile::class.java)
+            val sound = raw?.sound
+            val vibrate = raw?.vibrate
+            val importance = raw?.importance
+            val preview = raw?.preview
+            val badge = raw?.badge
+            if (sound != null && vibrate != null && importance != null && preview != null && badge != null) {
+                NotificationProfile(sound, vibrate, importance, preview, badge)
+            } else {
+                NotificationProfile.defaults()
+            }
+        } catch (e: Exception) {
+            NotificationProfile.defaults()
+        }
+    }
+
+    /** Per-account notification profile as a reactive flow (for the settings UI). */
+    fun notificationProfileFlow(accountId: String): Flow<NotificationProfile> =
+        context.dataStore.data.map { prefs ->
+            parseNotificationProfile(prefs[Keys.notificationProfileKey(accountId)])
+        }
+
+    /** One-shot profile read for workers (settingsFlow is pre-heated but per-account keys aren't). */
+    suspend fun getNotificationProfile(accountId: String): NotificationProfile =
+        parseNotificationProfile(context.dataStore.data.first()[Keys.notificationProfileKey(accountId)])
+
+    suspend fun setNotificationProfile(accountId: String, profile: NotificationProfile) {
+        context.dataStore.edit { it[Keys.notificationProfileKey(accountId)] = gson.toJson(profile) }
     }
 
     /**
@@ -293,9 +348,6 @@ class SettingsDataStore(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs[Keys.TEMPLATES] = gson.toJson(templates)
         }
-    }
-    suspend fun setDemoSmartFolders(enabled: Boolean) {
-        context.dataStore.edit { it[Keys.DEMO_SMART_FOLDERS] = enabled }
     }
     val templatesFlow: Flow<List<EmailTemplate>> = context.dataStore.data.map { prefs ->
         val json = prefs[Keys.TEMPLATES] ?: return@map emptyList()

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/EmailSyncWorker.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/EmailSyncWorker.kt
@@ -94,7 +94,7 @@ class EmailSyncWorker @AssistedInject constructor(
                 Log.i("EmailSyncWorker", "New email detected for $accountId, but notifications are disabled for this account. Skipping notification banner.")
             } else {
                 Log.i("EmailSyncWorker", "New email detected for $accountId! Showing notification...")
-                showNotification(accountId, newestThread, accountId.hashCode())
+                showNotification(account, newestThread, accountId.hashCode())
             }
         } else if (isLatestDraft) {
             Log.i("EmailSyncWorker", "Newest message is a draft. Skipping notification banner.")
@@ -134,17 +134,18 @@ class EmailSyncWorker @AssistedInject constructor(
         )
     }
 
-    private fun showNotification(
-        accountId: String,
+    private suspend fun showNotification(
+        account: com.shrivatsav.monomail.core.data.auth.UserProfile,
         thread: com.shrivatsav.monomail.data.model.EmailThread,
         notificationId: Int
     ) {
         showNewEmailNotification(
             context = applicationContext,
-            accountId = accountId,
+            account = account,
             thread = thread,
             notificationId = notificationId,
-            quickActions = settingsDataStore.settingsFlow.value.notificationQuickActions
+            quickActions = settingsDataStore.settingsFlow.value.notificationQuickActions,
+            profile = settingsDataStore.getNotificationProfile(account.id)
         )
     }
 }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NewEmailNotifications.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NewEmailNotifications.kt
@@ -1,8 +1,6 @@
 package com.shrivatsav.monomail.core.data.worker
 
 import android.Manifest
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -14,6 +12,9 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.RemoteInput
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
+import com.shrivatsav.monomail.core.data.auth.UserProfile
+import com.shrivatsav.monomail.core.data.settings.NotificationPreview
+import com.shrivatsav.monomail.core.data.settings.NotificationProfile
 
 private const val TAG = "NewEmailNotification"
 
@@ -27,10 +28,11 @@ fun channelIdForAccount(accountId: String): String = "monomail_$accountId"
  */
 fun showNewEmailNotification(
     context: Context,
-    accountId: String,
+    account: UserProfile,
     thread: com.shrivatsav.monomail.data.model.EmailThread,
     notificationId: Int,
-    quickActions: Set<String>
+    quickActions: Set<String>,
+    profile: NotificationProfile
 ) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
         ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
@@ -39,7 +41,7 @@ fun showNewEmailNotification(
         Log.e(TAG, "POST_NOTIFICATIONS permission not granted! Aborting notification display.")
         return
     }
-    createNotificationChannel(context, accountId, thread.from)
+    NotificationChannelManager.ensureNewEmailChannel(context, account, profile)
 
     val openIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
@@ -52,7 +54,7 @@ fun showNewEmailNotification(
     val replyPendingIntent = NotificationActionReceiver.createReplyPendingIntent(
         context = context,
         params = NotificationActionReceiver.ReplyParams(
-            accountId = accountId,
+            accountId = account.id,
             threadId = thread.threadId,
             messageId = thread.latestMessageId,
             subject = thread.subject,
@@ -70,7 +72,7 @@ fun showNewEmailNotification(
 
     val archivePendingIntent = NotificationActionReceiver.createArchivePendingIntent(
         context = context,
-        accountId = accountId,
+        accountId = account.id,
         threadId = thread.threadId,
         notificationId = notificationId
     )
@@ -80,7 +82,7 @@ fun showNewEmailNotification(
 
     val deletePendingIntent = NotificationActionReceiver.createDeletePendingIntent(
         context = context,
-        accountId = accountId,
+        accountId = account.id,
         threadId = thread.threadId,
         notificationId = notificationId
     )
@@ -90,7 +92,7 @@ fun showNewEmailNotification(
 
     val snoozePendingIntent = NotificationActionReceiver.createSnoozePendingIntent(
         context = context,
-        accountId = accountId,
+        accountId = account.id,
         threadId = thread.threadId,
         notificationId = notificationId
     )
@@ -106,7 +108,7 @@ fun showNewEmailNotification(
     ).filter { it.first in quickActions }.map { it.second }
 
     val cleanSnippet = thread.snippet.replace(Regex("\\bOn\\s+[A-Z][a-z]{2},.*?wrote:.*"), "").trim()
-    val channelId = channelIdForAccount(accountId)
+    val channelId = channelIdForAccount(account.id)
     val builder = NotificationCompat.Builder(context, channelId)
         .setSmallIcon(com.shrivatsav.monomail.core.data.R.drawable.ic_notification_leaf)
         .setContentTitle(thread.from)
@@ -119,23 +121,19 @@ fun showNewEmailNotification(
         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
         .setContentIntent(openPendingIntent)
         .setAutoCancel(true)
+        .setVisibility(
+            when (profile.preview) {
+                NotificationPreview.FULL -> NotificationCompat.VISIBILITY_PUBLIC
+                NotificationPreview.PRIVATE -> NotificationCompat.VISIBILITY_PRIVATE
+                NotificationPreview.NONE -> NotificationCompat.VISIBILITY_SECRET
+            }
+        )
+        .apply {
+            if (!profile.badge) setBadgeIconType(NotificationCompat.BADGE_ICON_NONE)
+        }
     actions.forEach(builder::addAction)
 
-    NotificationManagerCompat.from(context).notify(accountId, notificationId, builder.build())
+    NotificationManagerCompat.from(context).notify(account.id, notificationId, builder.build())
     Log.i(TAG, "Notification successfully sent to NotificationManagerCompat (id: $notificationId)")
 }
 
-private fun createNotificationChannel(context: Context, accountId: String, accountName: String) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        val channelId = channelIdForAccount(accountId)
-        val channelName = "$accountName ($accountId)"
-        val descriptionText = "Notifications for $accountName"
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
-        val channel = NotificationChannel(channelId, channelName, importance).apply {
-            description = descriptionText
-        }
-        val notificationManager: NotificationManager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.createNotificationChannel(channel)
-    }
-}

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NewEmailNotifications.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NewEmailNotifications.kt
@@ -18,8 +18,6 @@ import com.shrivatsav.monomail.core.data.settings.NotificationProfile
 
 private const val TAG = "NewEmailNotification"
 
-/** Channel id used for per-account new-email notifications. */
-fun channelIdForAccount(accountId: String): String = "monomail_$accountId"
 
 /**
  * Posts the new-email notification for [thread] on [accountId]'s channel,
@@ -108,7 +106,7 @@ fun showNewEmailNotification(
     ).filter { it.first in quickActions }.map { it.second }
 
     val cleanSnippet = thread.snippet.replace(Regex("\\bOn\\s+[A-Z][a-z]{2},.*?wrote:.*"), "").trim()
-    val channelId = channelIdForAccount(account.id)
+    val channelId = NotificationChannelManager.channelIdFor(account.id, profile)
     val builder = NotificationCompat.Builder(context, channelId)
         .setSmallIcon(com.shrivatsav.monomail.core.data.R.drawable.ic_notification_leaf)
         .setContentTitle(thread.from)

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationActionReceiver.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationActionReceiver.kt
@@ -447,10 +447,11 @@ class NotificationActionReceiver : BroadcastReceiver() {
         )
         showNewEmailNotification(
             context = context,
-            accountId = account.id,
+            account = account,
             thread = thread,
             notificationId = 7000 + account.id.hashCode(),
-            quickActions = deps.settingsDataStore().settingsFlow.value.notificationQuickActions
+            quickActions = deps.settingsDataStore().settingsFlow.value.notificationQuickActions,
+            profile = deps.settingsDataStore().getNotificationProfile(account.id)
         )
     }
 }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationChannelManager.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationChannelManager.kt
@@ -11,10 +11,13 @@ import com.shrivatsav.monomail.core.data.settings.NotificationSound
 /**
  * Owns the per-account new-email notification channel lifecycle.
  *
- * Channel properties (name, importance, sound, vibration, badge) are immutable
- * after creation, so any change requires delete + recreate. The name is the
- * account email — never the first sender's name. Recreating also repairs
- * channels created by older builds that were mislabeled with a sender name.
+ * Channel properties (importance, sound, vibration, badge) are immutable after
+ * creation, and Android does NOT honor delete + recreate of the same channel id
+ * (the recreated channel keeps the original settings — a channel that was once
+ * silent stays silent forever). So the channel id is derived from the profile:
+ * any profile change maps to a NEW channel id, which is always created with the
+ * exact requested settings, and switching back reuses the original channel.
+ * Stale channels for the account are deleted once the current one exists.
  */
 object NotificationChannelManager {
 
@@ -25,32 +28,33 @@ object NotificationChannelManager {
     }
 
     /**
-     * Creates (or repairs) the new-email channel for [account] so it matches
-     * [profile]. Deletes and recreates when any immutable property differs.
+     * Stable channel id per (account, profile). Encode every immutable channel
+     * property so a changed setting yields a different channel.
+     */
+    fun channelIdFor(accountId: String, profile: NotificationProfile): String =
+        "monomail_${accountId}_${profile.importance.name}_${profile.sound.name}_${profile.vibrate}_${profile.badge}"
+
+    private fun isAccountChannel(id: String, accountId: String): Boolean =
+        id == "monomail_$accountId" || id.startsWith("monomail_${accountId}_")
+
+    /**
+     * Ensures the channel matching [profile] exists for [account]. Creates it
+     * on first use; deletes stale channels (older profile ids and the legacy
+     * sender-name-mislabeled channel) afterwards.
      */
     fun ensureNewEmailChannel(context: Context, account: UserProfile, profile: NotificationProfile) {
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channelId = channelIdForAccount(account.id)
-        val existing = nm.getNotificationChannel(channelId)
+        val desiredId = channelIdFor(account.id, profile)
+        val existing = nm.getNotificationChannel(desiredId)
+        if (existing != null && existing.name == account.email) {
+            cleanupStaleChannels(nm, account.id, desiredId)
+            return
+        }
 
-        val wantsSilentSound = profile.sound == NotificationSound.SILENT
-        val wantsImportance = channelImportance(profile.importance)
-
-        val matches =
-            existing != null &&
-                existing.name == account.email &&
-                existing.importance == wantsImportance &&
-                (existing.sound == null) == !wantsSilentSound &&
-                existing.shouldVibrate() == profile.vibrate &&
-                existing.canShowBadge() == profile.badge
-        if (matches) return
-
-        if (existing != null) nm.deleteNotificationChannel(channelId)
-
-        val channel = NotificationChannel(channelId, account.email, wantsImportance).apply {
+        val channel = NotificationChannel(desiredId, account.email, channelImportance(profile.importance)).apply {
             description = "Notifications for ${account.email}"
             setShowBadge(profile.badge)
-            if (wantsSilentSound) {
+            if (profile.sound == NotificationSound.SILENT) {
                 setSound(null, null)
             }
             if (!profile.vibrate) {
@@ -58,11 +62,24 @@ object NotificationChannelManager {
             }
         }
         nm.createNotificationChannel(channel)
+        cleanupStaleChannels(nm, account.id, desiredId)
     }
 
-    /** Deletes an account's channel (called when the account is removed). */
+    private fun cleanupStaleChannels(nm: NotificationManager, accountId: String, keepId: String) {
+        for (channel in nm.notificationChannels) {
+            if (channel.id != keepId && isAccountChannel(channel.id, accountId)) {
+                nm.deleteNotificationChannel(channel.id)
+            }
+        }
+    }
+
+    /** Deletes every channel for an account (called when the account is removed). */
     fun deleteChannel(context: Context, accountId: String) {
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        nm.deleteNotificationChannel(channelIdForAccount(accountId))
+        for (channel in nm.notificationChannels) {
+            if (isAccountChannel(channel.id, accountId)) {
+                nm.deleteNotificationChannel(channel.id)
+            }
+        }
     }
 }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationChannelManager.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationChannelManager.kt
@@ -1,0 +1,68 @@
+package com.shrivatsav.monomail.core.data.worker
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import com.shrivatsav.monomail.core.data.auth.UserProfile
+import com.shrivatsav.monomail.core.data.settings.NotificationImportance
+import com.shrivatsav.monomail.core.data.settings.NotificationProfile
+import com.shrivatsav.monomail.core.data.settings.NotificationSound
+
+/**
+ * Owns the per-account new-email notification channel lifecycle.
+ *
+ * Channel properties (name, importance, sound, vibration, badge) are immutable
+ * after creation, so any change requires delete + recreate. The name is the
+ * account email — never the first sender's name. Recreating also repairs
+ * channels created by older builds that were mislabeled with a sender name.
+ */
+object NotificationChannelManager {
+
+    fun channelImportance(importance: NotificationImportance): Int = when (importance) {
+        NotificationImportance.DEFAULT -> NotificationManager.IMPORTANCE_DEFAULT
+        NotificationImportance.URGENT -> NotificationManager.IMPORTANCE_HIGH
+        NotificationImportance.SILENT -> NotificationManager.IMPORTANCE_LOW
+    }
+
+    /**
+     * Creates (or repairs) the new-email channel for [account] so it matches
+     * [profile]. Deletes and recreates when any immutable property differs.
+     */
+    fun ensureNewEmailChannel(context: Context, account: UserProfile, profile: NotificationProfile) {
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channelId = channelIdForAccount(account.id)
+        val existing = nm.getNotificationChannel(channelId)
+
+        val wantsSilentSound = profile.sound == NotificationSound.SILENT
+        val wantsImportance = channelImportance(profile.importance)
+
+        val matches =
+            existing != null &&
+                existing.name == account.email &&
+                existing.importance == wantsImportance &&
+                (existing.sound == null) == !wantsSilentSound &&
+                existing.shouldVibrate() == profile.vibrate &&
+                existing.canShowBadge() == profile.badge
+        if (matches) return
+
+        if (existing != null) nm.deleteNotificationChannel(channelId)
+
+        val channel = NotificationChannel(channelId, account.email, wantsImportance).apply {
+            description = "Notifications for ${account.email}"
+            setShowBadge(profile.badge)
+            if (wantsSilentSound) {
+                setSound(null, null)
+            }
+            if (!profile.vibrate) {
+                enableVibration(false)
+            }
+        }
+        nm.createNotificationChannel(channel)
+    }
+
+    /** Deletes an account's channel (called when the account is removed). */
+    fun deleteChannel(context: Context, accountId: String) {
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.deleteNotificationChannel(channelIdForAccount(accountId))
+    }
+}

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -350,39 +350,8 @@ fun InboxScreen(
                                     }
                                 }
                             }
-                            val displayItems = remember(inboxStructure, expandedGroupsList, appSettings.demoSmartFolders) {
-                                val items = flattenDisplayItems(inboxStructure, expandedGroupsList.toSet(), tabPrefix = currentTab.name).toMutableList()
-                                if (appSettings.demoSmartFolders) {
-                                    items.add(0, InboxDisplayItem.GroupHeader(
-                                        groupName = "Demo Smart Folder",
-                                        count = 42,
-                                        unreadCount = 5,
-                                        latestDate = System.currentTimeMillis(),
-                                        isExpanded = expandedGroupsList.contains("Demo Smart Folder"),
-                                        avatarUrl = null,
-                                        tab = currentTab.name
-                                    ))
-                                    val isDemoExpanded = expandedGroupsList.contains("Demo Smart Folder")
-                                    items.add(1, InboxDisplayItem.NestedThread(
-                                        thread = com.shrivatsav.monomail.data.model.EmailThread(
-                                            threadId = "demo_thread_1",
-                                            subject = "This is a demo email",
-                                            from = "Demo Sender",
-                                            fromEmail = "demo@example.com",
-                                            snippet = "Just demonstrating the smart folder expansion",
-                                            date = System.currentTimeMillis(),
-                                            messageCount = 1,
-                                            isRead = false,
-                                            isStarred = false,
-                                            latestMessageId = "demo_msg_1",
-                                            participants = listOf("Demo Sender")
-                                        ),
-                                        groupName = "Demo Smart Folder",
-                                        tab = currentTab.name,
-                                        isVisible = isDemoExpanded
-                                    ))
-                                }
-                                items
+                            val displayItems = remember(inboxStructure, expandedGroupsList) {
+                                flattenDisplayItems(inboxStructure, expandedGroupsList.toSet(), tabPrefix = currentTab.name)
                             }
                             val orderedThreadIds by remember(displayItems) {
                                 derivedStateOf {

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/NotificationSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/NotificationSettingsScreen.kt
@@ -59,10 +59,69 @@ internal fun NotificationSettingsScreen(
                         }
                     )
                     
-                    if (isEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    if (isEnabled) {
+                        val profile by viewModel.notificationProfileFlow(account.id)
+                            .collectAsState(initial = NotificationProfile.defaults())
+                        CardDivider()
+                        BottomSheetPickerRow(
+                            icon = Icons.Rounded.NotificationsActive,
+                            title = "Alert style",
+                            currentValue = profile.importance.displayName(),
+                            options = NotificationImportance.entries.map { it.displayName() },
+                            onSelected = { idx ->
+                                viewModel.setNotificationProfile(
+                                    account.id, profile.copy(importance = NotificationImportance.entries[idx])
+                                )
+                            }
+                        )
+                        CardDivider()
+                        BottomSheetPickerRow(
+                            icon = Icons.Rounded.VolumeUp,
+                            title = "Sound",
+                            currentValue = profile.sound.displayName(),
+                            options = NotificationSound.entries.map { it.displayName() },
+                            onSelected = { idx ->
+                                viewModel.setNotificationProfile(
+                                    account.id, profile.copy(sound = NotificationSound.entries[idx])
+                                )
+                            }
+                        )
+                        CardDivider()
+                        SettingsToggleRow(
+                            icon = Icons.Rounded.Vibration,
+                            title = "Vibrate",
+                            subtitle = "Vibrate when a notification arrives",
+                            checked = profile.vibrate,
+                            onCheckedChange = { checked ->
+                                viewModel.setNotificationProfile(account.id, profile.copy(vibrate = checked))
+                            }
+                        )
+                        CardDivider()
+                        BottomSheetPickerRow(
+                            icon = Icons.Rounded.Lock,
+                            title = "Lock screen preview",
+                            currentValue = profile.preview.displayName(),
+                            options = NotificationPreview.entries.map { it.displayName() },
+                            onSelected = { idx ->
+                                viewModel.setNotificationProfile(
+                                    account.id, profile.copy(preview = NotificationPreview.entries[idx])
+                                )
+                            }
+                        )
+                        CardDivider()
+                        SettingsToggleRow(
+                            icon = Icons.Rounded.Badge,
+                            title = "App icon badge",
+                            subtitle = "Show the app icon badge with a count",
+                            checked = profile.badge,
+                            onCheckedChange = { checked ->
+                                viewModel.setNotificationProfile(account.id, profile.copy(badge = checked))
+                            }
+                        )
+                        CardDivider()
                         InfoRow(
                             icon = Icons.Rounded.Tune,
-                            title = "Customize Sound & Vibration",
+                            title = "System channel settings",
                             value = "",
                             onClick = {
                                 val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/NotificationSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/NotificationSettingsScreen.kt
@@ -15,6 +15,7 @@ import com.shrivatsav.monomail.core.data.auth.AuthManager
 import com.shrivatsav.monomail.feature.settings.BuildConfig
 import com.shrivatsav.monomail.core.data.settings.*
 import com.shrivatsav.monomail.core.data.worker.NotificationActionReceiver
+import com.shrivatsav.monomail.core.data.worker.NotificationChannelManager
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -126,7 +127,7 @@ internal fun NotificationSettingsScreen(
                             onClick = {
                                 val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
                                     putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-                                    putExtra(Settings.EXTRA_CHANNEL_ID, "monomail_${account.id}")
+                                    putExtra(Settings.EXTRA_CHANNEL_ID, NotificationChannelManager.channelIdFor(account.id, profile))
                                 }
                                 try {
                                     context.startActivity(intent)

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsComponents.kt
@@ -838,6 +838,23 @@ internal fun EmailTheme.displayName() = when (this) {
     EmailTheme.ORIGINAL -> "Original"
 }
 
+internal fun NotificationSound.displayName() = when (this) {
+    NotificationSound.DEFAULT -> "Default sound"
+    NotificationSound.SILENT -> "Silent"
+}
+
+internal fun NotificationImportance.displayName() = when (this) {
+    NotificationImportance.DEFAULT -> "Default"
+    NotificationImportance.URGENT -> "Urgent"
+    NotificationImportance.SILENT -> "Silent"
+}
+
+internal fun NotificationPreview.displayName() = when (this) {
+    NotificationPreview.FULL -> "Full content"
+    NotificationPreview.PRIVATE -> "Hide on lock screen"
+    NotificationPreview.NONE -> "Don't show"
+}
+
 internal fun EmailTheme.description() = when (this) {
     EmailTheme.AUTO     -> "Adapt simple emails to the app theme; show styled emails as sent"
     EmailTheme.ORIGINAL -> "Always show the sender's original colors on a light background"

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.shrivatsav.monomail.ui.theme.MonoSpring
 import com.shrivatsav.monomail.ui.theme.MonoTween
 import androidx.compose.ui.platform.LocalContext
+import com.shrivatsav.monomail.feature.settings.BuildConfig
 
 enum class SettingsSection(val icon: ImageVector, val title: String, val subtitle: String) {
     ACCOUNTS(Icons.Rounded.ManageAccounts, "Accounts", "Manage accounts, providers, connection status"),
@@ -49,7 +50,6 @@ fun SettingsScreen(
     onNavigateBack: () -> Unit,
     onNavigateToLegal: (String) -> Unit,
     onNavigateToPgpKeys: () -> Unit = {},
-    onNavigateToSampleCompose: () -> Unit = {},
 ) {
     var currentSection by remember { mutableStateOf<SettingsSection?>(null) }
     BackHandler(currentSection != null) { currentSection = null }
@@ -90,8 +90,7 @@ fun SettingsScreen(
             )
             SettingsSection.DEVELOPER -> DeveloperSettingsScreen(
                 viewModel = viewModel,
-                onBack = { currentSection = null },
-                onNavigateToSampleCompose = onNavigateToSampleCompose
+                onBack = { currentSection = null }
             )
             SettingsSection.NOTIFICATIONS -> NotificationSettingsScreen(
                 authManager = authManager,
@@ -286,12 +285,12 @@ private fun SettingsHubScreen(
         }
     }
 }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DeveloperSettingsScreen(
     viewModel: SettingsViewModel,
     onBack: () -> Unit,
-    onNavigateToSampleCompose: () -> Unit = {}
 ) {
     val settings by viewModel.settings.collectAsState()
     val context = LocalContext.current
@@ -307,134 +306,91 @@ internal fun DeveloperSettingsScreen(
                 checked = settings.isDeveloperMode,
                 onCheckedChange = { viewModel.setDeveloperMode(it) }
             )
-            CardDivider()
-            SettingsToggleRow(
-                icon = Icons.Rounded.FolderSpecial,
-                title = "Demo Smart Folders",
-                subtitle = "Enable smart folders demonstration",
-                checked = settings.demoSmartFolders,
-                onCheckedChange = { viewModel.setDemoSmartFolders(it) }
-            )
         }
         Spacer(Modifier.height(8.dp))
-        SettingsCard {
-            // Sample Attachments
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = onNavigateToSampleCompose)
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.AttachFile,
-                    contentDescription = "Sample Attachments",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(Modifier.width(14.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        "Sample Attachments",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurface
+        if (BuildConfig.DEBUG) {
+            SettingsCard {
+                // Preview Welcome button (dev only)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = {
+                            viewModel.resetWelcomePrompt()
+                            android.widget.Toast.makeText(
+                                context,
+                                "Welcome prompt will show on next app launch",
+                                android.widget.Toast.LENGTH_SHORT
+                            ).show()
+                        })
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Preview,
+                        contentDescription = "Preview Welcome",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
                     )
-                    Text(
-                        "Open compose with sample attachments for testing",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                    )
-                }
-                Spacer(Modifier.width(4.dp))
-                Icon(
-                    imageVector = Icons.Rounded.ChevronRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-            CardDivider()
-            // Preview Welcome button
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = {
-                        viewModel.resetWelcomePrompt()
-                        android.widget.Toast.makeText(
-                            context,
-                            "Welcome prompt will show on next app launch",
-                            android.widget.Toast.LENGTH_SHORT
-                        ).show()
-                    })
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Preview,
-                    contentDescription = "Preview Welcome",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(Modifier.width(14.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        "Preview Welcome",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    Text(
-                        "Reset welcome prompt and show modal on next app launch",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    Spacer(Modifier.width(14.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "Preview Welcome",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            "Reset welcome prompt and show modal on next app launch",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        )
+                    }
+                    Spacer(Modifier.width(4.dp))
+                    Icon(
+                        imageVector = Icons.Rounded.ChevronRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                        modifier = Modifier.size(18.dp)
                     )
                 }
-                Spacer(Modifier.width(4.dp))
-                Icon(
-                    imageVector = Icons.Rounded.ChevronRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-            CardDivider()
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = {
-                        throw RuntimeException("Intentional crash for testing purposes")
-                    })
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Warning,
-                    contentDescription = "Test Crash",
-                    tint = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(Modifier.width(14.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        "Test App Crash",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.error
+                CardDivider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = {
+                            throw RuntimeException("Intentional crash for testing purposes")
+                        })
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Warning,
+                        contentDescription = "Test Crash",
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(20.dp)
                     )
-                    Text(
-                        "Intentionally crash the app to verify crash handler",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
+                    Spacer(Modifier.width(14.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "Test App Crash",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                        Text(
+                            "Intentionally crash the app to verify crash handler",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
+                        )
+                    }
+                    Spacer(Modifier.width(4.dp))
+                    Icon(
+                        imageVector = Icons.Rounded.ChevronRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error.copy(alpha = 0.4f),
+                        modifier = Modifier.size(18.dp)
                     )
                 }
-                Spacer(Modifier.width(4.dp))
-                Icon(
-                    imageVector = Icons.Rounded.ChevronRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.error.copy(alpha = 0.4f),
-                    modifier = Modifier.size(18.dp)
-                )
             }
         }
     }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
@@ -34,6 +34,9 @@ class SettingsViewModel @Inject constructor(
     fun setDefaultReply(reply: DefaultReply) = viewModelScope.launch { settingsDataStore.setDefaultReply(reply) }
     fun setDisabledNotificationAccounts(accounts: Set<String>) = viewModelScope.launch { settingsDataStore.setDisabledNotificationAccounts(accounts) }
     fun setNotificationQuickActions(actions: Set<String>) = viewModelScope.launch { settingsDataStore.setNotificationQuickActions(actions) }
+    fun notificationProfileFlow(accountId: String) = settingsDataStore.notificationProfileFlow(accountId)
+    fun setNotificationProfile(accountId: String, profile: NotificationProfile) =
+        viewModelScope.launch { settingsDataStore.setNotificationProfile(accountId, profile) }
     fun setSyncFrequency(freq: SyncFrequency) = viewModelScope.launch { settingsDataStore.setSyncFrequency(freq) }
     fun setUnifiedInboxEnabled(enabled: Boolean) = viewModelScope.launch {
         settingsDataStore.setUnifiedInboxEnabled(enabled)
@@ -56,7 +59,6 @@ class SettingsViewModel @Inject constructor(
     fun setUndoSendWindow(window: UndoSendWindow) = viewModelScope.launch { settingsDataStore.setUndoSendWindow(window) }
     fun setDockConfig(config: DockConfig) = viewModelScope.launch { settingsDataStore.setDockConfig(config) }
     fun setDeveloperMode(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setDeveloperMode(enabled) }
-    fun setDemoSmartFolders(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setDemoSmartFolders(enabled) }
     fun setShowInlineImages(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowInlineImages(enabled) }
     fun setShowInlineAttachments(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowInlineAttachments(enabled) }
     fun setShowMarkAllRead(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setShowMarkAllRead(enabled) }


### PR DESCRIPTION
## Summary

Per-account notification customisation, replacing the global notification setup, and removal of placeholder/demo data from the app.

### Notification customisation (per account)
- New `NotificationProfile` (sound, alert style, vibration, lock-screen preview, badge) stored in DataStore under a per-account key — settings are independent per account.
- New `NotificationChannelManager`: each account gets its own channel named after the account email. Channel properties are immutable on Android, so any profile change deletes + recreates the channel; this also repairs channels created by older builds that were mislabeled with the first sender's name.
- Channels are deleted when an account is removed or signed out.
- Notifications apply the profile: channel importance/sound/vibration/badge plus lock-screen visibility (`FULL/PRIVATE/NONE` → `PUBLIC/PRIVATE/SECRET`) and badge-icon suppression.
- Settings → Notifications now shows a per-account panel (Alert style, Sound, Vibrate, Lock screen preview, App icon badge) with a deep link to the system channel settings.

### Placeholder data removal
- Removed the "Demo Smart Folders" developer toggle and its synthetic inbox items.
- Removed the "Sample Attachments" compose screen and route (`SampleCompose`).
- "Preview Welcome" and "Test App Crash" dev stubs are now gated behind `BuildConfig.DEBUG` (not shown in release builds).

## Verification
- `./gradlew.bat :app:assemblePlaystoreDebug` — BUILD SUCCESSFUL
- Installed playstore debug on Pixel 9a emulator (API 17) — success
- Grep confirms zero remaining references to removed symbols (`demoSmartFolders`, `SampleCompose`, `onNavigateToSampleCompose`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->