### PR TITLE
Fix release workflow task names and resolve pre-existing lint errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         run: >-
           ./gradlew
           lintGithubRelease lintPlaystoreRelease
-          testGithubReleaseUnitTest testPlaystoreReleaseUnitTest
+          testGithubDebugUnitTest testPlaystoreDebugUnitTest
           assembleGithubRelease bundlePlaystoreRelease
           --stacktrace
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools" >
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/BodyBackfill.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/repository/BodyBackfill.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.app.PendingIntent
 import android.content.Intent
+import android.annotation.SuppressLint
 import android.os.Build
 import android.util.Log
 import com.shrivatsav.monomail.core.data.worker.NotificationActionReceiver
@@ -91,6 +92,7 @@ internal fun ensureBodyBackfillDoneChannel(context: Context) {
  * levels. (ProgressStyle segments were tried on 37 but its setProgress()
  * semantics filled the bar regardless of the counter — dropped for correctness.)
  */
+@SuppressLint("NewApi")
 internal fun buildBodyBackfillNotification(context: Context, completed: Int, total: Int, folder: String? = null): Notification {
     val builder = Notification.Builder(context, BODY_BACKFILL_CHANNEL_ID)
         .setSmallIcon(android.R.drawable.stat_sys_download)

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/util/Notifications.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/util/Notifications.kt
@@ -1,0 +1,13 @@
+package com.shrivatsav.monomail.core.data.util
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+fun canPostNotifications(context: Context): Boolean {
+    return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+        ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+        PackageManager.PERMISSION_GRANTED
+}

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NewEmailNotifications.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NewEmailNotifications.kt
@@ -1,6 +1,7 @@
 package com.shrivatsav.monomail.core.data.worker
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -15,6 +16,7 @@ import androidx.core.text.HtmlCompat
 import com.shrivatsav.monomail.core.data.auth.UserProfile
 import com.shrivatsav.monomail.core.data.settings.NotificationPreview
 import com.shrivatsav.monomail.core.data.settings.NotificationProfile
+import com.shrivatsav.monomail.core.data.util.canPostNotifications
 
 private const val TAG = "NewEmailNotification"
 
@@ -131,7 +133,10 @@ fun showNewEmailNotification(
         }
     actions.forEach(builder::addAction)
 
-    NotificationManagerCompat.from(context).notify(account.id, notificationId, builder.build())
-    Log.i(TAG, "Notification successfully sent to NotificationManagerCompat (id: $notificationId)")
+    @SuppressLint("MissingPermission")
+    if (canPostNotifications(context)) {
+        NotificationManagerCompat.from(context).notify(account.id, notificationId, builder.build())
+        Log.i(TAG, "Notification successfully sent to NotificationManagerCompat (id: $notificationId)")
+    }
 }
 

--- a/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationActionReceiver.kt
+++ b/core/data/src/main/java/com/shrivatsav/monomail/core/data/worker/NotificationActionReceiver.kt
@@ -3,6 +3,7 @@ package com.shrivatsav.monomail.core.data.worker
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -18,6 +19,7 @@ import androidx.core.app.RemoteInput
 import com.shrivatsav.monomail.core.data.auth.AccountManager
 import com.shrivatsav.monomail.core.data.repository.EmailRepository
 import com.shrivatsav.monomail.core.data.repository.SendEmailParams
+import com.shrivatsav.monomail.core.data.util.canPostNotifications
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -264,9 +266,12 @@ class NotificationActionReceiver : BroadcastReceiver() {
             .setAutoCancel(true)
             .setTimeoutAfter(5000)
 
-        NotificationManagerCompat.from(context).notify(
-            ARCHIVE_CONFIRM_CHANNEL, UNDO_NOTIFICATION_ID_BASE + originalNotificationId, undoBuilder.build()
-        )
+        @SuppressLint("MissingPermission")
+        if (canPostNotifications(context)) {
+            NotificationManagerCompat.from(context).notify(
+                ARCHIVE_CONFIRM_CHANNEL, UNDO_NOTIFICATION_ID_BASE + originalNotificationId, undoBuilder.build()
+            )
+        }
     }
 
     private suspend fun handleUndoArchive(context: Context, intent: Intent) {
@@ -311,9 +316,12 @@ class NotificationActionReceiver : BroadcastReceiver() {
             .setTimeoutAfter(5000)
             .setAutoCancel(true)
 
-        NotificationManagerCompat.from(context).notify(
-            ARCHIVE_CONFIRM_CHANNEL, UNDO_NOTIFICATION_ID_BASE + originalNotificationId, undoBuilder.build()
-        )
+        @SuppressLint("MissingPermission")
+        if (canPostNotifications(context)) {
+            NotificationManagerCompat.from(context).notify(
+                ARCHIVE_CONFIRM_CHANNEL, UNDO_NOTIFICATION_ID_BASE + originalNotificationId, undoBuilder.build()
+            )
+        }
     }
 
     private suspend fun handleUndoDelete(context: Context, intent: Intent) {
@@ -357,9 +365,12 @@ class NotificationActionReceiver : BroadcastReceiver() {
             .addAction(android.R.drawable.ic_menu_revert, "Undo", undoPendingIntent)
             .setAutoCancel(true)
 
-        NotificationManagerCompat.from(context).notify(
-            ARCHIVE_CONFIRM_CHANNEL, UNDO_NOTIFICATION_ID_BASE + originalNotificationId, undoBuilder.build()
-        )
+        @SuppressLint("MissingPermission")
+        if (canPostNotifications(context)) {
+            NotificationManagerCompat.from(context).notify(
+                ARCHIVE_CONFIRM_CHANNEL, UNDO_NOTIFICATION_ID_BASE + originalNotificationId, undoBuilder.build()
+            )
+        }
     }
 
     private suspend fun handleUndoSnooze(context: Context, intent: Intent) {
@@ -388,7 +399,10 @@ class NotificationActionReceiver : BroadcastReceiver() {
             builder.setProgress(0, 0, true).setOngoing(true)
         }
 
-        NotificationManagerCompat.from(context).notify(REPLY_STATUS_CHANNEL, notificationId, builder.build())
+        @SuppressLint("MissingPermission")
+        if (canPostNotifications(context)) {
+            NotificationManagerCompat.from(context).notify(REPLY_STATUS_CHANNEL, notificationId, builder.build())
+        }
     }
 
     private fun createReplyStatusChannel(context: Context) {

--- a/feature/attachment/lint.xml
+++ b/feature/attachment/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<lint>
+    <issue id="UnsafeOptInUsageError">
+        <option name="opt-in" value="androidx.media3.common.util.UnstableApi" />
+    </issue>
+</lint>

--- a/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/VideoPlayerScreen.kt
+++ b/feature/attachment/src/main/java/com/shrivatsav/monomail/feature/attachment/VideoPlayerScreen.kt
@@ -23,13 +23,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, UnstableApi::class)
 @Composable
-fun VideoPlayerScreen(
+internal fun VideoPlayerScreen(
     uri: Uri,
     name: String,
     onBack: () -> Unit

--- a/feature/inbox/src/main/AndroidManifest.xml
+++ b/feature/inbox/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+</manifest>

--- a/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/ProfileCard.kt
+++ b/feature/inbox/src/main/java/com/shrivatsav/monomail/feature/inbox/components/ProfileCard.kt
@@ -108,16 +108,17 @@ private fun ProfileAvatarSection(
             (fadeOut(tween(150)) + scaleOut(tween(150), targetScale = 0.9f))
         },
         label = "profileContent"
-    ) {
+    ) { profileId ->
+        val activeProfile = accounts.firstOrNull { it.id == profileId } ?: userProfile
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth()
         ) {
-            DraggableAvatarBox(userProfile, accounts, callbacks, unifiedInboxEnabled)
+            DraggableAvatarBox(activeProfile, accounts, callbacks, unifiedInboxEnabled)
 
             Spacer(Modifier.height(14.dp))
             Text(
-                text = userProfile.displayName,
+                text = activeProfile.displayName,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onBackground,
@@ -125,7 +126,7 @@ private fun ProfileAvatarSection(
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = userProfile.email,
+                text = activeProfile.email,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
                 maxLines = 1,


### PR DESCRIPTION
## Summary

Fixes the failing **Build and Release** workflow run #80 and the CI lint gate, both of which failed after PR #151 merged.

### Release workflow fix
`release.yml` referenced nonexistent Gradle tasks `testGithubReleaseUnitTest`/`testPlaystoreReleaseUnitTest` — AGP only registers debug unit-test tasks in this project. Now runs `testGithubDebugUnitTest`/`testPlaystoreDebugUnitTest` instead. The full task set (`lint*Release`, `test*DebugUnitTest`, `assembleGithubRelease`, `bundlePlaystoreRelease`) verified passing locally.

### Pre-existing lint error fixes
These shipped on old code and blocked the PR CI job and the release pipeline's mandatory `lint*Release` commands:

- **core:data MissingPermission (9)** — `NotificationManagerCompat.notify` calls in `NewEmailNotifications` and `NotificationActionReceiver` (undo/reply-status) now guarded by a `POST_NOTIFICATIONS` check via shared `canPostNotifications` helper.
- **core:data NewApi** — `setRequestPromotedOngoing` is already runtime-guarded (`SDK_INT >= BAKLAVA` + try/catch); added `@SuppressLint` since API 36.1 minor version is not expressible via `SDK_INT`.
- **feature:inbox MissingPermission (3)** — `ACCESS_NETWORK_STATE` declared in the feature module manifest (connectivity APIs in `rememberConnectivityState`).
- **feature:inbox UnsafeOptInUsageError/AnimatedContent** — `AnimatedContent` now resolves the active profile from its target state param.
- **feature:attachment UnsafeOptInUsageError (5)** — media3 `UnstableApi` opted in via `lint.xml`; `VideoPlayerScreen` made `internal` with `@OptIn`.

Local verification: `lintGithubDebug lintPlaystoreDebug lintGithubRelease lintPlaystoreRelease testGithubDebugUnitTest testPlaystoreDebugUnitTest assembleGithubRelease bundlePlaystoreRelease` → BUILD SUCCESSFUL.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shrivatsav-org/codesmith/monomail/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->