### PR TITLE
Fix actionable issues from August

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,23 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.SENDTO" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="mailto" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -530,9 +530,77 @@ fun NavGraph(
                     navArgument("messageId") { type = NavType.StringType; defaultValue = "" },
                     navArgument("scheduledId") { type = NavType.StringType; defaultValue = "" },
                     navArgument("unified") { type = NavType.BoolType; defaultValue = false }
+                ),
+                deepLinks = listOf(
+                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_SEND; mimeType = "*/*" },
+                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_SEND_MULTIPLE; mimeType = "*/*" },
+                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_SENDTO; uriPattern = "mailto:.*" },
+                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_VIEW; uriPattern = "mailto:.*" }
                 )
-            ) { _ ->
+            ) { backStackEntry ->
                 val vm: ComposeViewModel = hiltViewModel()
+                val context = LocalContext.current
+                LaunchedEffect(Unit) {
+                    val intent = backStackEntry.arguments?.getParcelable(androidx.navigation.NavController.KEY_DEEP_LINK_INTENT) as? android.content.Intent
+                    if (intent != null) {
+                        val action = intent.action
+                        val type = intent.type
+                        if (action == android.content.Intent.ACTION_SENDTO || action == android.content.Intent.ACTION_VIEW) {
+                            val uri = intent.data
+                            if (uri != null && uri.scheme.equals("mailto", ignoreCase = true)) {
+                                uri.schemeSpecificPart?.let { vm.updateTo(it) }
+                                uri.getQueryParameter("subject")?.let { vm.updateSubject(it) }
+                                uri.getQueryParameter("body")?.let { vm.updateBody(it) }
+                            }
+                        }
+                        if (action == android.content.Intent.ACTION_SEND || action == android.content.Intent.ACTION_SENDTO || action == android.content.Intent.ACTION_VIEW) {
+                            intent.getStringExtra(android.content.Intent.EXTRA_EMAIL)?.let { vm.updateTo(it) }
+                            intent.getStringArrayExtra(android.content.Intent.EXTRA_EMAIL)?.firstOrNull()?.let { vm.updateTo(it) }
+                            intent.getStringExtra(android.content.Intent.EXTRA_SUBJECT)?.let { vm.updateSubject(it) }
+                            intent.getStringExtra(android.content.Intent.EXTRA_TEXT)?.let { vm.updateBody(it) }
+                            val streamUri = intent.getParcelableExtra<Uri>(android.content.Intent.EXTRA_STREAM)
+                            if (streamUri != null) {
+                                val resolver = context.contentResolver
+                                var name = "attachment"
+                                var size = 0L
+                                val mime = resolver.getType(streamUri) ?: "application/octet-stream"
+                                val cursor = resolver.query(streamUri, null, null, null, null)
+                                cursor?.use { c ->
+                                    if (c.moveToFirst()) {
+                                        val nameIndex = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                                        val sizeIndex = c.getColumnIndex(android.provider.OpenableColumns.SIZE)
+                                        if (nameIndex != -1) name = c.getString(nameIndex) ?: name
+                                        if (sizeIndex != -1) size = c.getLong(sizeIndex)
+                                    }
+                                }
+                                vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(streamUri, name, size, mime))
+                            }
+                        }
+                        if (action == android.content.Intent.ACTION_SEND_MULTIPLE) {
+                            intent.getStringExtra(android.content.Intent.EXTRA_EMAIL)?.let { vm.updateTo(it) }
+                            intent.getStringArrayExtra(android.content.Intent.EXTRA_EMAIL)?.firstOrNull()?.let { vm.updateTo(it) }
+                            intent.getStringExtra(android.content.Intent.EXTRA_SUBJECT)?.let { vm.updateSubject(it) }
+                            intent.getStringExtra(android.content.Intent.EXTRA_TEXT)?.let { vm.updateBody(it) }
+                            val streamUris = intent.getParcelableArrayListExtra<Uri>(android.content.Intent.EXTRA_STREAM)
+                            streamUris?.forEach { streamUri ->
+                                val resolver = context.contentResolver
+                                var name = "attachment"
+                                var size = 0L
+                                val mime = resolver.getType(streamUri) ?: "application/octet-stream"
+                                val cursor = resolver.query(streamUri, null, null, null, null)
+                                cursor?.use { c ->
+                                    if (c.moveToFirst()) {
+                                        val nameIndex = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                                        val sizeIndex = c.getColumnIndex(android.provider.OpenableColumns.SIZE)
+                                        if (nameIndex != -1) name = c.getString(nameIndex) ?: name
+                                        if (sizeIndex != -1) size = c.getLong(sizeIndex)
+                                    }
+                                }
+                                vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(streamUri, name, size, mime))
+                            }
+                        }
+                    }
+                }
                 ComposeScreen(
                     viewModel = vm,
                     onBack = { navController.popBackStack() },

--- a/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shrivatsav/monomail/ui/navigation/NavGraph.kt
@@ -1,5 +1,8 @@
 package com.shrivatsav.monomail.ui.navigation
+import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -45,6 +48,7 @@ import com.shrivatsav.monomail.feature.auth.SignInViewModel
 import com.shrivatsav.monomail.feature.compose.ComposeMode
 import com.shrivatsav.monomail.feature.compose.ComposeScreen
 import com.shrivatsav.monomail.feature.compose.ComposeViewModel
+import com.shrivatsav.monomail.data.model.EmailAttachment
 import com.shrivatsav.monomail.model.InboxTab
 import com.shrivatsav.monomail.feature.detail.EmailDetailScreen
 import com.shrivatsav.monomail.feature.detail.EmailDetailViewModel
@@ -532,74 +536,17 @@ fun NavGraph(
                     navArgument("unified") { type = NavType.BoolType; defaultValue = false }
                 ),
                 deepLinks = listOf(
-                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_SEND; mimeType = "*/*" },
-                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_SEND_MULTIPLE; mimeType = "*/*" },
-                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_SENDTO; uriPattern = "mailto:.*" },
-                    androidx.navigation.navDeepLink { action = android.content.Intent.ACTION_VIEW; uriPattern = "mailto:.*" }
+                    androidx.navigation.navDeepLink { action = Intent.ACTION_SEND; mimeType = "*/*" },
+                    androidx.navigation.navDeepLink { action = Intent.ACTION_SEND_MULTIPLE; mimeType = "*/*" },
+                    androidx.navigation.navDeepLink { action = Intent.ACTION_SENDTO; uriPattern = "mailto:.*" },
+                    androidx.navigation.navDeepLink { action = Intent.ACTION_VIEW; uriPattern = "mailto:.*" }
                 )
             ) { backStackEntry ->
                 val vm: ComposeViewModel = hiltViewModel()
                 val context = LocalContext.current
                 LaunchedEffect(Unit) {
-                    val intent = backStackEntry.arguments?.getParcelable(androidx.navigation.NavController.KEY_DEEP_LINK_INTENT) as? android.content.Intent
-                    if (intent != null) {
-                        val action = intent.action
-                        val type = intent.type
-                        if (action == android.content.Intent.ACTION_SENDTO || action == android.content.Intent.ACTION_VIEW) {
-                            val uri = intent.data
-                            if (uri != null && uri.scheme.equals("mailto", ignoreCase = true)) {
-                                uri.schemeSpecificPart?.let { vm.updateTo(it) }
-                                uri.getQueryParameter("subject")?.let { vm.updateSubject(it) }
-                                uri.getQueryParameter("body")?.let { vm.updateBody(it) }
-                            }
-                        }
-                        if (action == android.content.Intent.ACTION_SEND || action == android.content.Intent.ACTION_SENDTO || action == android.content.Intent.ACTION_VIEW) {
-                            intent.getStringExtra(android.content.Intent.EXTRA_EMAIL)?.let { vm.updateTo(it) }
-                            intent.getStringArrayExtra(android.content.Intent.EXTRA_EMAIL)?.firstOrNull()?.let { vm.updateTo(it) }
-                            intent.getStringExtra(android.content.Intent.EXTRA_SUBJECT)?.let { vm.updateSubject(it) }
-                            intent.getStringExtra(android.content.Intent.EXTRA_TEXT)?.let { vm.updateBody(it) }
-                            val streamUri = intent.getParcelableExtra<Uri>(android.content.Intent.EXTRA_STREAM)
-                            if (streamUri != null) {
-                                val resolver = context.contentResolver
-                                var name = "attachment"
-                                var size = 0L
-                                val mime = resolver.getType(streamUri) ?: "application/octet-stream"
-                                val cursor = resolver.query(streamUri, null, null, null, null)
-                                cursor?.use { c ->
-                                    if (c.moveToFirst()) {
-                                        val nameIndex = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                                        val sizeIndex = c.getColumnIndex(android.provider.OpenableColumns.SIZE)
-                                        if (nameIndex != -1) name = c.getString(nameIndex) ?: name
-                                        if (sizeIndex != -1) size = c.getLong(sizeIndex)
-                                    }
-                                }
-                                vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(streamUri, name, size, mime))
-                            }
-                        }
-                        if (action == android.content.Intent.ACTION_SEND_MULTIPLE) {
-                            intent.getStringExtra(android.content.Intent.EXTRA_EMAIL)?.let { vm.updateTo(it) }
-                            intent.getStringArrayExtra(android.content.Intent.EXTRA_EMAIL)?.firstOrNull()?.let { vm.updateTo(it) }
-                            intent.getStringExtra(android.content.Intent.EXTRA_SUBJECT)?.let { vm.updateSubject(it) }
-                            intent.getStringExtra(android.content.Intent.EXTRA_TEXT)?.let { vm.updateBody(it) }
-                            val streamUris = intent.getParcelableArrayListExtra<Uri>(android.content.Intent.EXTRA_STREAM)
-                            streamUris?.forEach { streamUri ->
-                                val resolver = context.contentResolver
-                                var name = "attachment"
-                                var size = 0L
-                                val mime = resolver.getType(streamUri) ?: "application/octet-stream"
-                                val cursor = resolver.query(streamUri, null, null, null, null)
-                                cursor?.use { c ->
-                                    if (c.moveToFirst()) {
-                                        val nameIndex = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                                        val sizeIndex = c.getColumnIndex(android.provider.OpenableColumns.SIZE)
-                                        if (nameIndex != -1) name = c.getString(nameIndex) ?: name
-                                        if (sizeIndex != -1) size = c.getLong(sizeIndex)
-                                    }
-                                }
-                                vm.addAttachment(com.shrivatsav.monomail.data.model.EmailAttachment(streamUri, name, size, mime))
-                            }
-                        }
-                    }
+                    val intent = backStackEntry.arguments?.getParcelable(androidx.navigation.NavController.KEY_DEEP_LINK_INTENT) as? Intent
+                    if (intent != null) applyComposeIntent(intent, context, vm)
                 }
                 ComposeScreen(
                     viewModel = vm,
@@ -641,4 +588,48 @@ fun NavGraph(
             }
         }
     }
