### PR TITLE
feat: allow editing display name for imap accounts

### DIFF
--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AccountManager.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AccountManager.kt
@@ -171,6 +171,30 @@ class AccountManager(private val context: Context) {
             }
         }
     }
+    suspend fun updateAccount(updated: UserProfile) {
+        context.dataStore.edit { prefs ->
+            val json = prefs[KEY_ACCOUNTS_JSON]
+            if (json != null) {
+                val decryptedJson = SecurityUtil.decryptString(json)
+                if (decryptedJson == null) {
+                    Log.w(TAG, "Failed to decrypt accounts in updateAccount — treating as corrupt")
+                    _decryptionFailed.value = true
+                    return@edit
+                }
+                val type = object : TypeToken<List<UserProfile>>() {}.type
+                val accounts: MutableList<UserProfile> = gson.fromJson(decryptedJson, type)
+                val index = accounts.indexOfFirst { it.id == updated.id }
+                if (index != -1) {
+                    accounts[index] = updated
+                    val newJson = gson.toJson(accounts)
+                    val encrypted = SecurityUtil.encryptString(newJson)
+                    if (encrypted != null) {
+                        prefs[KEY_ACCOUNTS_JSON] = encrypted
+                    }
+                }
+            }
+        }
+    }
     suspend fun clearAll() {
         context.dataStore.edit { it.clear() }
     }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AuthManager.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/auth/AuthManager.kt
@@ -328,6 +328,12 @@ class AuthManager(
         _userProfile = updated
         accountManager.updateAccountToken(updated.id, updated.accessToken)
     }
