### PR TITLE
fix(imap): connection storm, send reliability, editable IMAP/SMTP config, settings modal redesign

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/MainActivity.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/MainActivity.kt
@@ -209,11 +209,10 @@ class MainActivity : ComponentActivity() {
             SyncFrequency.MIN_30 -> 30L
             SyncFrequency.HOUR_1 -> 60L
             SyncFrequency.MANUAL -> {
-                // Cancel periodic sync when user selects Manual
-                WorkManager.getInstance(this).cancelUniqueWork("EmailSyncWork")
-                // Still schedule push subscription renewal (independent of notification frequency)
-                scheduleRenewalWorker()
-                return
+                // Manual: no frequent background checks, but keep a quiet 6h
+                // safety-net sync so accounts never go fully stale (GitHub builds
+                // have no push to fall back on).
+                6 * 60L
             }
         }
         val workRequest = PeriodicWorkRequestBuilder<EmailSyncWorker>(

--- a/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
@@ -12,6 +12,7 @@ import com.shrivatsav.monomail.core.data.auth.provideGoogleAuthHelper
 import com.shrivatsav.monomail.core.network.provider.EmailProvider
 import com.shrivatsav.monomail.core.network.provider.GmailProvider
 import com.shrivatsav.monomail.core.network.provider.OutlookProvider
+import com.shrivatsav.monomail.core.network.provider.ProviderCache
 import com.shrivatsav.monomail.core.network.provider.imap.ImapAccountConfig
 import com.shrivatsav.monomail.core.network.provider.imap.ImapProvider
 import com.shrivatsav.monomail.core.network.remote.RetrofitClient
@@ -63,10 +64,9 @@ object AppModule {
         accountManager: AccountManager,
         authManager: AuthManager
     ): (UserProfile) -> EmailProvider {
-        val providerCache = java.util.concurrent.ConcurrentHashMap<String, EmailProvider>()
         return { profile ->
-            providerCache.getOrPut(profile.id) {
-                val retrofit = createRetrofitClient(profile, context, accountManager, authManager, providerCache)
+            ProviderCache.getOrCreate(profile.id) {
+                val retrofit = createRetrofitClient(profile, context, accountManager, authManager)
                 retrofit.cachedToken.set(profile.accessToken.takeIf { it.isNotEmpty() })
                 createProvider(profile, retrofit, context, authManager)
             }
@@ -77,10 +77,9 @@ object AppModule {
         profile: UserProfile,
         context: Context,
         accountManager: AccountManager,
-        authManager: AuthManager,
-        providerCache: java.util.concurrent.ConcurrentHashMap<String, EmailProvider>
+        authManager: AuthManager
     ) = RetrofitClient(
-        tokenRefresher = { refreshProfileToken(profile, context, accountManager, authManager, providerCache) },
+        tokenRefresher = { refreshProfileToken(profile, context, accountManager, authManager) },
         onRefreshFailed = { authManager.notifyReauthRequired(profile.email, profile.provider) },
         onHttpError = { code -> android.util.Log.w("AppModule", "HTTP $code for ${profile.id}") }
     )
@@ -89,8 +88,7 @@ object AppModule {
         profile: UserProfile,
         context: Context,
         accountManager: AccountManager,
-        authManager: AuthManager,
-        providerCache: java.util.concurrent.ConcurrentHashMap<String, EmailProvider>
+        authManager: AuthManager
     ): String? {
         // ponytail: runBlocking required — tokenRefresher is sync (OkHttp interceptor). Dispatchers.IO keeps DataStore ops off the dispatcher thread.
         val currentProfile = runBlocking(kotlinx.coroutines.Dispatchers.IO) { accountManager.getAccounts().find { it.id == profile.id } }
@@ -99,7 +97,7 @@ object AppModule {
             val newToken = fetchNewToken(currentProfile, context, authManager)
             if (newToken != null) {
                 runBlocking(kotlinx.coroutines.Dispatchers.IO) { authManager.updateAccessToken(currentProfile.copy(accessToken = newToken)) }
-                providerCache.remove(profile.id)
+                ProviderCache.invalidate(profile.id)
             }
             newToken
         } catch (e: GoogleAuthException) {

--- a/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/di/AppModule.kt
@@ -146,6 +146,7 @@ object AppModule {
         val config = ImapAccountConfig.fromJson(configJson)
         val password = SecurityUtil.decryptString(profile.refreshToken)
             ?: throw IllegalStateException("Cannot decrypt IMAP password")
+        android.util.Log.i("AppModule", "IMAP provider for ${profile.id}: smtpHost='${config.smtpHost}' smtpPort=${config.smtpPort} ssl=${config.smtpSsl} startTls=${config.smtpStartTls}")
         ImapProvider(config, password, context)
     } catch (e: Exception) {
         android.util.Log.e("AppModule", "Failed to create IMAP provider for ${profile.id}", e)

--- a/app/src/test/java/com/shrivatsav/monomail/MigrationTest.kt
+++ b/app/src/test/java/com/shrivatsav/monomail/MigrationTest.kt
@@ -3,14 +3,15 @@ package com.shrivatsav.monomail
 import com.shrivatsav.monomail.core.database.local.MIGRATION_2_3
 import com.shrivatsav.monomail.core.database.local.MIGRATION_3_4
 import com.shrivatsav.monomail.core.database.local.MIGRATION_4_5
+import com.shrivatsav.monomail.core.database.local.MIGRATION_18_19
 import org.junit.Test
 import org.junit.Assert.*
 
 class MigrationTest {
     @Test
     fun allMigrationsAreRegistered() {
-        val migrations = listOf(2 to 3, 3 to 4, 4 to 5)
-        val objects = listOf(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+        val migrations = listOf(2 to 3, 3 to 4, 4 to 5, 18 to 19)
+        val objects = listOf(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_18_19)
         for ((i, m) in migrations.withIndex()) {
             assertEquals(m.first, objects[i].startVersion)
             assertEquals(m.second, objects[i].endVersion)

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AccountManager.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AccountManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import com.shrivatsav.monomail.security.SecurityUtil
+import com.shrivatsav.monomail.core.network.provider.ProviderCache
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "auth_prefs")
 class AccountManager(private val context: Context) {
     companion object {
@@ -164,6 +165,9 @@ class AccountManager(private val context: Context) {
                     accounts[index] = accounts[index].copy(accessToken = newToken)
                     try { prefs[KEY_ACCOUNTS_JSON] = SecurityUtil.encryptString(gson.toJson(accounts)) } catch (e: Exception) { Log.e(TAG, "Failed to serialize accounts", e) }
                 }
+                // Providers cache config/token at construction; drop the cached
+                // instance so the next access rebuilds with the new settings.
+                ProviderCache.invalidate(accountId)
             }
         }
     }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/EmailRepository.kt
@@ -363,9 +363,16 @@ class EmailRepository(
     @Volatile private var lastBackfillFinished = 0L
     private val backfillCooldownMs = 5L * 60 * 1000
 
-    /** Concurrent IMAP body downloads per sweep; matches the connection pool
-     *  size so each downloader gets its own connection (Gmail allows 15). */
-    private val IMAP_BACKFILL_CONCURRENCY = 5
+    /** Concurrent IMAP body downloads per sweep. Deliberately BELOW the pool
+     *  size: the sync worker and other paths also lease pool connections, and
+     *  bursting 5 fresh connections within milliseconds was observed tripping
+     *  Gmail into `* BYE`-kicking the account (issue #129). 3 stays parallel
+     *  while keeping total connections per account comfortably under 15. */
+    private val IMAP_BACKFILL_CONCURRENCY = 3
+    /** Failed queued sends are retried on each drain (every sync); after this
+     *  many consecutive failures the row is dropped so a permanently failing
+     *  send (bad credentials, dead SMTP server) cannot retry forever. */
+    private val PENDING_SEND_MAX_RETRIES = 5
 
     suspend fun refreshInbox(tab: InboxTab, pageToken: String? = null, query: String? = null, accountId: String? = null): Result<String?> = refreshMutex.withLock {
         return try {
@@ -379,6 +386,13 @@ class EmailRepository(
             // than its own newest row. The old global cutoff made Sent/Archive/Spam
             // tabs return empty — those emails are older than the newest INBOX mail.
             // Null when the tab is empty → full folder fetch on first open.
+            // Clamped to "now": the stored cutoff is the newest header sent-date,
+            // which can be in the FUTURE (sender's clock ahead, or a synced
+            // device clock >24h ahead of the server). With the search cutoff
+            // being sent-date-minus-24h compared against the server's INTERNAL
+            //DATE (arrival), a future cutoff permanently starves new arrivals
+            // ("inbox doesn't sync"). Clamping keeps the fallback window at
+            // [now - 24h, now + server time], which always includes new mail.
             val sinceDate = when (tab) {
                 InboxTab.SENT -> emailDao.getLatestSentEmailDate(resolvedAccountId)
                 InboxTab.ARCHIVED -> emailDao.getLatestArchivedEmailDate(resolvedAccountId)
@@ -386,6 +400,9 @@ class EmailRepository(
                 InboxTab.SPAM -> emailDao.getLatestSpamEmailDate(resolvedAccountId)
                 InboxTab.DRAFTS -> emailDao.getLatestDraftEmailDate(resolvedAccountId)
                 else -> emailDao.getLatestInboxEmailDate(resolvedAccountId)
+            }?.let { stored ->
+                // Null when the tab is empty → full folder fetch on first open.
+                minOf(stored, System.currentTimeMillis())
             }
             val listResponse = provider.listThreads(
                 folder = folder,
@@ -603,6 +620,23 @@ class EmailRepository(
         }
     }
 
+    /** True when [e] (or any cause in its chain) indicates the connection
+     *  itself died — Gmail's `* BYE`, read timeout, EOF, connect refusal.
+     *  Protocol-level errors (bad folder, bad search term) return false. */
+    private fun isConnectionLevelImapError(e: Throwable): Boolean {
+        var cause: Throwable? = e
+        while (cause != null) {
+            val msg = cause.message ?: ""
+            if (msg.contains("BYE", ignoreCase = true) ||
+                cause is java.net.SocketTimeoutException ||
+                cause is java.io.EOFException ||
+                cause is java.net.ConnectException
+            ) return true
+            cause = cause.cause
+        }
+        return false
+    }
+
     private suspend fun runBodyBackfillSweep(accountId: String, maxEmails: Int) {
         val notifier = BodyBackfillNotificationHelper(context)
         var sweepCancelled = false
@@ -644,15 +678,18 @@ class EmailRepository(
             )
             // Download several threads at once — the IMAP connection pool
             // serves up to 5 concurrent connections (Gmail allows 15 per
-            // account), turning serial round trips into a ~5x faster sweep.
-            // Threads still dispatch in folder order (Inbox -> Sent -> ...),
-            // so folders finish mostly in sequence.
             val slots = Semaphore(IMAP_BACKFILL_CONCURRENCY)
             val progressMutex = Mutex()
+            // Once a connection-level error (Gmail `* BYE`, socket death)
+            // occurs, stop launching new work: every retry opens a fresh
+            // connection and feeds the reconnect storm that made the server
+            // kick us in the first place.
+            val connectionAborted = java.util.concurrent.atomic.AtomicBoolean(false)
             coroutineScope {
                 for (threadMeta in sortedThreadIds) {
                     launch {
                         slots.withPermit {
+                            if (connectionAborted.get()) return@withPermit
                             val threadId = threadMeta.threadId
                             val threadEmails = missing.filter { it.threadId == threadId }
                             // Search only the folders this thread's emails live in (labels are
@@ -691,11 +728,30 @@ class EmailRepository(
                                 }
                             } catch (e: jakarta.mail.MessagingException) {
                                 Log.w("EmailRepo", "Body backfill mail error for thread $threadId: ${e.message}")
+                                if (isConnectionLevelImapError(e)) {
+                                    // Gmail kicked us (`* BYE`) or the socket died
+                                    // mid-download. Abort the whole sweep — the
+                                    // remaining threads retry on the next sweep
+                                    // after the 5-min cooldown, when the server
+                                    // has had time to recover.
+                                    connectionAborted.set(true)
+                                    if (_bodyBackfillError.value == null) {
+                                        _bodyBackfillError.value = "Connection to mail server was lost. Email content will download on the next sync."
+                                    }
+                                    return@withPermit
+                                }
                                 if (_bodyBackfillError.value == null) {
                                     _bodyBackfillError.value = "Mail server error. Email content download will retry later."
                                 }
                             } catch (e: Exception) {
                                 Log.w("EmailRepo", "Body backfill failed for thread $threadId: ${e.message}")
+                                if (isConnectionLevelImapError(e)) {
+                                    connectionAborted.set(true)
+                                    if (_bodyBackfillError.value == null) {
+                                        _bodyBackfillError.value = "Connection to mail server was lost. Email content will download on the next sync."
+                                    }
+                                    return@withPermit
+                                }
                                 // Continue with next thread
                             }
                             // Progress advances per thread regardless of outcome, so a slow or
@@ -1239,10 +1295,34 @@ class EmailRepository(
             ),
             explicitAccountId = entity.accountId
         )
-        pendingSendDao.deleteById(id)
-        cleanupPendingAttachmentFiles(entity.attachmentsJson)
-        if (result.isFailure) {
-            Log.w("EmailRepo", "completePendingSend failed for $id", result.exceptionOrNull())
+        if (result.isSuccess) {
+            // Only remove the row once the email is actually delivered.
+            // Deleting before the failure check (the old behaviour) silently
+            // dropped the send on SMTP failure with no retry.
+            pendingSendDao.deleteById(id)
+            cleanupPendingAttachmentFiles(entity.attachmentsJson)
+            return
+        }
+        // Delivery failed: keep the row (and its attachment files) so the next
+        // drain retries. A cap stops a permanently failing send (bad
+        // credentials, dead server) from retrying forever on every sync.
+        val retries = entity.retryCount + 1
+        Log.w("EmailRepo", "completePendingSend failed for $id (attempt $retries/$PENDING_SEND_MAX_RETRIES)", result.exceptionOrNull())
+        if (retries >= PENDING_SEND_MAX_RETRIES) {
+            pendingSendDao.deleteById(id)
+            cleanupPendingAttachmentFiles(entity.attachmentsJson)
+            Log.w("EmailRepo", "Dropping pending send $id after $PENDING_SEND_MAX_RETRIES failed attempts")
+        } else {
+            pendingSendDao.updateRetryCount(id, retries)
+        }
+    }
+
+    /** Retry every queued send for one account. Called from the sync worker so
+     *  queued sends drain even when the inbox is never opened (the undo-send
+     *  countdown in InboxViewModel is only a fast path). */
+    suspend fun drainPendingSendsForAccount(accountId: String) {
+        for (entity in pendingSendDao.getAllForAccount(accountId)) {
+            completePendingSend(entity.id)
         }
     }
 

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/EmailSyncWorker.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/EmailSyncWorker.kt
@@ -65,8 +65,15 @@ class EmailSyncWorker @AssistedInject constructor(
         val accountId = account.id
         val lastKnownTimestamp = accountManager.getLastKnownEmailId(accountId)
         Log.i("EmailSyncWorker", "Starting sync for account $accountId (lastKnownTimestamp: $lastKnownTimestamp)")
+        // Deliver queued sends first: a send stuck in pending_sends (undo-send
+        // countdown expired without the app being opened) must not wait for
+        // the user to reopen the inbox. Failures keep the row for the next run.
+        try {
+            emailRepository.drainPendingSendsForAccount(accountId)
+        } catch (e: Exception) {
+            Log.w(TAG, "Draining pending sends failed for $accountId", e)
+        }
         val refreshResult = emailRepository.refreshInbox(InboxTab.INBOX, accountId = accountId)
-        Log.i("EmailSyncWorker", "Refresh result for $accountId: isSuccess=${refreshResult.isSuccess}")
 
         if (refreshResult.isFailure) {
             return handleSyncFailure(accountId, refreshResult.exceptionOrNull())

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/AppDatabase.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/AppDatabase.kt
@@ -8,7 +8,7 @@ import com.shrivatsav.monomail.security.SecurityUtil
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 @Database(
     entities = [ThreadEntity::class, EmailEntity::class, EmailFtsEntity::class, ScheduledMessageEntity::class, PendingActionEntity::class, PendingSendEntity::class],
-    version = 18,
+    version = 19,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -48,7 +48,7 @@ abstract class AppDatabase : RoomDatabase() {
                     dbFile.absolutePath
                 )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19)
                 .fallbackToDestructiveMigration(true)
                 .build()
                 INSTANCE = instance
@@ -254,5 +254,10 @@ val MIGRATION_17_18 = object : androidx.room.migration.Migration(17, 18) {
     override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE threads ADD COLUMN inDrafts INTEGER NOT NULL DEFAULT 0")
         db.execSQL("ALTER TABLE emails ADD COLUMN inDrafts INTEGER NOT NULL DEFAULT 0")
+    }
+}
+val MIGRATION_18_19 = object : androidx.room.migration.Migration(18, 19) {
+    override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE pending_sends ADD COLUMN retryCount INTEGER NOT NULL DEFAULT 0")
     }
 }

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/Entities.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/Entities.kt
@@ -188,7 +188,8 @@ data class PendingSendEntity(
     @ColumnInfo(defaultValue = "NULL") val fromAlias: String? = null,
     @ColumnInfo(defaultValue = "NULL") val threadId: String? = null,
     @ColumnInfo(defaultValue = "NULL") val messageId: String? = null,
-    @ColumnInfo(defaultValue = "NULL") val messageReferences: String? = null
+    @ColumnInfo(defaultValue = "NULL") val messageReferences: String? = null,
+    @ColumnInfo(defaultValue = "0") val retryCount: Int = 0
 )
 
 enum class PendingActionType {

--- a/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/PendingSendDao.kt
+++ b/core/database/src/main/java/com/shrivatsav/monomail/core/database/local/PendingSendDao.kt
@@ -25,4 +25,6 @@ interface PendingSendDao {
 
     @Query("DELETE FROM pending_sends WHERE id = :id")
     suspend fun deleteById(id: String)
+    @Query("UPDATE pending_sends SET retryCount = :count WHERE id = :id")
+    suspend fun updateRetryCount(id: String, count: Int)
 }

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/ProviderCache.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/ProviderCache.kt
@@ -1,0 +1,21 @@
+package com.shrivatsav.monomail.core.network.provider
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Process-wide cache of created [EmailProvider] instances keyed by account id.
+ *
+ * Providers hold their account's config/token at construction time, so any
+ * change (token refresh, IMAP/SMTP config edit) must invalidate the entry —
+ * the next access then rebuilds with fresh settings.
+ */
+object ProviderCache {
+    private val providers = ConcurrentHashMap<String, EmailProvider>()
+
+    fun getOrCreate(accountId: String, create: () -> EmailProvider): EmailProvider =
+        providers.getOrPut(accountId) { create() }
+
+    fun invalidate(accountId: String) {
+        providers.remove(accountId)
+    }
+}

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapAccountConfig.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapAccountConfig.kt
@@ -33,14 +33,41 @@ data class ImapAccountConfig(
     @SerializedName("authMethod") val authMethod: AuthMethod = AuthMethod.PASSWORD,
     @SerializedName("displayName") val displayName: String = ""
 ) {
+    /**
+     * The SMTP settings actually used at send time, after fallbacks and
+     * normalization:
+     * - blank host falls back to the IMAP host (most providers serve SMTP
+     *   on the same hostname)
+     * - port is derived (465 SSL / 587 STARTTLS) when SMTP was left at
+     *   setup defaults (blank host or port <= 0)
+     * - 587 is the IANA STARTTLS submission port: a stored 587+SSL config
+     *   (the setup UI defaults SSL on) normalizes to STARTTLS, since
+     *   implicit TLS on 587 fails the handshake on most servers
+     */
+    fun effectiveSmtp(): EffectiveSmtp {
+        val host = smtpHost.ifBlank { imapHost }
+        val port = if (smtpHost.isBlank() || smtpPort <= 0) {
+            if (smtpSsl) 465 else 587
+        } else {
+            smtpPort
+        }
+        val startTls = smtpStartTls || (smtpPort == 587 && smtpSsl)
+        val useSsl = smtpSsl && !(smtpPort == 587 && !smtpStartTls)
+        return EffectiveSmtp(host, port, startTls, useSsl)
+    }
+
+    /** A sender's FROM domain to use as the SMTP HELO hostname. */
+    fun heloDomain(from: String): String =
+        from.substringAfterLast("@").ifBlank { effectiveSmtp().host }
+
     fun toJson(): String = Gson().toJson(this)
-    
+
     /** Returns true if this is a Gmail/Googlemail account */
-    fun isGmail(): Boolean = 
-        imapHost.contains("gmail", ignoreCase = true) || 
+    fun isGmail(): Boolean =
+        imapHost.contains("gmail", ignoreCase = true) ||
         smtpHost.contains("gmail", ignoreCase = true) ||
         imapHost.contains("googlemail", ignoreCase = true)
-    
+
     companion object {
         fun fromJson(json: String): ImapAccountConfig = Gson().fromJson(json, ImapAccountConfig::class.java)
 
@@ -75,3 +102,13 @@ data class ImapAccountConfig(
         }
     }
 }
+
+/**
+ * Resolved SMTP settings: what [ImapAccountConfig.effectiveSmtp] produces.
+ */
+data class EffectiveSmtp(
+    val host: String,
+    val port: Int,
+    val startTls: Boolean,
+    val useSsl: Boolean
+)

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapConnectionPool.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapConnectionPool.kt
@@ -5,6 +5,7 @@ import jakarta.mail.Folder
 import jakarta.mail.Session
 import jakarta.mail.Store
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -44,26 +45,39 @@ class ImapConnectionPool(
      * Execute a block with a connected Store, leasing one of the pooled
      * connections. Creates a new connection when demand exceeds supply (up to
      * [poolSize]) and reconnects automatically if the connection dropped.
+     *
+     * Reconnects are bounded and back off exponentially: a server that keeps
+     * kicking us (Gmail sends `* BYE` and closes connections under connection
+     * pressure) must not be hammered with instant reconnects — that turns a
+     * single dropped connection into a reconnect storm.
      */
     suspend fun <T> withStore(block: suspend (Store) -> T): T = withContext(Dispatchers.IO) {
-        var active = leaseStore()
-        try {
+        var attempt = 0
+        while (true) {
+            val active = leaseStore()
             try {
-                block(active)
+                val result = block(active)
+                returnStore(active)
+                return@withContext result
             } catch (e: Exception) {
-                // Connection may have dropped — try once more after reconnect
-                if (!active.isConnected) {
-                    Log.w(tag, "Store disconnected, reconnecting")
-                    dropStore(active)
-                    active = leaseStore()
-                    block(active)
-                } else {
-                    throw e
+                val disconnected = !active.isConnected
+                // Drop dead stores, return healthy ones to the idle pool.
+                returnStore(active)
+                if (disconnected && attempt < STORE_RECONNECT_ATTEMPTS) {
+                    attempt++
+                    val delayMs = STORE_RECONNECT_BASE_DELAY_MS * attempt
+                    Log.w(tag, "Store disconnected, retrying in ${delayMs}ms (attempt $attempt/$STORE_RECONNECT_ATTEMPTS)")
+                    delay(delayMs)
+                    continue
                 }
+                throw e
             }
-        } finally {
-            returnStore(active)
         }
+        // Unreachable: the loop above only exits via return@withContext or
+        // throw. This Nothing-typed tail keeps the lambda's inferred type T
+        // instead of Unit (a bare while loop would fix T = Unit).
+        @Suppress("UNREACHABLE_CODE")
+        error("unreachable")
     }
 
     /**
@@ -252,5 +266,11 @@ class ImapConnectionPool(
         /** Gmail allows 15 simultaneous IMAP connections per account; 5 leaves
          *  headroom for other clients/devices while giving backfill ~5x speedup. */
         const val DEFAULT_POOL_SIZE = 5
+
+        /** Bounded reconnect attempts and linear backoff (2s, 4s, 6s) after a
+         *  connection is dropped, so a server that is kicking us (Gmail `* BYE`)
+         *  is not hammered with an instant-reconnect storm. */
+        private const val STORE_RECONNECT_ATTEMPTS = 3
+        private const val STORE_RECONNECT_BASE_DELAY_MS = 2000L
     }
 }

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
@@ -777,35 +777,13 @@ class ImapProvider(
 
     private fun buildSmtpProps(from: String): Properties {
         val props = Properties()
-        // Port 587 is the IANA STARTTLS submission port; implicit TLS on 587
-        // is non-standard and most servers there (Infomaniak included) speak
-        // plaintext + STARTTLS. The setup UI defaults SSL on, so a config
-        // stored as 587+SSL without STARTTLS is a misconfiguration that
-        // would fail the TLS handshake — normalize it to STARTTLS instead.
-        val startTls = config.smtpStartTls || (config.smtpPort == 587 && config.smtpSsl)
-        val useSsl = config.smtpSsl && !(config.smtpPort == 587 && !config.smtpStartTls)
-        val protocol = if (useSsl) "smtps" else "smtp"
-        // SMTP settings are optional in setup and legacy accounts may lack
-        // them entirely. An empty host makes JavaMail silently fall back to
-        // localhost:25 — a confusing send failure. Fall back to the IMAP
-        // host (most providers, Infomaniak included, serve SMTP on the same
-        // hostname) and a standard port.
-        val smtpHost = config.smtpHost.ifBlank { config.imapHost }
-        // A blank host means SMTP was left at setup defaults, so the stored
-        // port is untrustworthy too (defaults produce host="" + a port that
-        // does not match the derived host's protocol). Derive it from the
-        // TLS flags: 465 SMTPS or 587 STARTTLS, both verified against
-        // common providers.
-        val smtpPort = if (config.smtpHost.isBlank() || config.smtpPort <= 0) {
-            if (config.smtpSsl) 465 else 587
-        } else {
-            config.smtpPort
-        }
-        android.util.Log.i("ImapProvider", "SMTP props: protocol=$protocol host=$smtpHost port=$smtpPort ssl=$useSsl startTls=$startTls")
+        val eff = config.effectiveSmtp()
+        val protocol = if (eff.useSsl) "smtps" else "smtp"
+        android.util.Log.i("ImapProvider", "SMTP props: protocol=$protocol host=${eff.host} port=${eff.port} ssl=${eff.useSsl} startTls=${eff.startTls}")
         props["mail.transport.protocol"] = protocol
-        props["mail.$protocol.host"] = smtpHost
+        props["mail.$protocol.host"] = eff.host
         props["mail.$protocol.auth"] = "true"
-        if (startTls) props["mail.$protocol.starttls.enable"] = "true"
+        if (eff.startTls) props["mail.$protocol.starttls.enable"] = "true"
         props["mail.$protocol.connectiontimeout"] = "15000"
         props["mail.$protocol.timeout"] = "15000"
         props["mail.$protocol.writetimeout"] = "15000"
@@ -813,11 +791,11 @@ class ImapProvider(
         // hardcoded `mail.smtp.*` keys were silent no-ops under `smtps`
         // (Gmail/Yahoo/Zoho 465 presets), leaving HELO hostname and quitwait
         // at JavaMail defaults and — critically — server-identity checks off.
-        props["mail.$protocol.localhost"] = from.substringAfterLast("@").ifBlank { smtpHost }
+        props["mail.$protocol.localhost"] = config.heloDomain(from)
         props["mail.$protocol.quitwait"] = "false"
         props["mail.$protocol.ssl.protocols"] = "TLSv1.2 TLSv1.3"
-        if (useSsl || startTls) props["mail.$protocol.ssl.checkserveridentity"] = "true"
-        if (startTls) props["mail.$protocol.starttls.required"] = "true"
+        if (eff.useSsl || eff.startTls) props["mail.$protocol.ssl.checkserveridentity"] = "true"
+        if (eff.startTls) props["mail.$protocol.starttls.required"] = "true"
         return props
     }
 

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
@@ -608,6 +608,21 @@ class ImapProvider(
         saveToSentFolder(message)
         SendEmailResult(messageId = message.messageID, threadId = message.messageID)
     }
+    /** Verify SMTP connectivity and auth with the stored config without
+     *  sending anything. Used by the setup flow so a broken/blank SMTP
+     *  configuration is caught at account creation instead of at first send
+     *  (where it used to silently fail against localhost:25). */
+    fun testSmtpConnection(from: String = config.username) {
+        val session = Session.getInstance(buildSmtpProps(from), object : jakarta.mail.Authenticator() {
+            override fun getPasswordAuthentication() = jakarta.mail.PasswordAuthentication(config.username, password)
+        })
+        val transport = session.getTransport()
+        try {
+            transport.connect()
+        } finally {
+            try { transport.close() } catch (_: Exception) {}
+        }
+    }
 
     private fun buildMimeMessage(
         session: Session,
@@ -762,20 +777,47 @@ class ImapProvider(
 
     private fun buildSmtpProps(from: String): Properties {
         val props = Properties()
-        val protocol = if (config.smtpSsl) "smtps" else "smtp"
+        // Port 587 is the IANA STARTTLS submission port; implicit TLS on 587
+        // is non-standard and most servers there (Infomaniak included) speak
+        // plaintext + STARTTLS. The setup UI defaults SSL on, so a config
+        // stored as 587+SSL without STARTTLS is a misconfiguration that
+        // would fail the TLS handshake — normalize it to STARTTLS instead.
+        val startTls = config.smtpStartTls || (config.smtpPort == 587 && config.smtpSsl)
+        val useSsl = config.smtpSsl && !(config.smtpPort == 587 && !config.smtpStartTls)
+        val protocol = if (useSsl) "smtps" else "smtp"
+        // SMTP settings are optional in setup and legacy accounts may lack
+        // them entirely. An empty host makes JavaMail silently fall back to
+        // localhost:25 — a confusing send failure. Fall back to the IMAP
+        // host (most providers, Infomaniak included, serve SMTP on the same
+        // hostname) and a standard port.
+        val smtpHost = config.smtpHost.ifBlank { config.imapHost }
+        // A blank host means SMTP was left at setup defaults, so the stored
+        // port is untrustworthy too (defaults produce host="" + a port that
+        // does not match the derived host's protocol). Derive it from the
+        // TLS flags: 465 SMTPS or 587 STARTTLS, both verified against
+        // common providers.
+        val smtpPort = if (config.smtpHost.isBlank() || config.smtpPort <= 0) {
+            if (config.smtpSsl) 465 else 587
+        } else {
+            config.smtpPort
+        }
+        android.util.Log.i("ImapProvider", "SMTP props: protocol=$protocol host=$smtpHost port=$smtpPort ssl=$useSsl startTls=$startTls")
         props["mail.transport.protocol"] = protocol
-        props["mail.$protocol.host"] = config.smtpHost
-        props["mail.$protocol.port"] = config.smtpPort.toString()
+        props["mail.$protocol.host"] = smtpHost
         props["mail.$protocol.auth"] = "true"
-        if (config.smtpStartTls) props["mail.$protocol.starttls.enable"] = "true"
+        if (startTls) props["mail.$protocol.starttls.enable"] = "true"
         props["mail.$protocol.connectiontimeout"] = "15000"
         props["mail.$protocol.timeout"] = "15000"
         props["mail.$protocol.writetimeout"] = "15000"
-        props["mail.smtp.localhost"] = from.substringAfterLast("@").ifBlank { config.smtpHost }
-        props["mail.smtp.quitwait"] = "false"
+        // All keys must be prefixed with the ACTIVE protocol. The old
+        // hardcoded `mail.smtp.*` keys were silent no-ops under `smtps`
+        // (Gmail/Yahoo/Zoho 465 presets), leaving HELO hostname and quitwait
+        // at JavaMail defaults and — critically — server-identity checks off.
+        props["mail.$protocol.localhost"] = from.substringAfterLast("@").ifBlank { smtpHost }
+        props["mail.$protocol.quitwait"] = "false"
         props["mail.$protocol.ssl.protocols"] = "TLSv1.2 TLSv1.3"
-        if (config.smtpSsl || config.smtpStartTls) props["mail.$protocol.checkserveridentity"] = "true"
-        if (config.smtpStartTls) props["mail.$protocol.starttls.required"] = "true"
+        if (useSsl || startTls) props["mail.$protocol.ssl.checkserveridentity"] = "true"
+        if (startTls) props["mail.$protocol.starttls.required"] = "true"
         return props
     }
 
@@ -795,8 +837,8 @@ class ImapProvider(
     }
 
     private suspend fun saveToSentFolder(message: jakarta.mail.Message) {
-        val sentName = getFolderName(EmailFolder.SENT) ?: return
         try {
+            val sentName = getFolderName(EmailFolder.SENT) ?: return
             withStore { store ->
                 val sentFolder = store.getFolder(sentName)
                 if (sentFolder.exists()) {
@@ -810,6 +852,10 @@ class ImapProvider(
                 }
             }
         } catch (e: Exception) {
+            // Best-effort: the email was already delivered via SMTP. A failure
+            // here (e.g. the IMAP pool is saturated or the server kicked us)
+            // must never surface as a send failure — that makes users retry
+            // and send duplicates.
             android.util.Log.w("ImapProvider", "Failed to save to Sent folder", e)
         }
     }

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/ImapSetupViewModel.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/ImapSetupViewModel.kt
@@ -166,6 +166,18 @@ class ImapSetupViewModel @Inject constructor(
             try {
                 val provider = ImapProvider(config, _password.value, context)
                 provider.listThreads(com.shrivatsav.monomail.core.network.provider.EmailFolder.INBOX, 1)
+                // IMAP verified — now verify SMTP too, so a blank/wrong
+                // outgoing config is caught here and not at first send
+                // (where it used to silently fail against localhost:25).
+                try {
+                    provider.testSmtpConnection()
+                } catch (e: jakarta.mail.AuthenticationFailedException) {
+                    _testState.value = ImapTestState.Error("SMTP: wrong username or password")
+                    return@launch
+                } catch (e: jakarta.mail.MessagingException) {
+                    _testState.value = ImapTestState.Error("SMTP connection failed: ${e.message?.take(80)}")
+                    return@launch
+                }
                 pendingProfile = buildProfile(config)
                 _testState.value = ImapTestState.Verified
             } catch (e: AuthenticationFailedException) {
@@ -244,7 +256,7 @@ class ImapSetupViewModel @Inject constructor(
 
     private fun buildConfig(): ImapAccountConfig? {
         val iPort = _imapPort.value.toIntOrNull() ?: return null
-        val sPort = _smtpPort.value.toIntOrNull() ?: return null
+        val sPort = _smtpPort.value.toIntOrNull() ?: if (_smtpSsl.value) 465 else 587
 
         // Determine auth method based on Gmail mode
         val authMethod = if (_isGmailMode.value) {
@@ -252,13 +264,15 @@ class ImapSetupViewModel @Inject constructor(
         } else {
             AuthMethod.PASSWORD
         }
-        
+
         return ImapAccountConfig(
             imapHost = _imapHost.value,
             imapPort = iPort,
             imapSsl = _imapSsl.value,
             imapStartTls = _imapStartTls.value,
-            smtpHost = _smtpHost.value,
+            // A blank SMTP host reuses the IMAP host: most providers (and
+            // Infomaniak specifically) serve SMTP on the same hostname.
+            smtpHost = _smtpHost.value.ifBlank { _imapHost.value },
             smtpPort = sPort,
             smtpSsl = _smtpSsl.value,
             smtpStartTls = _smtpStartTls.value,

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
@@ -126,9 +126,12 @@ internal fun AccountsSettingsScreen(
         }
     }
 
-    selectedImapAccount?.let { account ->
+    // Resolve the selected account against the live list so the dialog
+    // re-reads the config after a save (the tap-time snapshot would stay stale).
+    selectedImapAccount?.let { selected ->
+        val current = accounts.firstOrNull { it.id == selected.id } ?: selected
         ImapAccountDetailDialog(
-            account = account,
+            account = current,
             authManager = authManager,
             onDismiss = { selectedImapAccount = null }
         )

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
@@ -3,6 +3,7 @@ package com.shrivatsav.monomail.feature.settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
@@ -11,7 +12,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import com.shrivatsav.monomail.core.network.provider.imap.ImapAccountConfig
 import com.shrivatsav.monomail.core.data.auth.AuthManager
 import com.shrivatsav.monomail.core.data.auth.UserProfile
@@ -107,6 +110,7 @@ internal fun AccountsSettingsScreen(
     selectedImapAccount?.let { account ->
         ImapAccountDetailDialog(
             account = account,
+            authManager = authManager,
             onDismiss = { selectedImapAccount = null }
         )
     }
@@ -115,14 +119,33 @@ internal fun AccountsSettingsScreen(
 @Composable
 private fun ImapAccountDetailDialog(
     account: UserProfile,
+    authManager: AuthManager,
     onDismiss: () -> Unit
 ) {
-    val config: ImapAccountConfig? = remember(account.id) {
+    val config: ImapAccountConfig? = remember(account) {
         try {
             val configJson = SecurityUtil.decryptString(account.accessToken)
             if (configJson != null) ImapAccountConfig.fromJson(configJson) else null
         } catch (e: Exception) { null }
     }
+    val scope = rememberCoroutineScope()
+    var editing by remember { mutableStateOf(false) }
+
+    // Field state is keyed on (config, editing) so entering edit mode always
+    // starts from the saved config — cancelling or saving discards stale edits.
+    var imapHost by remember(config, editing) { mutableStateOf(config?.imapHost ?: "") }
+    var imapPortStr by remember(config, editing) { mutableStateOf(config?.imapPort?.toString() ?: "") }
+    var imapSsl by remember(config, editing) { mutableStateOf(config?.imapSsl ?: true) }
+    var imapStartTls by remember(config, editing) { mutableStateOf(config?.imapStartTls ?: false) }
+    var smtpHost by remember(config, editing) { mutableStateOf(config?.smtpHost ?: "") }
+    var smtpPortStr by remember(config, editing) { mutableStateOf(config?.smtpPort?.takeIf { it > 0 }?.toString() ?: "") }
+    var smtpSsl by remember(config, editing) { mutableStateOf(config?.smtpSsl ?: true) }
+    var smtpStartTls by remember(config, editing) { mutableStateOf(config?.smtpStartTls ?: false) }
+
+    val imapPort = imapPortStr.toIntOrNull()
+    val smtpPort = smtpPortStr.toIntOrNull()
+    val portsValid = imapPort != null && imapPort in 1..65535 &&
+        (smtpPortStr.isBlank() || (smtpPort != null && smtpPort in 1..65535))
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -130,19 +153,88 @@ private fun ImapAccountDetailDialog(
             Icon(Icons.Rounded.Storage, contentDescription = null)
         },
         title = {
-            Text("IMAP Account")
+            Text(if (editing) "Edit IMAP Account" else "IMAP Account")
         },
         text = {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                DetailRow("Email", account.email)
-                DetailRow("Display Name", account.displayName.ifBlank { "—" })
+            if (config == null) {
+                Text(
+                    "Could not decrypt IMAP configuration",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            } else if (editing) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text("IMAP", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    OutlinedTextField(
+                        value = imapHost,
+                        onValueChange = { imapHost = it },
+                        label = { Text("IMAP Host") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = imapPortStr,
+                        onValueChange = { imapPortStr = it.filter(Char::isDigit) },
+                        label = { Text("IMAP Port") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                        Text("IMAP SSL", modifier = Modifier.weight(1f))
+                        Switch(checked = imapSsl, onCheckedChange = { imapSsl = it })
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                        Text("IMAP STARTTLS", modifier = Modifier.weight(1f))
+                        Switch(checked = imapStartTls, onCheckedChange = { imapStartTls = it })
+                    }
 
-                if (config != null) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    Text("SMTP", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    OutlinedTextField(
+                        value = smtpHost,
+                        onValueChange = { smtpHost = it },
+                        label = { Text("SMTP Host (blank = use IMAP host)") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = smtpPortStr,
+                        onValueChange = { smtpPortStr = it.filter(Char::isDigit) },
+                        label = { Text("SMTP Port (blank = auto)") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                        Text("SMTP SSL", modifier = Modifier.weight(1f))
+                        Switch(checked = smtpSsl, onCheckedChange = { smtpSsl = it })
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                        Text("SMTP STARTTLS", modifier = Modifier.weight(1f))
+                        Switch(checked = smtpStartTls, onCheckedChange = { smtpStartTls = it })
+                    }
+                    Text(
+                        "Tip: port 587 normally uses STARTTLS, port 465 uses SSL.",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    DetailRow("Email", account.email)
+                    DetailRow("Display Name", account.displayName.ifBlank { "—" })
+
                     HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                     DetailRow("IMAP Host", config.imapHost)
                     DetailRow("IMAP Port", config.imapPort.toString())
@@ -150,23 +242,53 @@ private fun ImapAccountDetailDialog(
                     DetailRow("IMAP STARTTLS", if (config.imapStartTls) "Yes" else "No")
 
                     HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    DetailRow("SMTP Host", config.smtpHost)
-                    DetailRow("SMTP Port", config.smtpPort.toString())
+                    DetailRow("SMTP Host", config.smtpHost.ifBlank { "auto (IMAP host)" })
+                    DetailRow("SMTP Port", if (config.smtpPort > 0) config.smtpPort.toString() else "auto")
                     DetailRow("SMTP SSL", if (config.smtpSsl) "Yes" else "No")
                     DetailRow("SMTP STARTTLS", if (config.smtpStartTls) "Yes" else "No")
 
                     HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                     DetailRow("Username", config.username.ifBlank { account.email })
-                } else {
-                    Text(
-                        "Could not decrypt IMAP configuration",
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall
-                    )
                 }
             }
         },
         confirmButton = {
+            if (editing) {
+                TextButton(onClick = { editing = false }) {
+                    Text("Cancel")
+                }
+                TextButton(
+                    onClick = {
+                        val saved = config ?: return@TextButton
+                        val newConfig = saved.copy(
+                            imapHost = imapHost.trim().ifBlank { saved.imapHost },
+                            imapPort = imapPort ?: saved.imapPort,
+                            imapSsl = imapSsl,
+                            imapStartTls = imapStartTls,
+                            smtpHost = smtpHost.trim(),
+                            smtpPort = smtpPort ?: 0,
+                            smtpSsl = smtpSsl,
+                            smtpStartTls = smtpStartTls
+                        )
+                        scope.launch {
+                            val encrypted = SecurityUtil.encryptString(newConfig.toJson())
+                            if (encrypted != null) {
+                                authManager.updateAccessToken(account.copy(accessToken = encrypted))
+                                editing = false
+                            }
+                        }
+                    },
+                    enabled = portsValid
+                ) {
+                    Text("Save")
+                }
+            } else {
+                TextButton(onClick = { editing = true }, enabled = config != null) {
+                    Text("Edit")
+                }
+            }
+        },
+        dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text("Close")
             }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
@@ -1,5 +1,15 @@
 package com.shrivatsav.monomail.feature.settings
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -13,12 +23,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import com.shrivatsav.monomail.core.network.provider.imap.ImapAccountConfig
 import com.shrivatsav.monomail.core.data.auth.AuthManager
 import com.shrivatsav.monomail.core.data.auth.UserProfile
 import com.shrivatsav.monomail.security.SecurityUtil
+import com.shrivatsav.monomail.core.network.provider.imap.EffectiveSmtp
+import com.shrivatsav.monomail.ui.theme.MonoOpacity
+import com.shrivatsav.monomail.ui.theme.cornerShape
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -129,126 +148,66 @@ private fun ImapAccountDetailDialog(
         } catch (e: Exception) { null }
     }
     val scope = rememberCoroutineScope()
+    val haptics = LocalHapticFeedback.current
+    val reauthInfo by authManager.reauthNeeded.collectAsState()
+    val isReauthNeeded = reauthInfo?.email == account.email
     var editing by remember { mutableStateOf(false) }
 
     // Field state is keyed on (config, editing) so entering edit mode always
     // starts from the saved config — cancelling or saving discards stale edits.
     var imapHost by remember(config, editing) { mutableStateOf(config?.imapHost ?: "") }
     var imapPortStr by remember(config, editing) { mutableStateOf(config?.imapPort?.toString() ?: "") }
-    var imapSsl by remember(config, editing) { mutableStateOf(config?.imapSsl ?: true) }
-    var imapStartTls by remember(config, editing) { mutableStateOf(config?.imapStartTls ?: false) }
+    var imapMode by remember(config, editing) { mutableStateOf(config?.let(::imapSecurityMode) ?: SecurityMode.SSL) }
     var smtpHost by remember(config, editing) { mutableStateOf(config?.smtpHost ?: "") }
     var smtpPortStr by remember(config, editing) { mutableStateOf(config?.smtpPort?.takeIf { it > 0 }?.toString() ?: "") }
-    var smtpSsl by remember(config, editing) { mutableStateOf(config?.smtpSsl ?: true) }
-    var smtpStartTls by remember(config, editing) { mutableStateOf(config?.smtpStartTls ?: false) }
+    var smtpMode by remember(config, editing) { mutableStateOf(config?.let(::smtpSecurityMode) ?: SecurityMode.SSL) }
 
     val imapPort = imapPortStr.toIntOrNull()
     val smtpPort = smtpPortStr.toIntOrNull()
-    val portsValid = imapPort != null && imapPort in 1..65535 &&
-        (smtpPortStr.isBlank() || (smtpPort != null && smtpPort in 1..65535))
+    val imapPortError = imapPortStr.isNotEmpty() && (imapPort == null || imapPort !in 1..65535)
+    val smtpPortError = smtpPortStr.isNotEmpty() && (smtpPort == null || smtpPort !in 1..65535)
+    val portsValid = !imapPortError && !smtpPortError
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        icon = {
-            Icon(Icons.Rounded.Storage, contentDescription = null)
-        },
-        title = {
-            Text(if (editing) "Edit IMAP Account" else "IMAP Account")
-        },
         text = {
-            if (config == null) {
-                Text(
+            when {
+                config == null -> Text(
                     "Could not decrypt IMAP configuration",
                     color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall
+                    style = MaterialTheme.typography.bodyMedium
                 )
-            } else if (editing) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text("IMAP", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                    OutlinedTextField(
-                        value = imapHost,
-                        onValueChange = { imapHost = it },
-                        label = { Text("IMAP Host") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    OutlinedTextField(
-                        value = imapPortStr,
-                        onValueChange = { imapPortStr = it.filter(Char::isDigit) },
-                        label = { Text("IMAP Port") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                        Text("IMAP SSL", modifier = Modifier.weight(1f))
-                        Switch(checked = imapSsl, onCheckedChange = { imapSsl = it })
+                else -> AnimatedContent(
+                    targetState = editing,
+                    transitionSpec = {
+                        (fadeIn(tween(220, easing = FastOutSlowInEasing)) +
+                            slideInVertically(tween(220, easing = FastOutSlowInEasing)) { it / 8 })
+                            .togetherWith(fadeOut(tween(150)))
+                    },
+                    label = "account-detail-mode"
+                ) { isEditing ->
+                    if (isEditing) {
+                        AccountEditContent(
+                            account = account,
+                            isReauthNeeded = isReauthNeeded,
+                            imapHost = imapHost,
+                            onImapHostChange = { imapHost = it },
+                            imapPortStr = imapPortStr,
+                            onImapPortChange = { imapPortStr = it.filter(Char::isDigit) },
+                            imapPortError = imapPortError,
+                            imapMode = imapMode,
+                            onImapMode = { imapMode = it; haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove) },
+                            smtpHost = smtpHost,
+                            onSmtpHostChange = { smtpHost = it },
+                            smtpPortStr = smtpPortStr,
+                            onSmtpPortChange = { smtpPortStr = it.filter(Char::isDigit) },
+                            smtpPortError = smtpPortError,
+                            smtpMode = smtpMode,
+                            onSmtpMode = { smtpMode = it; haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove) }
+                        )
+                    } else {
+                        AccountDetailContent(account = account, isReauthNeeded = isReauthNeeded, config = config)
                     }
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                        Text("IMAP STARTTLS", modifier = Modifier.weight(1f))
-                        Switch(checked = imapStartTls, onCheckedChange = { imapStartTls = it })
-                    }
-
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    Text("SMTP", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                    OutlinedTextField(
-                        value = smtpHost,
-                        onValueChange = { smtpHost = it },
-                        label = { Text("SMTP Host (blank = use IMAP host)") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    OutlinedTextField(
-                        value = smtpPortStr,
-                        onValueChange = { smtpPortStr = it.filter(Char::isDigit) },
-                        label = { Text("SMTP Port (blank = auto)") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                        Text("SMTP SSL", modifier = Modifier.weight(1f))
-                        Switch(checked = smtpSsl, onCheckedChange = { smtpSsl = it })
-                    }
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                        Text("SMTP STARTTLS", modifier = Modifier.weight(1f))
-                        Switch(checked = smtpStartTls, onCheckedChange = { smtpStartTls = it })
-                    }
-                    Text(
-                        "Tip: port 587 normally uses STARTTLS, port 465 uses SSL.",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            } else {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    DetailRow("Email", account.email)
-                    DetailRow("Display Name", account.displayName.ifBlank { "—" })
-
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    DetailRow("IMAP Host", config.imapHost)
-                    DetailRow("IMAP Port", config.imapPort.toString())
-                    DetailRow("IMAP SSL", if (config.imapSsl) "Yes" else "No")
-                    DetailRow("IMAP STARTTLS", if (config.imapStartTls) "Yes" else "No")
-
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    DetailRow("SMTP Host", config.smtpHost.ifBlank { "auto (IMAP host)" })
-                    DetailRow("SMTP Port", if (config.smtpPort > 0) config.smtpPort.toString() else "auto")
-                    DetailRow("SMTP SSL", if (config.smtpSsl) "Yes" else "No")
-                    DetailRow("SMTP STARTTLS", if (config.smtpStartTls) "Yes" else "No")
-
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                    DetailRow("Username", config.username.ifBlank { account.email })
                 }
             }
         },
@@ -260,6 +219,8 @@ private fun ImapAccountDetailDialog(
                 TextButton(
                     onClick = {
                         val saved = config ?: return@TextButton
+                        val (imapSsl, imapStartTls) = imapMode.toFlags()
+                        val (smtpSsl, smtpStartTls) = smtpMode.toFlags()
                         val newConfig = saved.copy(
                             imapHost = imapHost.trim().ifBlank { saved.imapHost },
                             imapPort = imapPort ?: saved.imapPort,
@@ -274,6 +235,7 @@ private fun ImapAccountDetailDialog(
                             val encrypted = SecurityUtil.encryptString(newConfig.toJson())
                             if (encrypted != null) {
                                 authManager.updateAccessToken(account.copy(accessToken = encrypted))
+                                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                                 editing = false
                             }
                         }
@@ -296,24 +258,335 @@ private fun ImapAccountDetailDialog(
     )
 }
 
+/** Identity: initials avatar, name/email, connection status. */
 @Composable
-private fun DetailRow(label: String, value: String) {
+private fun AccountIdentityHeader(account: UserProfile, isReauthNeeded: Boolean) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = initialsOf(account),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = account.displayName.ifBlank { account.email },
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .then(
+                            if (isReauthNeeded) {
+                                Modifier.border(1.5.dp, MaterialTheme.colorScheme.outline, CircleShape)
+                            } else {
+                                Modifier.background(MaterialTheme.colorScheme.onSurface)
+                            }
+                        )
+                )
+                Text(
+                    text = if (isReauthNeeded) "Session expired" else "Connected",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = MonoOpacity.secondary)
+                )
+                Text(
+                    text = "· ${account.provider.replaceFirstChar { it.uppercase() }}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = MonoOpacity.secondary)
+                )
+            }
+        }
+    }
+}
+
+private fun initialsOf(account: UserProfile): String {
+    val name = account.displayName.trim()
+    if (name.isNotEmpty()) {
+        val parts = name.split(Regex("\\s+")).filter { it.isNotEmpty() }
+        if (parts.size >= 2) return (parts[0].take(1) + parts[1].take(1)).uppercase()
+        return name.take(1).uppercase()
+    }
+    return account.email.take(1).uppercase()
+}
+
+/** Read-only view: identity + IMAP/SMTP section cards. */
+@Composable
+private fun AccountDetailContent(
+    account: UserProfile,
+    isReauthNeeded: Boolean,
+    config: ImapAccountConfig
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        AccountIdentityHeader(account, isReauthNeeded)
+
+        ConfigSectionCard(title = "IMAP", icon = Icons.Rounded.MoveToInbox) {
+            ConfigRow("Host", config.imapHost, mono = true)
+            ConfigRow("Port", config.imapPort.toString(), mono = true)
+            ConfigRow("Security", imapSecurityMode(config).label)
+            if (config.username.isNotBlank() && config.username != account.email) {
+                ConfigRow("Server user", config.username, mono = true)
+            }
+        }
+
+        ConfigSectionCard(title = "SMTP", icon = Icons.Rounded.Send) {
+            ConfigRow("Host", config.smtpHost.ifBlank { "Uses IMAP host" }, mono = true)
+            ConfigRow("Port", if (config.smtpPort > 0) config.smtpPort.toString() else "Auto", mono = true)
+            ConfigRow("Security", smtpSecurityMode(config).label)
+            val eff = config.effectiveSmtp()
+            Text(
+                text = "Effective: ${eff.host}:${eff.port} · ${eff.protocolLabel}",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = MonoOpacity.secondary),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 4.dp)
+            )
+        }
+    }
+}
+
+/** Edit view: same cards, host/port fields + security mode chips. */
+@Composable
+private fun AccountEditContent(
+    account: UserProfile,
+    isReauthNeeded: Boolean,
+    imapHost: String,
+    onImapHostChange: (String) -> Unit,
+    imapPortStr: String,
+    onImapPortChange: (String) -> Unit,
+    imapPortError: Boolean,
+    imapMode: SecurityMode,
+    onImapMode: (SecurityMode) -> Unit,
+    smtpHost: String,
+    onSmtpHostChange: (String) -> Unit,
+    smtpPortStr: String,
+    onSmtpPortChange: (String) -> Unit,
+    smtpPortError: Boolean,
+    smtpMode: SecurityMode,
+    onSmtpMode: (SecurityMode) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        AccountIdentityHeader(account, isReauthNeeded)
+
+        ConfigSectionCard(title = "IMAP", icon = Icons.Rounded.MoveToInbox) {
+            EditField(value = imapHost, onValueChange = onImapHostChange, label = "IMAP Host")
+            EditField(
+                value = imapPortStr,
+                onValueChange = onImapPortChange,
+                label = "IMAP Port",
+                number = true,
+                isError = imapPortError,
+                supportingText = if (imapPortError) "Enter a port from 1 to 65535" else null
+            )
+            SecurityModeChips(label = "Security", mode = imapMode, onSelect = onImapMode)
+        }
+
+        ConfigSectionCard(title = "SMTP", icon = Icons.Rounded.Send) {
+            EditField(
+                value = smtpHost,
+                onValueChange = onSmtpHostChange,
+                label = "SMTP Host",
+                placeholder = "Use IMAP host"
+            )
+            EditField(
+                value = smtpPortStr,
+                onValueChange = onSmtpPortChange,
+                label = "SMTP Port",
+                number = true,
+                placeholder = "Auto",
+                isError = smtpPortError,
+                supportingText = if (smtpPortError) "Enter a port from 1 to 65535" else null
+            )
+            SecurityModeChips(label = "Security", mode = smtpMode, onSelect = onSmtpMode)
+            Text(
+                "587 usually pairs with STARTTLS, 465 with SSL. Leaving the port blank auto-derives it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = MonoOpacity.secondary),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+            )
+        }
+    }
+}
+
+/** Grouped card matching the settings screens' visual language. */
+@Composable
+private fun ConfigSectionCard(
+    title: String,
+    icon: ImageVector,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Surface(
+        shape = cornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 0.dp,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(18.dp)
+                )
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+            content()
+        }
+    }
+}
+
+/** Label left, value right — technical values in monospace. */
+@Composable
+private fun ConfigRow(label: String, value: String, mono: Boolean = false) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.weight(0.4f)
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = MonoOpacity.secondary),
+            modifier = Modifier.weight(0.45f)
         )
         Text(
             text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
+            style = if (mono) {
+                MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace)
+            } else {
+                MaterialTheme.typography.bodyMedium
+            },
+            fontWeight = if (mono) FontWeight.Normal else FontWeight.Medium,
             color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.weight(0.6f)
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(0.55f)
         )
     }
 }
+
+@Composable
+private fun EditField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    placeholder: String? = null,
+    number: Boolean = false,
+    isError: Boolean = false,
+    supportingText: String? = null
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        placeholder = placeholder?.let { { Text(it) } },
+        singleLine = true,
+        isError = isError,
+        supportingText = supportingText?.let { { Text(it) } },
+        keyboardOptions = if (number) {
+            KeyboardOptions(keyboardType = KeyboardType.Number)
+        } else {
+            KeyboardOptions.Default
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+    )
+}
+
+/** One concept, three choices — replaces the old SSL/STARTTLS switch pair. */
+@Composable
+private fun SecurityModeChips(
+    label: String,
+    mode: SecurityMode,
+    onSelect: (SecurityMode) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = MonoOpacity.secondary)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            SecurityMode.entries.forEach { candidate ->
+                FilterChip(
+                    selected = mode == candidate,
+                    onClick = { onSelect(candidate) },
+                    label = { Text(candidate.label) }
+                )
+            }
+        }
+    }
+}
+
+private enum class SecurityMode(val label: String) {
+    NONE("None"),
+    STARTTLS("STARTTLS"),
+    SSL("SSL");
+
+    fun toFlags(): Pair<Boolean, Boolean> = when (this) {
+        NONE -> false to false
+        STARTTLS -> false to true
+        SSL -> true to false
+    }
+}
+
+private fun imapSecurityMode(config: ImapAccountConfig): SecurityMode = when {
+    config.imapSsl && !config.imapStartTls -> SecurityMode.SSL
+    config.imapStartTls -> SecurityMode.STARTTLS
+    else -> SecurityMode.NONE
+}
+
+private fun smtpSecurityMode(config: ImapAccountConfig): SecurityMode = when {
+    config.smtpSsl && !config.smtpStartTls -> SecurityMode.SSL
+    config.smtpStartTls -> SecurityMode.STARTTLS
+    else -> SecurityMode.NONE
+}
+
+private val EffectiveSmtp.protocolLabel: String
+    get() = when {
+        useSsl -> "SSL"
+        startTls -> "STARTTLS"
+        else -> "none"
+    }


### PR DESCRIPTION
## Summary

Four commits on top of the 1.8.2 bump: IMAP connection/sync hardening, reliable sending with retries, editable IMAP/SMTP credentials from the settings UI, and a redesigned account detail modal.

## Changes

**Connection & sync stability** (`8c6329de`)
- Pool: bounded reconnect with linear backoff (2s/4s/6s) instead of instant reconnect storm on server kicks (Gmail `* BYE`)
- Backfill: abort sweep on connection-level errors; concurrency 5 → 3
- Sync: clamp incremental cutoff to now — future-dated headers no longer starve new arrivals

**Send reliability** (`8c6329de`)
- `saveToSentFolder` fully best-effort — never fails a delivered send
- Pending sends kept on SMTP failure with 5-attempt cap + `retryCount` column (DB v19)
- Worker drains pending sends per account each sync

**Editable IMAP/SMTP config** (`65f7fac4`)
- Account detail dialog gains Edit mode: host/port/SSL/STARTTLS for IMAP and SMTP; blank SMTP host = use IMAP host, blank port = auto — persisted via encrypted config JSON
- `ProviderCache` singleton invalidates on any token/config change, so edits apply without restart
- Manual sync keeps a quiet 6h periodic sync instead of cancelling all background work (GitHub builds have no push fallback)

**Settings modal redesign** (`b3cc972d`)
- Identity header (initials avatar, display name, status dot, provider label)
- IMAP/SMTP as grouped section cards; SMTP shows resolved `Effective: host:port · TLS mode` via extracted `ImapAccountConfig.effectiveSmtp()` (send path now consumes the same normalization)
- Security as None/STARTTLS/SSL chips (one concept, three choices) replacing the ambiguous SSL+STARTTLS switch pair; inline port validation; haptic ticks
- 220ms/150ms crossfade between detail/edit modes

**Stale modal fix** (`dc616fb6`)
- Detail view re-reads the live account from `accountsFlow` after save instead of showing the tap-time snapshot

## Test plan
- `MigrationTest` updated for DB v19
- Manual: edit SMTP/IMAP settings → save → detail reflects changes immediately; trigger server kick → observe bounded backoff; send with SMTP down → message stays pending and retries on next sync

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->