### PR TITLE
feat: add 24-hour time format setting

### DIFF
--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -541,8 +541,10 @@ fun NavGraph(
             }
             composable(Screen.Scheduled.route) {
                 val vm: ScheduledMessagesViewModel = hiltViewModel()
+                val appSettings by settingsDataStore.settingsFlow.collectAsState()
                 ScheduledMessagesScreen(
                     viewModel = vm,
+                    use24HourTime = appSettings.use24HourTime,
                     onBack = { navController.popBackStack() },
                     onCompose = {
                         navController.navigate(Screen.Compose.createRoute())

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
@@ -102,6 +102,7 @@ data class AppSettings(
     val monochromeTheme: Boolean = false,
     val swipeThreshold: Float = 0.40f,
     val addSignature: Boolean = true,
+    val use24HourTime: Boolean = false,
 )
 class SettingsDataStore(private val context: Context) {
     private val gson = Gson()
@@ -143,6 +144,7 @@ class SettingsDataStore(private val context: Context) {
         val MONOCHROME_THEME = booleanPreferencesKey("monochrome_theme")
         val SWIPE_THRESHOLD = floatPreferencesKey("swipe_threshold")
         val ADD_SIGNATURE = booleanPreferencesKey("add_signature")
+        val USE_24_HOUR_TIME = booleanPreferencesKey("use_24_hour_time")
         fun notificationProfileKey(accountId: String) =
             stringPreferencesKey("notification_profile_$accountId")
     }
@@ -193,6 +195,7 @@ class SettingsDataStore(private val context: Context) {
             monochromeTheme = prefs[Keys.MONOCHROME_THEME] ?: false,
             swipeThreshold = prefs[Keys.SWIPE_THRESHOLD]?.coerceIn(0.20f, 0.60f) ?: 0.40f,
             addSignature = prefs[Keys.ADD_SIGNATURE] ?: true,
+            use24HourTime = prefs[Keys.USE_24_HOUR_TIME] ?: false,
         )
     }
     private fun parseNotificationProfile(json: String?): NotificationProfile {
@@ -335,6 +338,9 @@ class SettingsDataStore(private val context: Context) {
     }
     suspend fun setSwipeThreshold(threshold: Float) {
         context.dataStore.edit { it[Keys.SWIPE_THRESHOLD] = threshold.coerceIn(0.20f, 0.60f) }
+    }
+    suspend fun setUse24HourTime(enabled: Boolean) {
+        context.dataStore.edit { it[Keys.USE_24_HOUR_TIME] = enabled }
     }
     suspend fun getTemplates(): List<EmailTemplate> {
         val prefs = context.dataStore.data.first()

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeScreen.kt
@@ -314,7 +314,7 @@ private fun DraftsModal(
 }
 
 @Composable
-private fun ComposeDialogs(state: ComposeUiState, viewModel: ComposeViewModel) {
+private fun ComposeDialogs(state: ComposeUiState, viewModel: ComposeViewModel, use24HourTime: Boolean) {
     if (state.showConfirmSendDialog) {
         AlertDialog(
             onDismissRequest = { viewModel.dismissConfirmSend() },
@@ -334,6 +334,7 @@ private fun ComposeDialogs(state: ComposeUiState, viewModel: ComposeViewModel) {
     }
     if (state.showSchedulePicker) {
         ScheduleSendDialog(
+            use24HourTime = use24HourTime,
             onDismiss = { viewModel.dismissSchedulePicker() },
             onSchedule = { millis -> viewModel.scheduleSend(millis) }
         )
@@ -420,6 +421,7 @@ fun ComposeScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val suggestions by viewModel.suggestions.collectAsState()
+    val use24HourTime by viewModel.use24HourTime.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
     val canSend = state.to.isNotBlank()
@@ -482,7 +484,7 @@ fun ComposeScreen(
             viewModel.dismissError()
         }
     }
-    ComposeDialogs(state, viewModel)
+    ComposeDialogs(state, viewModel, use24HourTime)
     if (showDrafts) {
         DraftsModal(
             drafts = drafts,
@@ -788,6 +790,7 @@ private fun FormatButton(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ScheduleSendDialog(
+    use24HourTime: Boolean,
     onDismiss: () -> Unit,
     onSchedule: (Long) -> Unit
 ) {
@@ -796,7 +799,7 @@ private fun ScheduleSendDialog(
     val timePickerState = rememberTimePickerState(
         initialHour = (java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY) + 1) % 24,
         initialMinute = 0,
-        is24Hour = true
+        is24Hour = use24HourTime
     )
     if (step == 0) {
         DatePickerDialog(

--- a/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeViewModel.kt
+++ b/feature/compose/src/main/java/com/shrivatsav/monomail/feature/compose/ComposeViewModel.kt
@@ -112,6 +112,9 @@ class ComposeViewModel @Inject constructor(
     val templatesFlow = settingsDataStore.templatesFlow
     val drafts: StateFlow<List<com.shrivatsav.monomail.data.model.EmailThread>> = repository.getDraftThreadsFlow(accountId)
         .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+    val use24HourTime: StateFlow<Boolean> = settingsDataStore.settingsFlow
+        .map { it.use24HourTime }
+        .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), false)
 
     val state: StateFlow<ComposeUiState> = _state.asStateFlow()
 

--- a/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
+++ b/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailScreen.kt
@@ -132,6 +132,7 @@ data class EmailDisplayConfig(
     val showInlineImages: Boolean = true,
     val showInlineAttachments: Boolean = true,
     val isDeveloperMode: Boolean = false,
+    val use24HourTime: Boolean = false,
     val currentUserEmail: String = ""
 )
 
@@ -156,6 +157,7 @@ fun EmailDetailScreen(
     val isStarred by viewModel.isStarred.collectAsState()
     val decryptedBodies by viewModel.decryptedBodies.collectAsState()
     val isDeveloperMode by viewModel.isDeveloperMode.collectAsState()
+    val use24HourTime by viewModel.use24HourTime.collectAsState()
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -236,6 +238,7 @@ fun EmailDetailScreen(
                 emailTheme = emailTheme,
                 showInlineImages = showInlineImages,
                 showInlineAttachments = showInlineAttachments,
+                use24HourTime = use24HourTime,
                 isDeveloperMode = isDeveloperMode,
                 currentUserEmail = viewModel.currentUserEmail
             ),
@@ -611,7 +614,7 @@ private fun ConversationEmailItem(
                         modifier = Modifier.weight(1f)
                     )
                     Text(
-                        text = formatRelativeDate(email.date),
+                        text = formatRelativeDate(email.date, config.use24HourTime),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
                     )
@@ -841,7 +844,7 @@ private fun MessageBodyContent(
     var showQuotedText by remember { mutableStateOf(false) }
     val hasQuotedText = remember(safeBodyText) { hasQuotedTextBlock(safeBodyText) }
     if (showSender) {
-        SenderInfoSection(email, messageCount)
+        SenderInfoSection(email, messageCount, config.use24HourTime)
     }
     if (showSender && !config.showInlineAttachments && email.attachments.isNotEmpty()) {
         Spacer(modifier = Modifier.height(8.dp))
@@ -961,11 +964,11 @@ private fun EncryptionBadge(decryptedResult: PgpDecryptionResult?) {
 }
 
 @Composable
-private fun SenderInfoSection(email: Email, messageCount: Int) {
+private fun SenderInfoSection(email: Email, messageCount: Int, use24HourTime: Boolean) {
     val isMsgUnread = !email.isRead
     var showCcBcc by remember { mutableStateOf(false) }
     Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp)) {
-        SenderDetails(email, isMsgUnread)
+        SenderDetails(email, isMsgUnread, use24HourTime)
         Spacer(modifier = Modifier.height(8.dp))
         ToRow(email) { showCcBcc = !showCcBcc }
         if (showCcBcc && (email.cc.isNotBlank() || email.bcc.isNotBlank())) {
@@ -982,7 +985,7 @@ private fun SenderInfoSection(email: Email, messageCount: Int) {
 }
 
 @Composable
-private fun SenderDetails(email: Email, isMsgUnread: Boolean) {
+private fun SenderDetails(email: Email, isMsgUnread: Boolean, use24HourTime: Boolean) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         AvatarCircle(
             photoUrl = null,
@@ -1004,7 +1007,7 @@ private fun SenderDetails(email: Email, isMsgUnread: Boolean) {
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = formatDetailDate(email.date),
+                    text = formatDetailDate(email.date, use24HourTime),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
                 )
@@ -1745,13 +1748,14 @@ private fun FileAttachmentsGrid(
     }
 }
 
-private val detailDateFormat = SimpleDateFormat("MMM d, yyyy  h:mm a", Locale.getDefault())
+private val detailDateFormat12 = SimpleDateFormat("MMM d, yyyy  h:mm a", Locale.getDefault())
+private val detailDateFormat24 = SimpleDateFormat("MMM d, yyyy  HH:mm", Locale.getDefault())
 
 /**
  * Returns a relative timestamp for recent messages ("2h ago", "Yesterday")
  * and falls back to the full date for older messages.
  */
-private fun formatRelativeDate(epochMillis: Long): String {
+private fun formatRelativeDate(epochMillis: Long, use24HourTime: Boolean): String {
     if (epochMillis == 0L) return ""
     val now = System.currentTimeMillis()
     val diff = now - epochMillis
@@ -1770,7 +1774,7 @@ private fun formatRelativeDate(epochMillis: Long): String {
             "${cal.get(java.util.Calendar.DAY_OF_MONTH)} $month"
         }
 
-        else -> formatDetailDate(epochMillis)
+        else -> formatDetailDate(epochMillis, use24HourTime)
     }
 }
 
@@ -1823,9 +1827,10 @@ private fun stripBodyInlineStyles(html: String): String {
 private val FIXED_WIDTH_ATTR = Regex("""\bwidth\s*=\s*["']?(5[4-9]\d|[6-8]\d\d)["']?""", RegexOption.IGNORE_CASE)
 private val FIXED_WIDTH_STYLE = Regex("""(?:width|min-width)\s*:\s*(5[4-9]\d|[6-8]\d\d)px""", RegexOption.IGNORE_CASE)
 
-private fun formatDetailDate(epochMillis: Long): String {
+private fun formatDetailDate(epochMillis: Long, use24HourTime: Boolean): String {
     if (epochMillis == 0L) return ""
-    return detailDateFormat.format(Date(epochMillis))
+    val formatter = if (use24HourTime) detailDateFormat24 else detailDateFormat12
+    return formatter.format(Date(epochMillis))
 }
 
 @Composable

--- a/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailViewModel.kt
+++ b/feature/detail/src/main/java/com/shrivatsav/monomail/feature/detail/EmailDetailViewModel.kt
@@ -114,6 +114,9 @@ class EmailDetailViewModel @Inject constructor(
     val showInlineAttachments: StateFlow<Boolean> = settingsDataStore.settingsFlow
         .map { it.showInlineAttachments }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+    val use24HourTime: StateFlow<Boolean> = settingsDataStore.settingsFlow
+        .map { it.use24HourTime }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     val state: StateFlow<EmailDetailState> = _threadId.flatMapLatest { id ->
         if (id.isEmpty()) {

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/InboxScreen.kt
@@ -169,10 +169,11 @@ fun InboxScreen(
             snackbarHostState.showSnackbar(errorMsg)
         }
     }
-
+    val currentAppSettings by rememberUpdatedState(appSettings)
     LaunchedEffect(Unit) {
         viewModel.scheduledEmailEvents.collect { event ->
-            val formatted = java.text.SimpleDateFormat("MMM dd, hh:mm a", java.util.Locale.getDefault())
+            val pattern = if (currentAppSettings.use24HourTime) "MMM dd, HH:mm" else "MMM dd, hh:mm a"
+            val formatted = java.text.SimpleDateFormat(pattern, java.util.Locale.getDefault())
                 .format(java.util.Date(event.scheduledAt))
             snackbarHostState.showSnackbar(
                 "Email scheduled for $formatted"
@@ -758,6 +759,7 @@ fun InboxScreen(
                 LongPressMenu(
                     thread = thread,
                     state = state,
+                    use24HourTime = appSettings.use24HourTime,
                     onDismiss = { longPressedThread = null },
                     actions = LongPressMenuActions(
                         onEmailClick = { navActions.onEmailClick(thread.threadId, thread.latestMessageId) },
@@ -1293,6 +1295,7 @@ private fun LongPressMenu(
     thread: EmailThread,
     state: InboxState,
     onDismiss: () -> Unit,
+    use24HourTime: Boolean,
     actions: LongPressMenuActions
 ) {
     val tabForMenu = (state as? InboxState.Success)?.currentTab ?: InboxTab.INBOX
@@ -1309,7 +1312,7 @@ private fun LongPressMenu(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Surface(shape = cornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {
-                EmailItem(thread = thread, onClick = { onDismiss(); actions.onEmailClick() }, onLongClick = {}, modifier = Modifier)
+                EmailItem(thread = thread, onClick = { onDismiss(); actions.onEmailClick() }, onLongClick = {}, use24HourTime = use24HourTime, modifier = Modifier)
             }
             Spacer(Modifier.height(8.dp))
             Surface(shape = cornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 0.dp, shadowElevation = 8.dp) {

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/EmailItem.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/EmailItem.kt
@@ -74,6 +74,7 @@ fun EmailItem(
     onClick: () -> Unit,
     onLongClick: () -> Unit = {},
     showSnippet: Boolean = true,
+    use24HourTime: Boolean = false,
     compactMode: Boolean = false,
     selection: SelectionState = SelectionState(),
     unreadPosition: UnreadPosition = UnreadPosition.SOLO,
@@ -160,7 +161,7 @@ fun EmailItem(
         }
         Spacer(modifier = Modifier.width(16.dp))
         Column(modifier = Modifier.weight(1f)) {
-            EmailItemSenderInfo(thread = thread, isUnread = isUnread)
+            EmailItemSenderInfo(thread = thread, isUnread = isUnread, use24HourTime = use24HourTime)
             EmailItemSubject(thread = thread, isUnread = isUnread)
             if (showSnippet) {
                 EmailItemSnippet(thread = thread, compactMode = compactMode)
@@ -171,7 +172,7 @@ fun EmailItem(
 
 
 @Composable
-private fun EmailItemSenderInfo(thread: EmailThread, isUnread: Boolean) {
+private fun EmailItemSenderInfo(thread: EmailThread, isUnread: Boolean, use24HourTime: Boolean) {
     val senderWeight = if (isUnread) FontWeight.ExtraBold else FontWeight.Medium
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -209,7 +210,7 @@ private fun EmailItemSenderInfo(thread: EmailThread, isUnread: Boolean) {
         }
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-            text = formatTimestamp(thread.date),
+            text = formatTimestamp(thread.date, use24HourTime),
             style = MaterialTheme.typography.labelSmall,
             fontWeight = if (isUnread) FontWeight.Bold else FontWeight.Medium,
             color = MaterialTheme.colorScheme.onSurface.copy(
@@ -310,12 +311,14 @@ private fun displayName(from: String): String {
     val nameMatch = displayNameRegex.find(from)
     return nameMatch?.groupValues?.get(1)?.trim() ?: from.trim()
 }
-private val timeFormatter = DateTimeFormatter.ofPattern("h:mm a", Locale.getDefault())
+private val time12Formatter = DateTimeFormatter.ofPattern("h:mm a", Locale.getDefault())
+private val time24Formatter = DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault())
 private val dayFormatter = DateTimeFormatter.ofPattern("EEE", Locale.getDefault())
 private val dateFormatter = DateTimeFormatter.ofPattern("MMM d", Locale.getDefault())
 private val fullDateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.getDefault())
 
-private fun formatTimestamp(epochMillis: Long): String {
+private fun formatTimestamp(epochMillis: Long, use24HourTime: Boolean): String {
+    val timeFormatter = if (use24HourTime) time24Formatter else time12Formatter
     if (epochMillis == 0L) return ""
     val zdt = Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault())
     val date = zdt.toLocalDate()

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SwipeableEmailItem.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/SwipeableEmailItem.kt
@@ -106,6 +106,7 @@ internal fun SwipeableEmailItem(
                 onClick = callbacks.onEmailClick,
                 onLongClick = callbacks.onLongClick,
                 showSnippet = appSettings.showSnippet,
+                use24HourTime = appSettings.use24HourTime,
                 compactMode = appSettings.compactList,
                 selection = SelectionState(
                     isSelected = selection.isSelected,
@@ -130,6 +131,7 @@ internal fun SwipeableEmailItem(
                     onClick = callbacks.onEmailClick,
                     onLongClick = callbacks.onLongClick,
                     showSnippet = appSettings.showSnippet,
+                    use24HourTime = appSettings.use24HourTime,
                     compactMode = appSettings.compactList,
                     selection = SelectionState(
                         isSelected = selection.isSelected,

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/scheduled/ScheduledMessagesScreen.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/scheduled/ScheduledMessagesScreen.kt
@@ -24,6 +24,7 @@ import java.util.*
 @Composable
 fun ScheduledMessagesScreen(
     viewModel: ScheduledMessagesViewModel,
+    use24HourTime: Boolean = false,
     onBack: () -> Unit,
     onCompose: () -> Unit = {},
     onEdit: (com.shrivatsav.monomail.core.database.local.ScheduledMessageEntity) -> Unit = {}
@@ -97,6 +98,7 @@ fun ScheduledMessagesScreen(
                 items(messages, key = { it.id }) { msg ->
                     ScheduledMessageItem(
                         message = msg,
+                        use24HourTime = use24HourTime,
                         onCancel = { viewModel.cancelSchedule(msg.id) },
                         onEdit = { onEdit(msg) }
                     )
@@ -109,10 +111,16 @@ fun ScheduledMessagesScreen(
 @Composable
 private fun ScheduledMessageItem(
     message: com.shrivatsav.monomail.core.database.local.ScheduledMessageEntity,
+    use24HourTime: Boolean,
     onCancel: () -> Unit,
     onEdit: () -> Unit = {}
 ) {
-    val dateFormat = remember { SimpleDateFormat("MMM dd, yyyy · hh:mm a", Locale.getDefault()) }
+    val dateFormat = remember(use24HourTime) {
+        SimpleDateFormat(
+            if (use24HourTime) "MMM dd, yyyy · HH:mm" else "MMM dd, yyyy · hh:mm a",
+            Locale.getDefault()
+        )
+    }
     var showCancelConfirm by remember { mutableStateOf(false) }
 
     Surface(

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AppearanceSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/AppearanceSettingsScreen.kt
@@ -97,6 +97,14 @@ internal fun AppearanceSettingsScreen(
                 checked = settings.showMarkAllRead,
                 onCheckedChange = { viewModel.setShowMarkAllRead(it) }
             )
+            CardDivider()
+            SettingsToggleRow(
+                icon = Icons.Rounded.Schedule,
+                title = "24-Hour Time",
+                subtitle = "Show times in 24-hour format (e.g. 15:30)",
+                checked = settings.use24HourTime,
+                onCheckedChange = { viewModel.setUse24HourTime(it) }
+            )
         }
 }
 }

--- a/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/shrivatsav/monomail/feature/settings/SettingsViewModel.kt
@@ -65,6 +65,7 @@ class SettingsViewModel @Inject constructor(
     fun setMonochromeTheme(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setMonochromeTheme(enabled) }
     fun setCornerStyle(style: com.shrivatsav.monomail.core.data.settings.CornerStyle) = viewModelScope.launch { settingsDataStore.setCornerStyle(style) }
     fun setSwipeThreshold(threshold: Float) = viewModelScope.launch { settingsDataStore.setSwipeThreshold(threshold) }
+    fun setUse24HourTime(enabled: Boolean) = viewModelScope.launch { settingsDataStore.setUse24HourTime(enabled) }
     fun resetWelcomePrompt() = viewModelScope.launch {
         settingsDataStore.setHasSeenWelcomePrompt(false)
     }


### PR DESCRIPTION
## What
Adds a **24-Hour Time** toggle (Settings → Appearance) that switches every time-of-day display between 12-hour (`h:mm a`) and 24-hour (`HH:mm`) format.

## Changes
- **Data**: `AppSettings.use24HourTime` (default `false` — existing 12-hour behavior preserved), prefs key `use_24_hour_time`, `setUse24HourTime()` setter
- **Settings UI**: toggle row in `AppearanceSettingsScreen`
- **Consumers**:
  - Inbox list timestamps (`EmailItem.kt`)
  - Detail header + conversation rows (`EmailDetailScreen.kt`, via `EmailDisplayConfig`)
  - "Email scheduled for…" snackbar (`InboxScreen.kt`)
  - Scheduled messages list (`ScheduledMessagesScreen.kt`)
  - Schedule-send TimePicker (`ComposeScreen.kt`) — previously hardcoded 24h, now follows the setting

## Verification
- `:app:compileGithubDebugKotlin` passes
- `:app:installPlaystoreDebug` installed and launched on Pixel 9a (Android 17)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->