+    suspend fun updateAccount(updated: UserProfile) {
+        if (_userProfile?.id == updated.id) {
+            _userProfile = updated
+        }
+        accountManager.updateAccount(updated)
+    }
     private suspend fun requestAccessToken(
         activityContext: Context,
         email: String,

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/EmailSyncWorker.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/EmailSyncWorker.kt
@@ -95,7 +95,11 @@ class EmailSyncWorker @AssistedInject constructor(
         val isLatestDraft = latestEmail?.inDrafts == true
         val isSelfSent = latestEmail?.fromEmail?.equals(account.email, ignoreCase = true) == true
 
-        if (lastKnownTimestamp != null && newTimestamp.toString() != lastKnownTimestamp && !isLatestDraft && !isSelfSent) {
+        val lastKnownLong = lastKnownTimestamp?.toLongOrNull() ?: 0L
+        val isTrulyNew = newTimestamp > lastKnownLong
+        val isUnread = !newestThread.isRead
+
+        if (lastKnownTimestamp != null && isTrulyNew && !isLatestDraft && !isSelfSent && isUnread) {
             val disabledAccounts = settingsDataStore.settingsFlow.value.disabledNotificationAccounts
             if (disabledAccounts.contains(accountId)) {
                 Log.i("EmailSyncWorker", "New email detected for $accountId, but notifications are disabled for this account. Skipping notification banner.")

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
@@ -612,7 +612,7 @@ class ImapProvider(
      *  sending anything. Used by the setup flow so a broken/blank SMTP
      *  configuration is caught at account creation instead of at first send
      *  (where it used to silently fail against localhost:25). */
-    fun testSmtpConnection(from: String = config.username) {
+    suspend fun testSmtpConnection(from: String = config.username) = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
         val session = Session.getInstance(buildSmtpProps(from), object : jakarta.mail.Authenticator() {
             override fun getPasswordAuthentication() = jakarta.mail.PasswordAuthentication(config.username, password)
         })

--- a/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/ImapSetupScreen.kt
+++ b/feature/auth/src/main/java/com/shrivatsav/monomail/feature/auth/ImapSetupScreen.kt
@@ -141,7 +141,14 @@ private fun ServerSection(
     onPortChange: (String) -> Unit,
     onSslChange: (Boolean) -> Unit,
     onStartTlsChange: (Boolean) -> Unit,
-    portImeAction: ImeAction
+    portImeAction: ImeAction,
+    hostLabel: String = "Host *",
+    hostPlaceholder: String? = null,
+    portLabel: String = "Port *",
+    portPlaceholder: String? = null,
+    hostError: Boolean = false,
+    portError: Boolean = false,
+    portSupportingText: String? = null
 ) {
     Spacer(modifier = Modifier.height(8.dp))
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -153,19 +160,24 @@ private fun ServerSection(
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         OutlinedTextField(
             value = host,
-            onValueChange = onHostChange,
-            label = { Text("Host") },
+            onValueChange = { onHostChange(it) },
+            label = { Text(hostLabel) },
+            placeholder = hostPlaceholder?.let { { Text(it) } },
             modifier = Modifier.weight(0.7f),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Next),
-            singleLine = true
+            singleLine = true,
+            isError = hostError
         )
         OutlinedTextField(
             value = port,
-            onValueChange = onPortChange,
-            label = { Text("Port") },
+            onValueChange = { onPortChange(it) },
+            label = { Text(portLabel) },
+            placeholder = portPlaceholder?.let { { Text(it) } },
             modifier = Modifier.weight(0.3f),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = portImeAction),
-            singleLine = true
+            singleLine = true,
+            isError = portError,
+            supportingText = portSupportingText?.let { { Text(it) } }
         )
     }
 
@@ -255,6 +267,12 @@ private fun ImapSetupForm(
     var showPassword by remember { mutableStateOf(false) }
     val uriHandler = LocalUriHandler.current
     var showAdvanced by remember { mutableStateOf(false) }
+    
+    var usernameError by remember { mutableStateOf(false) }
+    var passwordError by remember { mutableStateOf(false) }
+    var imapHostError by remember { mutableStateOf(false) }
+    var imapPortError by remember { mutableStateOf(false) }
+    var smtpPortError by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -272,22 +290,25 @@ private fun ImapSetupForm(
         // Email
         OutlinedTextField(
             value = username,
-            onValueChange = { viewModel.setUsername(it) },
-            label = { Text("Email Address") },
+            onValueChange = { viewModel.setUsername(it); usernameError = false },
+            label = { Text("Email Address *") },
             modifier = Modifier.fillMaxWidth(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
-            singleLine = true
+            singleLine = true,
+            isError = usernameError,
+            supportingText = if (usernameError) { { Text("Email is required") } } else null
         )
 
         // Password / App Password
         OutlinedTextField(
             value = password,
-            onValueChange = { viewModel.setPassword(it) },
-            label = { Text(if (isGmailMode) "Gmail App Password" else "Password") },
+            onValueChange = { viewModel.setPassword(it); passwordError = false },
+            label = { Text(if (isGmailMode) "Gmail App Password *" else "Password *") },
             modifier = Modifier.fillMaxWidth(),
             visualTransformation = if (showPassword) VisualTransformation.None else PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next),
             singleLine = true,
+            isError = passwordError,
             trailingIcon = {
                 IconButton(onClick = { showPassword = !showPassword }) {
                     Icon(
@@ -296,7 +317,9 @@ private fun ImapSetupForm(
                     )
                 }
             },
-            supportingText = if (isGmailMode) {
+            supportingText = if (passwordError) {
+                { Text("Password is required") }
+            } else if (isGmailMode) {
                 { Text("16-character app password from myaccount.google.com/apppasswords") }
             } else null
         )
@@ -366,11 +389,14 @@ private fun ImapSetupForm(
                     port = imapPort,
                     ssl = imapSsl,
                     startTls = imapStartTls,
-                    onHostChange = { viewModel.setImapHost(it) },
-                    onPortChange = { viewModel.setImapPort(it) },
+                    onHostChange = { viewModel.setImapHost(it); imapHostError = false },
+                    onPortChange = { viewModel.setImapPort(it); imapPortError = false },
                     onSslChange = { viewModel.setImapSsl(it) },
                     onStartTlsChange = { viewModel.setImapStartTls(it) },
-                    portImeAction = ImeAction.Next
+                    portImeAction = ImeAction.Next,
+                    hostError = imapHostError,
+                    portError = imapPortError,
+                    portSupportingText = if (imapPortError) "Enter a port from 1 to 65535" else null
                 )
 
                 ServerSection(
@@ -381,10 +407,23 @@ private fun ImapSetupForm(
                     ssl = smtpSsl,
                     startTls = smtpStartTls,
                     onHostChange = { viewModel.setSmtpHost(it) },
-                    onPortChange = { viewModel.setSmtpPort(it) },
+                    onPortChange = { viewModel.setSmtpPort(it); smtpPortError = false },
                     onSslChange = { viewModel.setSmtpSsl(it) },
                     onStartTlsChange = { viewModel.setSmtpStartTls(it) },
-                    portImeAction = ImeAction.Done
+                    portImeAction = ImeAction.Done,
+                    hostLabel = "Host",
+                    hostPlaceholder = "Use IMAP host",
+                    portLabel = "Port",
+                    portPlaceholder = "Auto",
+                    portError = smtpPortError,
+                    portSupportingText = if (smtpPortError) "Enter a port from 1 to 65535" else null
+                )
+                
+                Text(
+                    "587 usually pairs with STARTTLS, 465 with SSL. Leaving the port blank auto-derives it.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = com.shrivatsav.monomail.ui.theme.MonoOpacity.secondary),
+                    modifier = Modifier.padding(start = 4.dp, top = 2.dp, bottom = 8.dp)
                 )
             }
         }
@@ -392,7 +431,20 @@ private fun ImapSetupForm(
         Spacer(modifier = Modifier.height(8.dp))
 
         OutlinedButton(
-            onClick = onTestCredentials,
+            onClick = {
+                var valid = true
+                if (username.isBlank()) { usernameError = true; valid = false } else { usernameError = false }
+                if (password.isBlank()) { passwordError = true; valid = false } else { passwordError = false }
+                if (imapHost.isBlank()) { imapHostError = true; valid = false; showAdvanced = true } else { imapHostError = false }
+                
+                val iPort = imapPort.toIntOrNull()
+                if (iPort == null || iPort !in 1..65535) { imapPortError = true; valid = false; showAdvanced = true } else { imapPortError = false }
+
+                val sPort = smtpPort.toIntOrNull()
+                if (smtpPort.isNotBlank() && (sPort == null || sPort !in 1..65535)) { smtpPortError = true; valid = false; showAdvanced = true } else { smtpPortError = false }
+
+                if (valid) onTestCredentials()
+            },
             modifier = Modifier.fillMaxWidth().height(50.dp),
             enabled = !isBusy
         ) {

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AccountsSettingsScreen.kt
@@ -164,6 +164,7 @@ private fun ImapAccountDetailDialog(
     var smtpHost by remember(config, editing) { mutableStateOf(config?.smtpHost ?: "") }
     var smtpPortStr by remember(config, editing) { mutableStateOf(config?.smtpPort?.takeIf { it > 0 }?.toString() ?: "") }
     var smtpMode by remember(config, editing) { mutableStateOf(config?.let(::smtpSecurityMode) ?: SecurityMode.SSL) }
+    var displayName by remember(account.displayName, editing) { mutableStateOf(account.displayName) }
 
     val imapPort = imapPortStr.toIntOrNull()
     val smtpPort = smtpPortStr.toIntOrNull()
@@ -193,6 +194,8 @@ private fun ImapAccountDetailDialog(
                         AccountEditContent(
                             account = account,
                             isReauthNeeded = isReauthNeeded,
+                            displayName = displayName,
+                            onDisplayNameChange = { displayName = it },
                             imapHost = imapHost,
                             onImapHostChange = { imapHost = it },
                             imapPortStr = imapPortStr,
@@ -237,7 +240,7 @@ private fun ImapAccountDetailDialog(
                         scope.launch {
                             val encrypted = SecurityUtil.encryptString(newConfig.toJson())
                             if (encrypted != null) {
-                                authManager.updateAccessToken(account.copy(accessToken = encrypted))
+                                authManager.updateAccount(account.copy(accessToken = encrypted, displayName = displayName.trim()))
                                 haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                                 editing = false
                             }
@@ -372,6 +375,8 @@ private fun AccountDetailContent(
 private fun AccountEditContent(
     account: UserProfile,
     isReauthNeeded: Boolean,
+    displayName: String,
+    onDisplayNameChange: (String) -> Unit,
     imapHost: String,
     onImapHostChange: (String) -> Unit,
     imapPortStr: String,
@@ -394,6 +399,10 @@ private fun AccountEditContent(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         AccountIdentityHeader(account, isReauthNeeded)
+
+        ConfigSectionCard(title = "Identity", icon = Icons.Rounded.Person) {
+            EditField(value = displayName, onValueChange = onDisplayNameChange, label = "Display Name", placeholder = account.email)
+        }
 
         ConfigSectionCard(title = "IMAP", icon = Icons.Rounded.MoveToInbox) {
             EditField(value = imapHost, onValueChange = onImapHostChange, label = "IMAP Host")


### PR DESCRIPTION
Adds the ability to change the display name of IMAP accounts from the Accounts settings edit modal. Plumbs the update through `AuthManager` and `AccountManager` to ensure the entire profile is persisted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->