+}
+
+/**
+ * Reads display name, size and mime type for a shared content URI.
+ */
+private fun readSharedAttachment(context: Context, uri: Uri): EmailAttachment {
+    val resolver = context.contentResolver
+    var name = "attachment"
+    var size = 0L
+    val mime = resolver.getType(uri) ?: "application/octet-stream"
+    resolver.query(uri, null, null, null, null)?.use { c ->
+        if (c.moveToFirst()) {
+            val nameIndex = c.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            val sizeIndex = c.getColumnIndex(OpenableColumns.SIZE)
+            if (nameIndex != -1) name = c.getString(nameIndex) ?: name
+            if (sizeIndex != -1) size = c.getLong(sizeIndex)
+        }
+    }
+    return EmailAttachment(uri, name, size, mime)
+}
+
+/**
+ * Populates the compose screen from a share-sheet / mailto deep link intent.
+ */
+private fun applyComposeIntent(intent: Intent, context: Context, vm: ComposeViewModel) {
+    val action = intent.action
+    if (action == Intent.ACTION_SENDTO || action == Intent.ACTION_VIEW) {
+        intent.data?.takeIf { it.scheme.equals("mailto", ignoreCase = true) }?.let { uri ->
+            uri.schemeSpecificPart?.let { vm.updateTo(it) }
+            uri.getQueryParameter("subject")?.let { vm.updateSubject(it) }
+            uri.getQueryParameter("body")?.let { vm.updateBody(it) }
+        }
+    }
+    intent.getStringExtra(Intent.EXTRA_EMAIL)?.let { vm.updateTo(it) }
+    intent.getStringArrayExtra(Intent.EXTRA_EMAIL)?.firstOrNull()?.let { vm.updateTo(it) }
+    intent.getStringExtra(Intent.EXTRA_SUBJECT)?.let { vm.updateSubject(it) }
+    intent.getStringExtra(Intent.EXTRA_TEXT)?.let { vm.updateBody(it) }
+
+    val streamUris = if (action == Intent.ACTION_SEND_MULTIPLE) {
+        intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM).orEmpty()
+    } else {
+        listOfNotNull(intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM))
+    }
+    streamUris.forEach { vm.addAttachment(readSharedAttachment(context, it)) }
 }

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
@@ -179,6 +179,7 @@ class SettingsDataStore(private val context: Context) {
             dockConfig = dockConfigJson?.let { json ->
                 try {
                     val raw = gson.fromJson(json, DockConfig::class.java)
+                    // Gson may silently produce broken objects (null/wrong-type primaryTabs)
                     // when deserializing Kotlin data classes via Unsafe. Validate the result.
                     val tabs = raw?.primaryTabs
                     @Suppress("SENSELESS_COMPARISON") // Gson Unsafe may produce wrong-type elements at runtime

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/settings/SettingsDataStore.kt
@@ -162,6 +162,7 @@ class SettingsDataStore(private val context: Context) {
             notificationQuickActions = prefs[Keys.NOTIFICATION_QUICK_ACTIONS]
                 ?: setOf("reply", "archive", "delete", "snooze"),
             disabledNotificationAccounts = prefs[Keys.DISABLED_NOTIF_ACCOUNTS] ?: emptySet(),
+            syncFrequency = prefs[Keys.SYNC_FREQUENCY]?.let { SyncFrequency.valueOf(it) } ?: SyncFrequency.MIN_15,
             unifiedInboxEnabled = prefs[Keys.UNIFIED_INBOX_ENABLED] ?: false,
             hasSeenWelcomePrompt = prefs[Keys.HAS_SEEN_WELCOME_PROMPT] ?: false,
             smartGroupingEnabled = prefs[Keys.SMART_GROUPING_ENABLED] ?: true,
@@ -178,7 +179,6 @@ class SettingsDataStore(private val context: Context) {
             dockConfig = dockConfigJson?.let { json ->
                 try {
                     val raw = gson.fromJson(json, DockConfig::class.java)
-                    // Gson may silently produce broken objects (null/wrong-type primaryTabs)
                     // when deserializing Kotlin data classes via Unsafe. Validate the result.
                     val tabs = raw?.primaryTabs
                     @Suppress("SENSELESS_COMPARISON") // Gson Unsafe may produce wrong-type elements at runtime

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
@@ -467,7 +467,7 @@ class ImapProvider(
                 val messages = srcFolder.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId))
                 if (messages.isNotEmpty()) {
                     srcFolder.copyMessages(messages, destFolder)
-                    srcFolder.setFlags(messages, jakarta.mail.Flags(jakarta.mail.Flags.Flag.DELETED), true)
+                    srcFolder.setFlags(messages, Flags(Flags.Flag.DELETED), true)
                     srcFolder.expunge()
                 }
             } catch (e: Exception) {
@@ -482,9 +482,13 @@ class ImapProvider(
         moveThread(threadId, EmailFolder.ARCHIVE)
     }
 
-    override suspend fun unarchiveThread(threadId: String) = withStore { store ->
-        val srcName = getFolderName(EmailFolder.ARCHIVE) ?: return@withStore
-        val destName = getFolderName(EmailFolder.INBOX) ?: return@withStore
+    private suspend fun moveThreadBetween(
+        threadId: String,
+        source: EmailFolder,
+        destination: EmailFolder
+    ) = withStore { store ->
+        val srcName = getFolderName(source) ?: return@withStore
+        val destName = getFolderName(destination) ?: return@withStore
         val srcFolder = store.getFolder(srcName)
         val destFolder = store.getFolder(destName)
         if (!srcFolder.exists()) return@withStore
@@ -498,36 +502,22 @@ class ImapProvider(
                 srcFolder.expunge()
             }
         } catch (e: Exception) {
-            // Ignore
+            // Ignore folder open/search errors and leave the thread in place
         } finally {
             if (srcFolder.isOpen) srcFolder.close(true)
         }
+    }
+
+    override suspend fun unarchiveThread(threadId: String) {
+        moveThreadBetween(threadId, EmailFolder.ARCHIVE, EmailFolder.INBOX)
     }
 
     override suspend fun trashThread(threadId: String) {
         moveThread(threadId, EmailFolder.TRASH)
     }
 
-    override suspend fun restoreThread(threadId: String) = withStore { store ->
-        val srcName = getFolderName(EmailFolder.TRASH) ?: return@withStore
-        val destName = getFolderName(EmailFolder.INBOX) ?: return@withStore
-        val srcFolder = store.getFolder(srcName)
-        val destFolder = store.getFolder(destName)
-        if (!srcFolder.exists()) return@withStore
-
-        try {
-            srcFolder.open(Folder.READ_WRITE)
-            val messages = srcFolder.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId))
-            if (messages.isNotEmpty()) {
-                srcFolder.copyMessages(messages, destFolder)
-                srcFolder.setFlags(messages, Flags(Flags.Flag.DELETED), true)
-                srcFolder.expunge()
-            }
-        } catch (e: Exception) {
-            // Ignore
-        } finally {
-            if (srcFolder.isOpen) srcFolder.close(true)
-        }
+    override suspend fun restoreThread(threadId: String) {
+        moveThreadBetween(threadId, EmailFolder.TRASH, EmailFolder.INBOX)
     }
 
     override suspend fun permanentlyDeleteThread(threadId: String) = withStore { store ->

--- a/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
+++ b/core/network/src/main/java/com/shrivatsav/monomail/core/network/provider/imap/ImapProvider.kt
@@ -111,8 +111,8 @@ class ImapProvider(
         val imapFolder = openListFolder(store, folder)
             ?: return@withStore ProviderThreadListResult(emptyList(), null)
 
-        imapFolder.open(Folder.READ_ONLY)
         try {
+            imapFolder.open(Folder.READ_ONLY)
             val fetchResult: FetchResult?
             var nextToken: String? = null
 
@@ -166,6 +166,8 @@ class ImapProvider(
                 .sortedByDescending { t -> t.messages.maxOfOrNull { it.date } ?: 0L }
 
             ProviderThreadListResult(threads, nextToken)
+        } catch (e: Exception) {
+            ProviderThreadListResult(emptyList(), null)
         } finally {
             if (imapFolder.isOpen) imapFolder.close(false)
         }
@@ -318,8 +320,8 @@ class ImapProvider(
         val f = store.getFolder(folderName)
         if (!f.exists()) return
 
-        f.open(Folder.READ_ONLY)
         try {
+            f.open(Folder.READ_ONLY)
             val orTerm = jakarta.mail.search.OrTerm(
                 jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId),
                 jakarta.mail.search.OrTerm(
@@ -341,6 +343,8 @@ class ImapProvider(
                 val raw = threadMessageToRaw(msg, threadId) ?: continue
                 rawMessages.add(raw)
             }
+        } catch (e: Exception) {
+            // Ignore folder open/search errors (e.g. [NONEXISTENT] Unknown Mailbox) and proceed to next folder
         } finally {
             if (f.isOpen) f.close(false)
         }
@@ -436,13 +440,15 @@ class ImapProvider(
         val f = store.getFolder(folderName)
         if (!f.exists()) return null
 
-        f.open(Folder.READ_ONLY)
         try {
+            f.open(Folder.READ_ONLY)
             val messages = f.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, messageId))
             if (messages.isEmpty()) return null
             return searchPart(messages[0], attachmentId)
+        } catch (e: Exception) {
+            return null
         } finally {
-            f.close(false)
+            if (f.isOpen) f.close(false)
         }
     }
 
@@ -456,16 +462,18 @@ class ImapProvider(
             val srcFolder = store.getFolder(srcName)
             if (!srcFolder.exists()) continue
 
-            srcFolder.open(Folder.READ_WRITE)
             try {
+                srcFolder.open(Folder.READ_WRITE)
                 val messages = srcFolder.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId))
                 if (messages.isNotEmpty()) {
                     srcFolder.copyMessages(messages, destFolder)
-                    srcFolder.setFlags(messages, Flags(Flags.Flag.DELETED), true)
+                    srcFolder.setFlags(messages, jakarta.mail.Flags(jakarta.mail.Flags.Flag.DELETED), true)
                     srcFolder.expunge()
                 }
+            } catch (e: Exception) {
+                // Ignore
             } finally {
-                srcFolder.close(true)
+                if (srcFolder.isOpen) srcFolder.close(false)
             }
         }
     }
@@ -481,16 +489,18 @@ class ImapProvider(
         val destFolder = store.getFolder(destName)
         if (!srcFolder.exists()) return@withStore
 
-        srcFolder.open(Folder.READ_WRITE)
         try {
+            srcFolder.open(Folder.READ_WRITE)
             val messages = srcFolder.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId))
             if (messages.isNotEmpty()) {
                 srcFolder.copyMessages(messages, destFolder)
                 srcFolder.setFlags(messages, Flags(Flags.Flag.DELETED), true)
                 srcFolder.expunge()
             }
+        } catch (e: Exception) {
+            // Ignore
         } finally {
-            srcFolder.close(true)
+            if (srcFolder.isOpen) srcFolder.close(true)
         }
     }
 
@@ -505,16 +515,18 @@ class ImapProvider(
         val destFolder = store.getFolder(destName)
         if (!srcFolder.exists()) return@withStore
 
-        srcFolder.open(Folder.READ_WRITE)
         try {
+            srcFolder.open(Folder.READ_WRITE)
             val messages = srcFolder.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId))
             if (messages.isNotEmpty()) {
                 srcFolder.copyMessages(messages, destFolder)
                 srcFolder.setFlags(messages, Flags(Flags.Flag.DELETED), true)
                 srcFolder.expunge()
             }
+        } catch (e: Exception) {
+            // Ignore
         } finally {
-            srcFolder.close(true)
+            if (srcFolder.isOpen) srcFolder.close(true)
         }
     }
 
@@ -523,15 +535,17 @@ class ImapProvider(
         val f = store.getFolder(srcName)
         if (!f.exists()) return@withStore
 
-        f.open(Folder.READ_WRITE)
         try {
+            f.open(Folder.READ_WRITE)
             val messages = f.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId))
             if (messages.isNotEmpty()) {
                 f.setFlags(messages, Flags(Flags.Flag.DELETED), true)
                 f.expunge()
             }
+        } catch (e: Exception) {
+            // Ignore
         } finally {
-            f.close(true)
+            if (f.isOpen) f.close(true)
         }
     }
 
@@ -544,14 +558,16 @@ class ImapProvider(
         for (folderName in searchFolders) {
             val f = store.getFolder(folderName)
             if (f.exists()) {
-                f.open(Folder.READ_WRITE)
                 try {
+                    f.open(Folder.READ_WRITE)
                     val messages = f.search(jakarta.mail.search.HeaderTerm(HEADER_MESSAGE_ID, threadId))
                     if (messages.isNotEmpty()) {
                         f.setFlags(messages, Flags(flag), set)
                     }
+                } catch (e: Exception) {
+                    // Ignore
                 } finally {
-                    f.close(false)
+                    if (f.isOpen) f.close(false)
                 }
             }
         }

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/BottomDockBar.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/BottomDockBar.kt
@@ -85,7 +85,7 @@ internal fun BottomDockBar(
         Row(
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .padding(end = 72.dp)
+                .fillMaxWidth()
                 .onGloballyPositioned { coordinates ->
                     dockRowHeightPx = coordinates.size.height.toFloat()
                 }
@@ -111,6 +111,7 @@ internal fun BottomDockBar(
                     onClick = { showRemainingTabs = !showRemainingTabs }
                 )
             }
+            Spacer(modifier = Modifier.width(72.dp))
         }
     }
 }


### PR DESCRIPTION
This PR resolves several actionable issues reported in August:

- **Resolves #144 & #143 (Share Sheet & mailto):** Adds `ACTION_SEND`, `ACTION_SENDTO`, `ACTION_VIEW` intent filters and extracts URIs/parameters natively via Jetpack Navigation's deep link intent.
- **Resolves #141 (Dock Scaling):** Fixes the dock cut-off bug by removing external padding and using an internal `Spacer` within the scrollable row.
- **Resolves #140 (Sync Frequency):** Fixes missing `syncFrequency` extraction from `SettingsDataStore.mapToSettings()`.
- **Resolves #129 (IMAP Select Failed):** Wraps `folder.open()` calls in `try/catch/finally` to gracefully bypass non-selectable root nodes (like `[Gmail]`) instead of crashing the email fetch coroutine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->